### PR TITLE
Add note on import placement

### DIFF
--- a/docs/core-concepts/write.mdx
+++ b/docs/core-concepts/write.mdx
@@ -43,6 +43,12 @@ def udf(name: str = "Fused"): # <- Function declaration
 The UDF Editor in Workbench imports the `fused` module automatically. To write UDFs outside of Workbench, install the [Fused Python SDK](/python-sdk/) with `pip install fused` and import it with `import fused`.
 :::
 
+:::note
+Placing import statements within a UDF function body (known as "local imports") is not a common Python practice, but there are specific reasons to do this when constructing UDFs. UDFs are distributed to servers as a self-contained units, and each unit needs to import all modules it needs for its execution. UDFs may be executed across many servers (10s, 100s, 1000s), and any time lost to importing unused modules will be multiplied.
+
+An exception to this convention is for modules used for function annotation, which need to be imported outside of the function being annotated.
+:::
+
 ## `@fused.cache` decorator
 
 Use the [@fused.cache](/core-concepts/content-management/cache/) decorator to persist a function's output across runs so UDFs run faster.


### PR DESCRIPTION
Adds note admonishment describing why UDFs break the common practice of having imports at the top of the file.