### PR TITLE
How to enable App builder from Experimental + most videos not on auto play

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -12,12 +12,6 @@ Fused [Workbench](/workbench) is an end-to-end cloud platform for data analytics
 
 The core feature behind Fused are Python functions that can be run via HTTP requests, called **User Defined Functions ([UDFs](/core-concepts/why/))**. You can run these UDFs and retrieve data from it from anywhere you can call a HTTP endpoint.
 
-{/* 
-
-<img src="https://fused-magic.s3.us-west-2.amazonaws.com/main_marketing_website/product_diagram_october2024.png" alt="product_diagram_october2024" style={{}} />
-
- */}
-
 ## First look
 
 _We're going to create a simple UDF and return it's results in a Google Sheet. Feel free to follow along by [first making sure you can login](/user-guide/login)._ 
@@ -72,7 +66,7 @@ Here's how to return our `GeoDataFrame` from the UDF defined in Workbench to Goo
 
 import ReactPlayer from 'react-player'
 
-<ReactPlayer className="video__player" playing={true} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/share_udf_to_sheets_updated.mp4" width="100%" />
+<ReactPlayer className="video__player" playing={false} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/share_udf_to_sheets_updated.mp4" width="100%" />
 
 
 ## Next Steps

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -215,11 +215,18 @@ That's the real power of Fused: you don't have to deploy anything. Just edit you
 
 ## Create an app [Beta]
 
-Sometimes we simply want to show the results of our analysis to someone else, which is what Fused Apps are for, which 
+Sometimes we simply want to show the results of our analysis to someone else, which is what Fused Apps are for.
 
-You can use Streamlit components to create an app in the [App Builder](/workbench/app-builder/), found on the sidebar:
+:::note
 
-<ReactPlayer className="video__player" playing={true} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/showcase_sidebar.mp4" width="100%" />
+  Fused Apps are still in Beta. To enable them you need to go to the bottom left of Workbench -> `⚙️` (Preferences) -> Under "Experimental Features", tick "Enable apps builder (Beta)"
+
+  {/* Change video showing how to do this */}
+  <ReactPlayer className="video__player" playing={true} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/Getting_started_enable_app_builders.mp4" width="100%" />
+
+:::
+
+You can use Streamlit components to create an app in the [App Builder](/workbench/app-builder/), found on the sidebar, after you've enabled it. You can then move from UDF builder to App Builder. 
 
 Here's a basic example to show our dataframe:
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -54,7 +54,7 @@ import ReactPlayer from 'react-player';
 
     :::
 
-    <ReactPlayer className="video__player" playing={true} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/simple_demo_workbench.mp4" width="100%" />
+    <ReactPlayer className="video__player" playing={false} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/simple_demo_workbench.mp4" width="100%" />
 
   </TabItem>
   <TabItem value="locally" label="Local">
@@ -106,7 +106,7 @@ def udf():
     return gdf
 ```
 
-<ReactPlayer className="video__player" playing={true} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/Getting_Started_Changing_dataset.mp4" width="100%" />
+<ReactPlayer className="video__player" playing={false} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/Getting_Started_Changing_dataset.mp4" width="100%" />
 
 Let's explore this data a bit more, the map shows us we have US states, let's print out some more info about it, just before the `return`:
 
@@ -121,7 +121,7 @@ def udf():
     return gdf
 ```
 
-<ReactPlayer className="video__player" playing={true} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/Getting_Started_print.mp4" width="100%" />
+<ReactPlayer className="video__player" playing={false} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/Getting_Started_print.mp4" width="100%" />
 
 The `stdout` view shows us we have a `name` column in our `GeoDataFrame`, so we can leverage `geopandas` to filter only a few states:
 
@@ -137,7 +137,7 @@ def udf():
     return gdf
 ```
 
-<ReactPlayer className="video__player" playing={true} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/Getting_Started_filter_states.mp4" width="100%" />
+<ReactPlayer className="video__player" playing={false} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/Getting_Started_filter_states.mp4" width="100%" />
 
 You can notice this change in 2 places:
 1. The map view only shows 2 states now
@@ -163,7 +163,7 @@ We can edit this UDF as much as we want but for now we're going to get this data
 - Go to the `⚙ Settings` Tab
 - Under `Share` click `Sharing` to see all the sharing operations
 
-<ReactPlayer className="video__player" playing={true} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/Getting_Started_save_and_share.mp4" width="100%" />
+<ReactPlayer className="video__player" playing={false} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/Getting_Started_save_and_share.mp4" width="100%" />
 
 We've pre-populated a few examples of ways to share these Fused UDFs, but at its core you can *call these UDFs as HTTP endpoints*
 
@@ -221,8 +221,7 @@ Sometimes we simply want to show the results of our analysis to someone else, wh
 
   Fused Apps are still in Beta. To enable them you need to go to the bottom left of Workbench -> `⚙️` (Preferences) -> Under "Experimental Features", tick "Enable apps builder (Beta)"
 
-  {/* Change video showing how to do this */}
-  <ReactPlayer className="video__player" playing={true} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/Getting_started_enable_app_builders.mp4" width="100%" />
+  <ReactPlayer className="video__player" playing={false} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/Getting_started_enable_app_builders.mp4" width="100%" />
 
 :::
 
@@ -239,7 +238,7 @@ st.write(fused.run("fsh_31xNwyPRtpOIM2Jq1x6dy4"))
 
 ```
 
-<ReactPlayer className="video__player" playing={true} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/Getting_started_sharing_fused_udf_in_app.mp4" width="100%" />
+<ReactPlayer className="video__player" playing={false} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/Getting_started_sharing_fused_udf_in_app.mp4" width="100%" />
 
 It should look like this: 
 
@@ -249,7 +248,7 @@ As we change our UDF, the output will also change in the app directly, just like
 
 You can then share your Fused app to anyone simply by sharing the link at the top of the App Builder:
 
-<ReactPlayer className="video__player" playing={true} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/Getting_started_sharing_app.mp4" width="100%" />
+<ReactPlayer className="video__player" playing={false} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/getting-started/Getting_started_sharing_app.mp4" width="100%" />
 
 These links work without needing a Fused account or the need to install anything, allowing you to share your work easily to anyone!
 


### PR DESCRIPTION
Implementing suggestions from @jorisvandenbossche:
- Only 1st video is on auto play, rest are paused so user sees 1st frame, not last. Also makes it less distracting
- More detailed info about how to enable `App Builder` in experimental features

Preview app: https://docs-staging.fused.io/pr/250/quickstart/