### PR TITLE
fix: Overlapping iframe

### DIFF
--- a/blog/2024-08-29-kevin/index.mdx
+++ b/blog/2024-08-29-kevin/index.mdx
@@ -108,10 +108,11 @@ The transparency and scalability of this approach make it accessible to a wide r
 import Iframe from "@site/src/components/Iframe";
 import CODE from "@site/src/app-iframe/python/vegetation_segmentation.py"
 
-
+<div style={{marginTop: '2rem'}}>
 <Iframe
   id="veg-segmentation-app"
   code={CODE}
   height="800px"
   useResizer={false}
 />
+</div>

--- a/blog/2024-09-05-dl4eo/index.mdx
+++ b/blog/2024-09-05-dl4eo/index.mdx
@@ -108,6 +108,7 @@ _This article was originally published in [LinkedIn](https://www.linkedin.com/pu
 import Iframe from "@site/src/components/Iframe";
 import DL4EO_CODE from "@site/src/app-iframe/python/dl4eo.py";
 
+<div style={{marginTop: '2rem'}}>
 <Iframe
   id="iframe-1-dl4eo"
   code={DL4EO_CODE}
@@ -122,3 +123,4 @@ import DL4EO_CODE from "@site/src/app-iframe/python/dl4eo.py";
   height = {700}
   useResizer={false}
 />
+</div>

--- a/blog/2024-09-17-milindsoni/index.mdx
+++ b/blog/2024-09-17-milindsoni/index.mdx
@@ -156,6 +156,7 @@ import load from "/blog/2024-09-17-milindsoni/load.png";
 import Iframe from "@site/src/components/Iframe";
 import RAIN_SIM from "@site/src/app-iframe/python/rainfall_similarity.py";
 
+<div style={{marginTop: '2rem'}}>
 <Iframe
   id="iframe-1-rainfall_similarity"
   code={RAIN_SIM}
@@ -171,3 +172,4 @@ import RAIN_SIM from "@site/src/app-iframe/python/rainfall_similarity.py";
   height={700}
   useResizer={false}
 />
+</div>

--- a/blog/2024-09-19-overture/index.mdx
+++ b/blog/2024-09-19-overture/index.mdx
@@ -96,6 +96,7 @@ This walkthrough provided a practical overview of how to create a UDF to enrich 
 import Iframe from "@site/src/components/Iframe";
 import CODE from "@site/src/app-iframe/python/overture_nsi.py";
 
+<div style={{marginTop: '2rem'}}>
 <Iframe
   id="iframe-1"
   code={CODE}
@@ -111,3 +112,4 @@ import CODE from "@site/src/app-iframe/python/overture_nsi.py";
     "pydeck",
   ]}
 />
+</div>

--- a/blog/2024-09-23-kristin/index.mdx
+++ b/blog/2024-09-23-kristin/index.mdx
@@ -74,6 +74,7 @@ Okay, I have prepped my actual and predictor variables. Now, I will focus on how
 import Iframe from "@site/src/components/Iframe";
 import BUFFER_CODE from "@site/src/app-iframe/python/kristin.py";
 
+<div style={{marginTop: '2rem'}}>
 <Iframe
   id="iframe-1"
   code={BUFFER_CODE}
@@ -89,3 +90,4 @@ import BUFFER_CODE from "@site/src/app-iframe/python/kristin.py";
   ]}
   height={500}
 />
+</div>

--- a/blog/2024-10-14-claudio/index.mdx
+++ b/blog/2024-10-14-claudio/index.mdx
@@ -27,6 +27,7 @@ The beauty of using Fused is that I can build and visualize the trip simulator i
 import Iframe from "@site/src/components/Iframe";
 import BUFFER_CODE from "@site/src/app-iframe/python/claudio.py";
 
+<div style={{marginTop: '2rem'}}>
 <Iframe
   id="iframe-1"
   code={BUFFER_CODE}
@@ -42,3 +43,4 @@ import BUFFER_CODE from "@site/src/app-iframe/python/claudio.py";
   ]}
   height={500}
 />
+</div>

--- a/blog/2024-10-22-kristin/index.mdx
+++ b/blog/2024-10-22-kristin/index.mdx
@@ -104,6 +104,7 @@ Feel free to reach out if you have any questions.
 import Iframe from "@site/src/components/Iframe";
 import BUFFER_CODE from "@site/src/app-iframe/python/kristin2.py";
 
+<div style={{marginTop: '2rem'}}>
 <Iframe
   id="iframe-1"
   code={BUFFER_CODE}
@@ -120,3 +121,4 @@ import BUFFER_CODE from "@site/src/app-iframe/python/kristin2.py";
   ]}
   height={500}
 />
+</div>

--- a/blog/2024-10-30-elizabeth/index.mdx
+++ b/blog/2024-10-30-elizabeth/index.mdx
@@ -70,6 +70,7 @@ The Fused UDF Builder makes developing and iterating on these analyses swift and
 import Iframe from "@site/src/components/Iframe";
 import PRECISELY_CODE from "@site/src/app-iframe/python/precisely.py";
 
+<div style={{marginTop: '2rem'}}>
 <Iframe
   id="iframe-1"
   code={PRECISELY_CODE}
@@ -86,3 +87,4 @@ import PRECISELY_CODE from "@site/src/app-iframe/python/precisely.py";
   ]}
   height={500}
 />
+</div>

--- a/docs/user-guide/examples/zonal-stats.mdx
+++ b/docs/user-guide/examples/zonal-stats.mdx
@@ -246,6 +246,7 @@ Now that you've created a UDF and explored different ways to invoke it, you can 
 import Iframe from "@site/src/components/Iframe";
 import CODE from "@site/src/app-iframe/python/example_zstats.py";
 
+<div style={{marginTop: '2rem'}}>
 <Iframe
   id="iframe-1"
   code={CODE}
@@ -262,6 +263,7 @@ import CODE from "@site/src/app-iframe/python/example_zstats.py";
   ]}
 >
 </Iframe>
+</div>
 
 \
 Click "Copy shareable link" to share the app with others or [embed it in Notion](/user-guide/out/notion/#2-embed-the-map-into-notion)!

--- a/docs/user-guide/fused-in-10-minutes.mdx
+++ b/docs/user-guide/fused-in-10-minutes.mdx
@@ -252,6 +252,7 @@ Now that you've created a UDF and explored different ways to invoke it, you can 
 import Iframe from "@site/src/components/Iframe";
 import CODE from "@site/src/app-iframe/python/example_zstats.py";
 
+<div style={{marginTop: '2rem'}}>
 <Iframe
   id="iframe-1"
   code={CODE}
@@ -268,6 +269,7 @@ import CODE from "@site/src/app-iframe/python/example_zstats.py";
   ]}
 >
 </Iframe>
+</div>
 
 \
 Click "Copy shareable link" to share the app with others or [embed it in Notion](/user-guide/out/notion/#2-embed-the-map-into-notion)!

--- a/docs/user-guide/out/notion.mdx
+++ b/docs/user-guide/out/notion.mdx
@@ -11,6 +11,7 @@ Embed responsive apps in Notion pages.
 import Iframe from "@site/src/components/Iframe";
 import CODE from "@site/src/app-iframe/python/basic.py";
 
+<div style={{marginTop: '2rem'}}>
 <Iframe
   id="iframe-1"
   code={CODE}
@@ -25,7 +26,7 @@ import CODE from "@site/src/app-iframe/python/basic.py";
   ]}
   height="250px"
 />
-
+</div>
 ## 2. Embed the map into Notion
 
 On a Notion page, type `/embed` to create an [embed component](https://www.notion.so/help/embed-and-connect-other-apps). Paste the app URL in the menu that appears. You may publish the page as a [Notion site](https://www.notion.so/help/public-pages-and-web-publishing).

--- a/docs/user-guide/transform/geospatial/point-polygon.mdx
+++ b/docs/user-guide/transform/geospatial/point-polygon.mdx
@@ -78,4 +78,6 @@ However, it is important to consider the limitations and potential complexities 
 import Iframe from "@site/src/components/Iframe";
 import POINT_IN_POLYGON_CODE from "@site/src/app-iframe/python/point-in-polygon.py";
 
+<div style={{marginTop: '2rem'}}>
 <Iframe id="iframe-1" code={POINT_IN_POLYGON_CODE} />
+</div>

--- a/docs/user-guide/transform/geospatial/zonal_stats.mdx
+++ b/docs/user-guide/transform/geospatial/zonal_stats.mdx
@@ -71,4 +71,6 @@ While zonal statistics is a valuable tool, it's often just the starting point fo
 import Iframe from "@site/src/components/Iframe";
 import ZONAL_STATS_CODE from "@site/src/app-iframe/python/zonal-stats.py";
 
+<div style={{marginTop: '2rem'}}>
 <Iframe id="iframe-1" code={ZONAL_STATS_CODE} />
+</div>

--- a/docs/user-guide/use-cases/overturensi.mdx
+++ b/docs/user-guide/use-cases/overturensi.mdx
@@ -60,7 +60,7 @@ def udf(bbox: fused.types.TileGDF = None):
 import Iframe from "@site/src/components/Iframe";
 import CODE from "@site/src/app-iframe/python/nsi.py";
 
-
+<div style={{marginTop: '2rem'}}>
 <Iframe
   id="iframe-1"
   code={CODE}
@@ -76,7 +76,7 @@ import CODE from "@site/src/app-iframe/python/nsi.py";
   url = "https://www.fused.io/workbench#app/s/a"
   height="250px"
 />
-
+</div>
 
 
 ##### [stash]

--- a/docs/workbench/app-builder.mdx
+++ b/docs/workbench/app-builder.mdx
@@ -37,6 +37,7 @@ You may add [input widgets](https://docs.streamlit.io/develop/api-reference/widg
 import Iframe from "@site/src/components/Iframe";
 import CODE from "@site/src/app-iframe/python/basic.py";
 
+<div style={{marginTop: '2rem'}}>
 <Iframe
   id="iframe-1"
   code={CODE}
@@ -50,6 +51,7 @@ import CODE from "@site/src/app-iframe/python/basic.py";
   ]}
   height="400px"
 />
+</div>
 
 \
 Try running the code snippets below to acquaint yourself with the App Builder.

--- a/src/components/Iframe.jsx
+++ b/src/components/Iframe.jsx
@@ -23,10 +23,11 @@ export default function Iframe({
   function syncIframeToContainer(boundingClientRect, iframe) {
     if (boundingClientRect) {
       iframe.style.display = "block";
-      iframe.style.left = `${boundingClientRect.left + window.scrollX}px`;
-      iframe.style.top = `${boundingClientRect.top + window.scrollY}px`;
-      iframe.style.width = `${boundingClientRect.width}px`;
-      iframe.style.height = `${boundingClientRect.height}px`;
+      iframe.style.position = "relative";
+      iframe.style.left = "0";
+      iframe.style.top = "0";
+      iframe.style.width = "100%";
+      iframe.style.height = "100%";
     }
   }
 
@@ -62,8 +63,9 @@ export default function Iframe({
       iframe.width = "100%";
       iframe.scrolling = "no";
       iframe.id = "magic-" + id;
+      iframe.style.position = "relative";
 
-      document.body.appendChild(iframe);
+      containerRef.current.appendChild(iframe);
     } else {
       iframe = document.getElementById("magic-" + id);
       const targetOrigin = new URL(url).origin;


### PR DESCRIPTION
It has been reported that some our custom `Iframe` component is overlapping the content in markdown in some cases.

https://github.com/user-attachments/assets/f2418065-f050-4e86-aa5e-424a2897be74

While I couldn't exactly reproduce this, I saw that while loading the iframe appears above the text and once the content is loaded it changes the position to be at the bottom. Also iframe gets repositioned when resizing the browser window.

Wrapping it in a simple `div` element and removing absolute positioning is the best that I can think of, and it looks like it's behaving as it should now.