### PR TITLE
Using `arg_list` to pass `dict` of inputs in `run_remote()`

### DIFF
--- a/docs/core-concepts/run-udfs/large_jobs.mdx
+++ b/docs/core-concepts/run-udfs/large_jobs.mdx
@@ -121,28 +121,39 @@ At the moment jobs called with `arg_list` can only be defined with a single vari
 @fused.udf
 def udf(variables: dict = {'val1':1, 'val2':2}):
     import pandas as pd
+    import fused
     val1 = variables['val1']
     val2 = variables['val2']
-    return pd.DataFrame(data={'output':[int(val1)*int(val2)]})
+    output_value = int(val1)*int(val2)
+
+    df = pd.DataFrame(data={'output':[output_value]})
+    print(f"Saving df with {output_value=}")
+    df.to_csv(fused.file_path(f"/demo_multiple_arg_list_run_output_{str(output_value)}.csv"))
+
+    return df
 ```
 
-This works when run 1 time:
+:::note
+  You do need to type the Python type of your input variable for this to work. If we had defined:
+  ```python showLineNumbers
+  @fused.udf
+  def udf(variables = {}):
+    # Notice the lack of `variables: dict = {}`
+    ...
+    return df
+  ```
+  without typing `variables` as a `dict` this would fail as Fused server has no way of knowing what to expect from `variables`
+:::
+
+As seen in the ["Getting Results" section](/core-concepts/run-udfs/run_large/#getting-results) we're saving `df` to disk to be able to access our results once the run is done
+
+So to call this UDF as a remote job by passing a list of dictionaries to `arg_list`:
 ```python showLineNumbers
-fused.run(udf, variables={'val1': 3, 'val2': 2})
-```
-
-Giving us:
-```bash
-    | output
-------------
-0   | 2
-```
-
-So to call this UDF as a remote job using `arg_list`:
-```python showLineNumbers
-job = udf(arg_list=[{"val1": 1, "val2": 2}, {"val1": 3, "val2": 4}])
+job = udf(arg_list=[{"val1": 5, "val2": 2}, {"val1": 3, "val2": 4}])
 job.run_remote()
 ```
+
+{/* TODO: As of now I don't see results in efs:// even if my job is successful. Need to check in before updating this section fully */}
 
 ### Accessing job logs
 
@@ -227,9 +238,14 @@ To get data back from your `run_remote()` jobs is a bit more complicated than fo
 
     Since our data is written to cloud storage, it can now be accessed anywhere else, through another UDF or any other application with access to cloud storage.
 
+    :::tip
+      You can use [File Explorer](/workbench/file-explorer/) to easily see your outputs! In this case of the above example typing `efs://AIS_{datestr}.csv` (and replacing `datestr` with your date) will show the results directly in File Explorer!
+    :::
+
 </details>
 
-{/* Need example here */}
+{/* TODO: Need example here */}
+{/* TODO: Show output on File Explorer */}
 
 
 ### Large jobs trade-offs

--- a/docs/core-concepts/run-udfs/large_jobs.mdx
+++ b/docs/core-concepts/run-udfs/large_jobs.mdx
@@ -106,7 +106,7 @@ job.run_remote(instance_type="m5.4xlarge", disk_size_gb=100)
 
 **Single Parameter**
 
-To pass UDF arguments to a remote job, use `arg_list`. At the moment this only supports UDFs with a single parameter:
+To pass UDF arguments to a remote job, use `arg_list` to specify a list of inputs to run your job over, as we did in [the above section](/core-concepts/run-udfs/run_large/#running-a-large-job-job-jobrun_remote):
 
 ```python showLineNumbers
 job = udf(arg_list=range(10))
@@ -115,27 +115,34 @@ job.run_remote()
 
 **Multiple Parameters**
 
-We're working on adding support for multiple parameters
-
-🚧 Under construction
-
-{/* TODO: This actually doesn't work, need to figure out why before mentioning it
-At the moment jobs can only be defined with a single variable. We can work around this by passing a dictionary to `arg_list` as so:
+At the moment jobs called with `arg_list` can only be defined with a single variable. We can work around this by passing a dictionary to `arg_list` as so:
 
 ```python showLineNumbers
 @fused.udf
-def udf(variables = {'val1':1, 'val2':2}):
+def udf(variables: dict = {'val1':1, 'val2':2}):
     import pandas as pd
     val1 = variables['val1']
     val2 = variables['val2']
     return pd.DataFrame(data={'output':[int(val1)*int(val2)]})
 ```
 
-Which allows to then call this UDF in a large instance with:
+This works when run 1 time:
+```python showLineNumbers
+fused.run(udf, variables={'val1': 3, 'val2': 2})
+```
+
+Giving us:
+```bash
+    | output
+------------
+0   | 2
+```
+
+So to call this UDF as a remote job using `arg_list`:
 ```python showLineNumbers
 job = udf(arg_list=[{"val1": 1, "val2": 2}, {"val1": 3, "val2": 4}])
 job.run_remote()
-``` */}
+```
 
 ### Accessing job logs
 


### PR DESCRIPTION
I was missing a [small little piece](https://fusedlabs.slack.com/archives/C04LSJTED52/p1736177300235119?thread_ts=1736160389.525079&cid=C04LSJTED52)

Todo:
- [ ]Emphasis on needing to type inputs, otherwise Fused server can't pick up input type properly
- [ ] Making simple demo to showcase
- [ ] Show output visible in `efs://` in File Explorer to show this worked properly 