### PR TITLE
Large job replacing mention of disk by shared disk

### DIFF
--- a/docs/core-concepts/run-udfs/large_jobs.mdx
+++ b/docs/core-concepts/run-udfs/large_jobs.mdx
@@ -226,10 +226,10 @@ import ImgRunRemoteEmail from '@site/docs/core-concepts/run-udfs/run-remote-emai
 
 ## Getting results
 
-To get data back from your `run_remote()` jobs is a bit more complicated than for ["real-time"](/core-concepts/run-udfs/run-small-udfs/#getting-real-time-results). Our recommendation is to have your UDF write data directly to disk or cloud storage and access it after
+To get data back from your `run_remote()` jobs is a bit more complicated than for ["real-time"](/core-concepts/run-udfs/run-small-udfs/#getting-real-time-results). Our recommendation is to have your UDF write data directly to shared storage `/mount/` or cloud storage and access it after
 
 <details>
-  <summary>Example job: saving to disk</summary>
+  <summary>Example job: saving to shared storage `/mount/`</summary>
 
     A common use case for offline jobs is as a "pre-ingestion" process. You can find a real-life example of this in our [dark vessel detection example](/user-guide/examples/dark-vessel-detection/#32---writing-a-udf-to-open-each-ais-dataset)
 
@@ -248,7 +248,7 @@ To get data back from your `run_remote()` jobs is a bit more complicated than fo
 
         url=f'https://coast.noaa.gov/htdata/CMSP/AISDataHandler/{datestr[:4]}/AIS_{datestr}.zip'
         # This is our local mount file path, 
-        path=f'/mnt/cache/AIS_demo/{datestr[:7]}/'
+        path=f'/mount/AIS_demo/{datestr[:7]}/'
         daily_ais_parquet = f'{path}/{datestr[-2:]}.parquet'
 
         # Download ZIP file to mounted disk
@@ -265,7 +265,7 @@ To get data back from your `run_remote()` jobs is a bit more complicated than fo
             return pd.DataFrame({'status':[f'read_error_{r.status_code}']})
     ```
 
-    Since our data is written to cloud storage, it can now be accessed anywhere else, through another UDF or any other application with access to cloud storage.
+    Data written to `/mount/` can be accessed by any other instance used by anyone on your team so it can be used by any other UDF you run after.
 
     :::tip
       You can use [File Explorer](/workbench/file-explorer/) to easily see your outputs! In this case of the above example typing `efs://AIS_{datestr}.csv` (and replacing `datestr` with your date) will show the results directly in File Explorer!


### PR DESCRIPTION
Quick fix to make it obvious `run_remote()` jobs should write to `/mount/` and not `/`