### PR TITLE
Fix/algolia crawl

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -15,6 +15,7 @@ jobs:
           crawler-user-id: ${{ secrets.ALGOLIA_CRAWLER_USER_ID }}
           crawler-api-key: ${{ secrets.ALGOLIA_CRAWLER_API_KEY }}
           github-token: ${{ github.token }}
+          crawler-name: "fused"
           algolia-app-id: ${{ secrets.ALGOLIA_APPLICATION_ID }}
           algolia-api-key: ${{ secrets.ALGOLIA_API_KEY }}
           site-url: "https://docs.fused.io"


### PR DESCRIPTION
<img width="1081" alt="image" src="https://github.com/user-attachments/assets/e846924f-ebb6-40a7-88f7-5815c6ecc80e" />

For some reason the `indexName` is populated as the default unset `crawler-name`. Hopefully this PR fixes it.