### PR TITLE
Adding status to main page + FAQ troubleshooting

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -38,7 +38,11 @@ Fused currently uses Auth0 to support authentication via Google and GitHub.
 
 ## Troubleshooting
 
+### Status page
 
+Access our [status page](https://fused.instatus.com/) at any time to check on Workbench & API status
+
+### Common Errors
 
 <details>
 <summary>Error: `Access is not configured for you in the Fused Workbench. Please refresh the page if you think this is an error, or get in touch if you require further help. Cause: Realtime instance not configured.`</summary>

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -131,6 +131,11 @@ const config: Config = {
           label: "Workbench",
           position: "right",
         },
+        {
+          href: "https://fused.instatus.com/",
+          label: "Status",
+          position: "right",
+        },
       ],
     },
     footer: {


### PR DESCRIPTION
2 locations:

1. Main header, always visible:

![CleanShot 2025-02-07 at 09 13 39@2x](https://github.com/user-attachments/assets/44222e76-a312-4fdd-be19-d86e82f2ca17)

2. FAQ page so it's easily findable with search `Cmd + K`:
![CleanShot 2025-02-07 at 09 14 39@2x](https://github.com/user-attachments/assets/c0836cf3-606d-4747-9ca6-92ad0e0e9a28)
