### PR TITLE
warning for running udf with dtype_out_vector=json

### DIFF
--- a/docs/core-concepts/filetile.mdx
+++ b/docs/core-concepts/filetile.mdx
@@ -129,6 +129,10 @@ This endpoint structure runs a UDF as a `File`. See implementation examples with
 https://www.fused.io/server/.../run/file?dtype_out_vector=csv
 ```
 
+:::info
+   In some cases, `dtype_out_vector=json` may return an error. This can happen when a GeoDataFrame without a `geometry` column is being return or a Pandas DataFrame. You can bypass this by using `dtype_out_vector=geojson`.
+:::
+
 ### Tile endpoint
 
 This endpoint structure runs a UDF as a `Tile`. The `{z}/{x}/{y}` templated path parameters correspond to the Tile's XYZ index, which Tiled web map clients dynamically populate. See implementation examples for Raster Tiles with [Felt](/user-guide/out/felt/#raster-tiles) and [DeckGL](/user-guide/out/deckgl/#raster-tile-layers), and for Vector Tiles with [DeckGL](/user-guide/out/deckgl/#vector-tile-layers) and [Mapbox](/user-guide/out/mapbox/#a-vector-tile-layers).

--- a/docs/core-concepts/run-udfs/run.mdx
+++ b/docs/core-concepts/run-udfs/run.mdx
@@ -350,10 +350,6 @@ https://www.fused.io/server/v1/realtime-shared/****/run/file?dtype_out_raster=pn
 
 Read how to structure HTTP endpoints to call the UDF as a [Map Tile & File](/core-concepts/filetile/#call-http-endpoints).
 
-:::warning
-   In some cases, `dtype_out_vector=json` may return an error. This can happen when a GeoDataFrame without a `geometry` column is being return or a Pandas DataFrame. You can bypass this by using `dtype_out_vector=geojson`.
-:::
-
 ## Caching responses
 
 If a UDF's [cache](/workbench/udf-builder/code-editor/#cache) is enabled, its endpoints cache outputs for each combination of code and parameters. The first call runs and caches the UDF, and subsequent calls return cached data.


### PR DESCRIPTION
Warning box added in core-concepts/run-small-udfs to describe when it occurs, and what to do about it