### PR TITLE
update the async example to use udf name instead of object

### DIFF
--- a/docs/core-concepts/async.mdx
+++ b/docs/core-concepts/async.mdx
@@ -33,8 +33,7 @@ def udf(date: str='2020-01-01'):
 We can now invoke the UDF asynchronously for each date in the `dates` list and concatenate the results:
 
 ```python showLineNumbers
-@fused.udf
-async def udf():
+async def parent_fn():
     import pandas as pd
     import asyncio
 

--- a/docs/core-concepts/async.mdx
+++ b/docs/core-concepts/async.mdx
@@ -16,8 +16,21 @@ A UDF can be called asynchronously using the [async/await](https://docs.python.o
     Setting `sync=False` in `fused.run` is intended for asynchronous calls when running in the cloud with `engine='realtime'`. The parameter has no effect if the UDF is ran in the local environment with `engine='local'`.
 :::
 
-This UDF illustrates the concept. It calls `udf_to_run_async` asynchronously for each date in the `dates` list and concatenates the results.
+To illustrate this concept, let's create a simple UDF and save it as `udf_to_run_async` in the workbench:
 
+```python showLineNumbers
+@fused.udf
+def udf(date: str='2020-01-01'):
+    import pandas as pd
+    import time
+    time.sleep(2)
+    return pd.DataFrame({'selected_date': [date]})
+```
+:::note
+    We can not pass a UDF object directly to `fused.run`. Asynchronous execution is only supported for saved UDFs specifed by name or token.
+:::
+
+We can now invoke the UDF asynchronously for each date in the `dates` list and concatenate the results:
 
 ```python showLineNumbers
 @fused.udf
@@ -25,20 +38,13 @@ async def udf():
     import pandas as pd
     import asyncio
 
-    @fused.udf
-    def udf_to_run_async(date: str='2020-01-01'):
-        import pandas as pd
-        import time
-        time.sleep(2)
-        return pd.DataFrame({'selected_date': [date]})
-
     # Parameter to loop through
     dates = ['2020-01-01', '2021-01-01', '2022-01-01', '2023-01-01']
 
     # Invoke the UDF as coroutines
     promises_dfs = []
     for date in dates:
-        df = fused.run(udf_to_run_async, date=date, engine='realtime', sync=False)
+        df = fused.run("udf_to_run_async", date=date, engine='realtime', sync=False)
         promises_dfs.append(df)
 
     # Run concurrently and collect the results


### PR DESCRIPTION
<img width="1582" alt="image" src="https://github.com/user-attachments/assets/c028637b-b024-4cc9-aa84-045767627386" />
fixes: [link](https://www.notion.so/fusedio/The-documentation-example-of-running-UDFs-async-is-broken-198899d3b763803e9506ed02560b4e2b?pvs=4)
