### PR TITLE
Making running with parameters more findable

### DIFF
--- a/docs/core-concepts/write.mdx
+++ b/docs/core-concepts/write.mdx
@@ -3,8 +3,6 @@ id: write
 title:  Write UDFs
 tags: [write, "@fused.udf", "@fused.cache", typed parameters, utility functions, return object]
 sidebar_position: 1
-toc_min_heading_level: 2
-toc_max_heading_level: 2
 ---
 
 import ImageAnatomy from '@site/static/img/udfanatomy.png';
@@ -72,7 +70,7 @@ def udf(bounds: fused.types.Bounds = None, name: str = "Fused"):
 
 
 
-### Typed parameters
+## Typed parameters
 
 UDFs resolve input parameters to the types specified in their function annotations.
 This example shows the [`bounds` parameter](/core-concepts/filetile/#bounds-object-types) typed as `fused.types.Bounds`
@@ -120,24 +118,26 @@ def udf(
 ):
 ```
 
-### Reserved parameters
+## Reserved parameters
 
 When running a UDF with `fused.run`, it's possible to specify the [map tile](/core-concepts/filetile/#map-tiles) Fused will use to structure the `bounds` object by using the following reserved parameters.
 
-#### With `x`, `y`, `z` parameters
+### With `x`, `y`, `z` parameters
 
 ```python showLineNumbers
 fused.run("UDF_Overture_Maps_Example", x=5241, y=12662, z=15)
 ```
 
-#### With a `bounds` `GeoDataFrame`
+### Passing a `GeoDataFrame`
 ```python showLineNumbers
 import geopandas as gpd
 bounds = gpd.GeoDataFrame.from_features({"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"coordinates":[[[-122.41152460661726,37.80695951427788],[-122.41152460661726,37.80386837460925],[-122.40744576928229,37.80386837460925],[-122.40744576928229,37.80695951427788],[-122.41152460661726,37.80695951427788]]],"type":"Polygon"},"id":1}]})
 fused.run("UDF_Overture_Maps_Example", bounds=bounds)
 ```
 
-#### With a `bounds` `bounds` array
+### Passing a bounding box list
+
+You can also pass a list of 4 points representing `[min_x, min_y, max_x, max_y]`
 
 ```python showLineNumbers
 fused.run('UDF_Overture_Maps_Example', bounds=[-122.349, 37.781, -122.341, 37.818])


### PR DESCRIPTION
Main value of this: These headers are easier to visually see when navigating though the pages. A lot of good info was hidden because not visible in the right navbar

Before:
![CleanShot 2025-03-03 at 12 43 08](https://github.com/user-attachments/assets/5c9ef44c-f35c-4b5a-97aa-14b05b1a0f76)

After:
![CleanShot 2025-03-03 at 12 42 32](https://github.com/user-attachments/assets/cf206542-5259-45be-abdc-6b8f7e12cc45)

Also making it more clear what passing a list of 4 looks like