### PR TITLE
remove direct fused.utils usage accross repo

### DIFF
--- a/blog/2024-09-19-overture/index.mdx
+++ b/blog/2024-09-19-overture/index.mdx
@@ -67,7 +67,8 @@ This UDF, running on the Fused Workbench, uses the `get_overture` helper functio
 ```python showLineNumbers
 @fused.udf
 def udf(bbox: fused.types.TileGDF=None):
-    return fused.utils.Overture_Maps_Example.get_overture(bbox=bbox, theme='buildings')
+    utils = fused.load("https://github.com/fusedio/udfs/tree/eda5aec/public/Overture_Maps_Example/").utils
+    return utils.get_overture(bbox=bbox, theme='buildings')
 ```
 
 ### 2. Enrich with NSI
@@ -84,8 +85,10 @@ def udf(bbox: fused.types.TileGDF=None):
     import geopandas as gpd
     import requests
 
+    utils = fused.load("https://github.com/fusedio/udfs/tree/eda5aec/public/Overture_Maps_Example/").utils
+
     # 1. Load Overture Buildings
-    gdf_overture = fused.utils.Overture_Maps_Example.get_overture(bbox=bbox)
+    gdf_overture = utils.get_overture(bbox=bbox)
 
     # 2. Load NSI from API
     response = requests.post(

--- a/blog/2024-09-23-kristin/index.mdx
+++ b/blog/2024-09-23-kristin/index.mdx
@@ -71,17 +71,17 @@ Now, let's get into the predictor variable—a NetCDF file from 5 degrees off th
 @fused.udf
 def udf(bbox: fused.types.TileGDF=None, path: str='s3://fused-asset/misc/kristin/sif_ann_201508b.nc'):
     xy_cols=['lon','lat']
+    utils = fused.load("https://github.com/fusedio/udfs/tree/main/public/common/").utils
     # Get the data array using the constructed path
-    da = fused.utils.common.get_da(path, coarsen_factor=3, variable_index=0, xy_cols=xy_cols)
+    da = utils.get_da(path, coarsen_factor=3, variable_index=0, xy_cols=xy_cols)
     # Clip the array based on the bounding box
-    arr_aoi = fused.utils.common.clip_arr(da.values,
+    arr_aoi = utils.clip_arr(da.values,
                        bounds_aoi=bbox.total_bounds,
-                       bounds_total=fused.utils.common.get_da_bounds(da, xy_cols=xy_cols))
+                       bounds_total=utils.get_da_bounds(da, xy_cols=xy_cols))
     # Convert the array to an image with the specified colormap
     img = (arr_aoi*255).astype('uint8')
-    return fused.utils.common.arr_to_plasma(arr_aoi, min_max=(0, 1), colormap="rainbow", include_opacity=False, reverse=True)
+    return utils.arr_to_plasma(arr_aoi, min_max=(0, 1), colormap="rainbow", include_opacity=False, reverse=True)
 ```
-
 Once I saved the UDF and created an [HTTP endpoint](/core-concepts/run-udfs/run-small-udfs/#http-requests), I visualized the data interactively in the [App Builder](/workbench/app-builder/).
 
 

--- a/blog/2024-09-23-kristin/index.mdx
+++ b/blog/2024-09-23-kristin/index.mdx
@@ -71,7 +71,7 @@ Now, let's get into the predictor variable—a NetCDF file from 5 degrees off th
 @fused.udf
 def udf(bbox: fused.types.TileGDF=None, path: str='s3://fused-asset/misc/kristin/sif_ann_201508b.nc'):
     xy_cols=['lon','lat']
-    utils = fused.load("https://github.com/fusedio/udfs/tree/main/public/common/").utils
+    utils = fused.load("https://github.com/fusedio/udfs/tree/057a273/public/common/").utils
     # Get the data array using the constructed path
     da = utils.get_da(path, coarsen_factor=3, variable_index=0, xy_cols=xy_cols)
     # Clip the array based on the bounding box

--- a/blog/2025-02-11-overture/index.mdx
+++ b/blog/2025-02-11-overture/index.mdx
@@ -97,11 +97,13 @@ The example above shows how to run an existing UDF to load Overture data, but it
 @fused.udf
 def udf(bbox: fused.types.TileGDF = None):
 
+    utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/Overture_Maps_Example/").utils
+
     # 1. Load Buildings
-    gdf_buildings = fused.utils.Overture_Maps_Example.get_overture(bbox=bbox, theme='buildings')
+    gdf_buildings = utils.get_overture(bbox=bbox, theme='buildings')
 
     # 2. Load Places
-    gdf_places = fused.utils.Overture_Maps_Example.get_overture(bbox=bbox, theme='places')
+    gdf_places = utils.get_overture(bbox=bbox, theme='places')
 
     # 3. Create a column with the Buliding Name
     gdf_buildings['primary_name'] = gdf_buildings['names'].apply(lambda x: x.get('primary') if isinstance(x, dict) else None)
@@ -158,8 +160,10 @@ def udf(bbox: fused.types.TileGDF = None):
     import pandas as pd
     import requests
 
+    utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/Overture_Maps_Example/").utils
+
     # 1. Load Overture Buildings
-    gdf_overture = fused.utils.Overture_Maps_Example.get_overture(bbox=bbox)
+    gdf_overture = utils.get_overture(bbox=bbox)
 
     # 2. Load NSI from API
     response = requests.post(

--- a/blog/2025-02-18-jennings/index.mdx
+++ b/blog/2025-02-18-jennings/index.mdx
@@ -54,13 +54,14 @@ aoi = json.dumps({"type":"FeatureCollection","features":[{"type":"Feature","prop
 @fused.udf
 def udf(bbox: fused.types.TileGDF=aoi):
     import geopandas as gpd
+    utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/Overture_Maps_Example/").utils
 
     # 1. Convert bbox to GeoDataFrame
     if isinstance(bbox, str):
         bbox = gpd.GeoDataFrame.from_features(json.loads(bbox))
 
     # 2. Load Overture Buildings that intersect the given bbox centroid
-    gdf = fused.utils.Overture_Maps_Example.get_overture(bbox=bbox.geometry.centroid, overture_type='building', min_zoom=10)
+    gdf = utils.get_overture(bbox=bbox.geometry.centroid, overture_type='building', min_zoom=10)
 
     # How many Overture buildings fall within the bbox centroid?
     print("Buildings in centroid: ", len(gdf))
@@ -96,6 +97,8 @@ def udf(gers_id: str='08b2a100d2cb6fff02000821de8bdff1'):
     import geopandas as gpd
     import pandas as pd
 
+    utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/Overture_Maps_Example/").utils
+
     # 1. H3 from GERS
     h3_index = gers_id[:16]
     print('h3_index', h3_index)
@@ -105,7 +108,7 @@ def udf(gers_id: str='08b2a100d2cb6fff02000821de8bdff1'):
     bbox = gpd.GeoDataFrame({'h3_index': [h3_index], 'geometry': [bounds]})
 
     # 3. Load Overture Buildings
-    gdf = fused.utils.Overture_Maps_Example.get_overture(bbox=bbox, overture_type='building', min_zoom=10)
+    gdf = utils.get_overture(bbox=bbox, overture_type='building', min_zoom=10)
 
     # 4. Subselect building
     gdf = gdf[gdf['id'] == gers_id]

--- a/docs/core-concepts/data_ingestion/why-ingestion.mdx
+++ b/docs/core-concepts/data_ingestion/why-ingestion.mdx
@@ -104,7 +104,8 @@ def from_csv_df_udf(
 ):
     import geopandas as gpd
     import pandas as pd
-    bounds = fused.utils.common.bounds_to_gdf(bounds)
+    utils = fused.load("https://github.com/fusedio/udfs/tree/eda5aec/public/common/").utils
+    bounds = utils.bounds_to_gdf(bounds)
     df = pd.read_csv(path)
     gdf = gpd.GeoDataFrame(df, geometry=gpd.points_from_xy(df.LON, df.LAT))
     bounds_ais = gdf[gdf.geometry.within(bounds.iloc[0].geometry)]
@@ -138,7 +139,8 @@ def from_parquet_udf(
     import geopandas as gpd
     import pandas as pd
     df = pd.read_parquet(path)
-    bounds = fused.utils.common.bounds_to_gdf(bounds)
+    utils = fused.load("https://github.com/fusedio/udfs/tree/eda5aec/public/common/").utils
+    bounds = utils.bounds_to_gdf(bounds)
     gdf = gpd.GeoDataFrame(df, geometry=gpd.points_from_xy(df.LON, df.LAT))
     bounds_ais = gdf[gdf.geometry.within(bounds.iloc[0].geometry)]
     return bounds_ais

--- a/docs/core-concepts/filetile.mdx
+++ b/docs/core-concepts/filetile.mdx
@@ -83,7 +83,8 @@ As `fused.types.Bounds` is a list of 4 points it cannot be returned in a UDF dir
 def udf(bounds: fused.types.Bounds=None):
     import shapely
     import geopandas as gpd
-    bounds = fused.utils.common.bounds_to_gdf(bounds)
+    utils = fused.load("https://github.com/fusedio/udfs/tree/eda5aec/public/common/").utils
+    bounds = utils.bounds_to_gdf(bounds)
     print(bounds)
     return bounds
 ```
@@ -93,7 +94,8 @@ def udf(bounds: fused.types.Bounds=None):
 ```python showLineNumbers
 @fused.udf
 def udf(bounds: fused.types.Bounds=None):
-    bounds = fused.utils.common.bounds_to_gdf(bounds)
+    utils = fused.load("https://github.com/fusedio/udfs/tree/eda5aec/public/common/").utils
+    bounds = utils.bounds_to_gdf(bounds)
     return bounds
 ```
 

--- a/docs/core-concepts/write.mdx
+++ b/docs/core-concepts/write.mdx
@@ -162,12 +162,6 @@ utils = fused.load(
 )
 ```
 
-Modules in the [public UDFs](https://github.com/fusedio/udfs/tree/main) repo are imported from `fused.utils`.
-
-```python showLineNumbers
-utils = fused.utils.common
-```
-
 `utils` Module are imported from other UDFs in a user's account.
 
 ```python showLineNumbers

--- a/docs/python-sdk/top-level-functions.mdx
+++ b/docs/python-sdk/top-level-functions.mdx
@@ -365,64 +365,6 @@ def geodataframe_from_geojson():
     return gdf
 ```
 
----
-
-## `utils`
-
-
-A module to access utility functions located in the UDF called "common".
-
-They can be imported by other UDFs with `utils = fused.utils.common`. They contain common operations such as:
-
-- `read_shape_zip`
-- `url_to_arr`
-- `get_collection_bbox`
-- `read_tiff_pc`
-- `table_to_tile`
-- `rasterize_geometry`
-- `estimate_zoom`
-
-**Examples**:
-
-This example shows how to access the `geo_buffer` function from the `common` UDF.
-
-```python showLineNumbers
-import fused
-import geopandas as gpd
-
-gdf = gpd.read_file('https://www2.census.gov/geo/tiger/TIGER_RD18/STATE/11_DISTRICT_OF_COLUMBIA/11/tl_rd22_11_bg.zip')
-gdf_buffered = fused.utils.common.geo_buffer(gdf, 10)
-```
-
-This example shows how to load a table with `table_to_tile`, which efficiently loads a table by filtering and adjusting based on the provided bounding box (bounds) and zoom level.
-
-```python showLineNumbers
-table_path = "s3://fused-asset/infra/census_bg_us"
-gdf = fused.utils.common.table_to_tile(
-    bounds, table_path, use_columns=["GEOID", "geometry"], min_zoom=12
-)
-```
-
-This example shows how to use `rasterize_geometry` to place an input geometry within an image array.
-
-```python showLineNumbers
-geom_masks = [fused.utils.common.rasterize_geometry(geom, arr.shape[-2:], transform) for geom in gdf.geometry]
-```
-
-
-This example shows how to use `estimate_zoom` to for a given bounding box. This function returns the zoom level at which a tile exists that, potentially shifted slightly, fully covers the bounding box.
-
-```python showLineNumbers
-utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
-
-z = utils.common.estimate_zoom(bounds)
-```
-
-
-Public UDFs are listed at https://github.com/fusedio/udfs/tree/main/public
-
----
-
 ## `ingest`
 
 ```python showLineNumbers

--- a/docs/python-sdk/top-level-functions.mdx
+++ b/docs/python-sdk/top-level-functions.mdx
@@ -151,7 +151,7 @@ on the format of the input and retrieves the UDF accordingly.
 Load a UDF from a GitHub URL:
 
 ```python showLineNumbers
-udf = fused.load("https://github.com/fusedio/udfs/tree/main/public/REM_with_HyRiver/")
+udf = fused.load("https://github.com/fusedio/udfs/tree/cb37656/public/REM_with_HyRiver/")
 ```
 
 Load a UDF from a local file:
@@ -236,7 +236,7 @@ Run a UDF saved in the Fused system:
 Run a UDF saved in GitHub:
 
 ```python showLineNumbers
-    loaded_udf = fused.load("https://github.com/fusedio/udfs/tree/main/public/Building_Tile_Example")
+    loaded_udf = fused.load("https://github.com/fusedio/udfs/tree/e3202f5/public/Building_Tile_Example")
     fused.run(loaded_udf, bounds=bounds)
     ```
 

--- a/docs/user-guide/examples/dark-vessel-detection.mdx
+++ b/docs/user-guide/examples/dark-vessel-detection.mdx
@@ -264,7 +264,8 @@ print(range_of_ais_dates)
 We can create a simple `lamda` function that takes each value and sends it to a [`PoolRunner` job](/core-concepts/run-udfs/run-small-udfs/#experimental-using-run_pool-and-poolrunner):
 
 ```python showLineNumbers
-runs = fused.utils.common.PoolRunner(lambda datestr: fused.run(read_ais_from_noaa_udf(datestr=datestr, overwrite=False)), range_of_ais_dates)
+utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
+runs = utils.PoolRunner(lambda datestr: fused.run(read_ais_from_noaa_udf(datestr=datestr, overwrite=False)), range_of_ais_dates)
 
 runs.get_result_all()
 ```
@@ -378,8 +379,9 @@ Let's start with a basic UDF just returning our area of interest:
 def udf(
     bounds: fused.types.Bounds,
 ):
+    utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
     # Convert bounds to GeoDataFrame using Fused utility function
-    bounds = fused.utils.common.bounds_to_gdf(bounds)
+    bounds = utils.bounds_to_gdf(bounds)
     return bounds
 ```
 
@@ -409,7 +411,8 @@ def udf(
 ):
     # Define our specific bounds
     specific_bounds = [-93.90425364, 29.61879782, -93.72767384, 29.7114987]
-    bounds = fused.utils.common.bounds_to_gdf(specific_bounds)
+    utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
+    bounds = utils.bounds_to_gdf(specific_bounds)
     return bounds
 ```
 
@@ -428,7 +431,8 @@ def udf(
     import shapely
     # Define our specific bounds and convert to GeoDataFrame
     specific_bounds = [-93.90425364, 29.61879782, -93.72767384, 29.7114987]
-    bounds = fused.utils.common.bounds_to_gdf(specific_bounds)
+    utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
+    bounds = utils.bounds_to_gdf(specific_bounds)
     
     catalog = pystac_client.Client.open(
         "https://planetarycomputer.microsoft.com/api/stac/v1",
@@ -453,7 +457,8 @@ def udf(
 
     time_of_interest="2024-09-03/2024-09-04"
     specific_bounds = [-93.90425364, 29.61879782, -93.72767384, 29.7114987]
-    bounds = fused.utils.common.bounds_to_gdf(specific_bounds)
+    utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
+    bounds = utils.bounds_to_gdf(specific_bounds)
 
     catalog = pystac_client.Client.open(
         "https://planetarycomputer.microsoft.com/api/stac/v1",
@@ -500,7 +505,8 @@ def udf(
     
     # Convert bounds to GeoDataFrame for STAC operations
     specific_bounds = [-93.90425364, 29.61879782, -93.72767384, 29.7114987]
-    bounds = fused.utils.common.bounds_to_gdf(specific_bounds)
+    utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
+    bounds = utils.bounds_to_gdf(specific_bounds)
 
     catalog = pystac_client.Client.open(
         "https://planetarycomputer.microsoft.com/api/stac/v1",
@@ -588,7 +594,8 @@ def get_data(
     import pystac_client
 
     # Convert bounds to GeoDataFrame
-    bounds = fused.utils.common.bounds_to_gdf(bounds)
+    utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
+    bounds = utils.bounds_to_gdf(bounds)
 
     if resolution < 10:
         print("Resolution shouldn't be lower than Sentinel 1 or 2 native resolution. Bumping to 10m")
@@ -673,7 +680,8 @@ We can make this even simpler by moving the `get_data` function under [the `Modu
 
         # Convert tile to GeoDataFrame if needed
         if not isinstance(bounds, gpd.GeoDataFrame):
-            bounds = fused.utils.common.bounds_to_gdf(bounds)
+            utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
+            bounds = utils.bounds_to_gdf(bounds)
 
         if resolution < 10:
             print("Resolution shouldn't be lower than Sentinel 1 or 2 native resolution. Bumping to 10m")
@@ -767,7 +775,8 @@ Radar images over calm water tend to look black (as all the radar signal is refl
 
 
         # Convert bounds to GeoDataFrame
-        bounds = fused.utils.common.bounds_to_gdf(bounds)
+        utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
+        bounds = utils.bounds_to_gdf(bounds)
 
         if resolution < 10:
             print("Resolution shouldn't be lower than Sentinel 1 or 2 native resolution. Bumping to 10m")
@@ -855,7 +864,8 @@ This is now relatively simple to vectorise (turn into a vector object, from imag
         import geopandas as gpd
         import numpy as np
         from local_utils import get_data, quick_convolution, vectorise_raster
-        bounds_gdf = fused.utils.common.bounds_to_gdf(bounds)
+        utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
+        bounds_gdf = utils.bounds_to_gdf(bounds)
         da = get_data(bounds, time_of_interest, resolution, bands)
         image = da.values * 1.0
 
@@ -894,8 +904,9 @@ This is now relatively simple to vectorise (turn into a vector object, from imag
         import odc.stac
         import planetary_computer
         import pystac_client
-        
-        bounds = fused.utils.common.bounds_to_gdf(bounds)
+
+        utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
+        bounds = utils.bounds_to_gdf(bounds)
         if resolution < 10:
             print("Resolution shouldn't be lower than Sentinel 1 or 2 native resolution. Bumping to 10m")
             resolution = 10
@@ -1006,14 +1017,15 @@ To get our AIS data, we now need to retrieve the exact moment our Sentinel 1 ima
         import geopandas as gpd
         import numpy as np
         from local_utils import get_data, quick_convolution, vectorise_raster
-        
-        bounds_gdf = fused.utils.common.bounds_to_gdf(bounds)
-        
+
+        utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
+        bounds_gdf = utils.bounds_to_gdf(bounds)
+
         da = get_data(bounds, time_of_interest, resolution, bands)
         image = da.values * 1.0
 
         convoled_image = quick_convolution(np.array(image), kernel_size=2)
-        
+
         gdf_predictions = vectorise_raster(
             raster=convoled_image.astype("uint8"),
             bounds=bounds_gdf, 
@@ -1051,7 +1063,8 @@ To get our AIS data, we now need to retrieve the exact moment our Sentinel 1 ima
         import planetary_computer
         import pystac_client
 
-        bounds = fused.utils.common.bounds_to_gdf(bounds)
+        utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
+        bounds = utils.bounds_to_gdf(bounds)
         
         if resolution < 10:
             print("Resolution shouldn't be lower than Sentinel 1 or 2 native resolution. Bumping to 10m")

--- a/docs/user-guide/examples/zonal-stats.mdx
+++ b/docs/user-guide/examples/zonal-stats.mdx
@@ -108,7 +108,7 @@ The first parameter of this UDF, `bounds`. It is reserved for Fused to pass a `G
 
 The `year` parameter is used to structure the S3 path of the CDL GeoTiff which the utility function `read_tiff` reads for the area defined by `bounds`. The `crop_id` parameter 36 corresponds to alfalfa the CDL [colormap](https://storage.googleapis.com/earthengine-stac/catalog/USDA/USDA_NASS_CDL.json), which the UDF uses to mask the raster array.
 
-Fused lets you import utility Modules from other UDFs with `fused.utils`. Their code lives in the [public UDFs repo](https://github.com/fusedio/udfs/blob/main/public/common/utils.py).
+Fused lets you import utility Modules from other UDFs with `fused.load`. Their code lives in the [public UDFs repo](https://github.com/fusedio/udfs/blob/main/public/common/utils.py).
 
 - `read_tiff` loads an array of the CDL dataset for the specified `bounds` extent and `year`
 - `table_to_tile` loads the table you geo partitioned for the specified `bounds` extent
@@ -124,8 +124,10 @@ def udf(
 ):
     import numpy as np
 
+    utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
+
     # Load CDLS data
-    arr = fused.utils.common.read_tiff(
+    arr = utils.read_tiff(
       bounds,
       input_tiff_path=f"s3://fused-asset/data/cdls/{year}_30m_cdls.tif"
     )
@@ -134,7 +136,7 @@ def udf(
     arr = np.where(np.isin(arr, [crop_id]), 1, 0)
 
     # Load polygons
-    gdf = fused.utils.common.table_to_tile(
+    gdf = utils.table_to_tile(
       bounds,
       table='s3://fused-asset/data/tl_2023_49_bg/',
       min_zoom=5,
@@ -143,7 +145,7 @@ def udf(
     gdf.crs = 4326
 
     # Calculate zonal stats
-    return fused.utils.common.geom_stats(gdf, arr)
+    return utils.geom_stats(gdf, arr)
 ```
 
 Try running the UDF in the [UDF Builder](/workbench/udf-builder/) and visually inspect the output on the map. See what happens when you change `year`. Try introducing print statements such as `print(arr)` and `print(gdf)` to show logs in the console.
@@ -274,7 +276,8 @@ def run_udf(year):
     gdf['year'] = year
     return gdf
 
-gdfs = fused.utils.common.run_pool(run_udf, [2019, 2020, 2021])
+utils = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
+gdfs = utils.run_pool(run_udf, [2019, 2020, 2021])
 gdf_final = pd.concat(gdfs)
 gdf_final
 ```

--- a/docs/user-guide/transform/generic/duckdb.mdx
+++ b/docs/user-guide/transform/generic/duckdb.mdx
@@ -20,7 +20,7 @@ This pattern gives DuckDB easy parallel operations. Fused spatially filters the 
 ```python showLineNumbers
 import fused
 
-udf = fused.load("https://github.com/fusedio/udfs/tree/main/public/DuckDB_H3_Example_Tile")
+udf = fused.load("https://github.com/fusedio/udfs/tree/ea99f07/public/DuckDB_H3_Example_Tile")
 gdf = fused.run(udf=udf, x=2412, y=3078, z=13, engine='local')
 gdf.head()
 ```

--- a/docs/user-guide/use-cases/overturensi.mdx
+++ b/docs/user-guide/use-cases/overturensi.mdx
@@ -42,7 +42,7 @@ This UDF performs a spatial join between the Overture Building Footprints and th
 @fused.udf
 def udf(bounds: fused.types.TileGDF = None):
     # Load datasets
-    utils = fused.load("https://github.com/fusedio/udfs/tree/main/public/Nsi_Overture").utils
+    utils = fused.load("https://github.com/fusedio/udfs/tree/9c5c8bf/public/Nsi_Overture").utils
     gdf_overture = utils.load_overture_gdf(bounds, overture_type="building")
     gdf_nsi = utils.load_nsi_gdf(bounds)
 

--- a/docs/workbench/udf-builder/viz-styling.mdx
+++ b/docs/workbench/udf-builder/viz-styling.mdx
@@ -212,8 +212,8 @@ def udf(
 ):
     import numpy as np
     import random
-    bounds = fused.utils.common.bounds_to_gdf(bounds)
     utils = fused.load("https://github.com/fusedio/udfs/tree/eda5aec/public/common/").utils
+    bounds = utils.bounds_to_gdf(bounds)
 
     # Load data
     gdf=utils.table_to_tile(bounds, table=table_path)


### PR DESCRIPTION
Replace all instances of `fused.utils` usage with `fused.load(...).utils`.
[link to task](https://www.notion.so/fusedio/Remove-fused-utils-mention-in-docs-1ac899d3b76380bf98f4f0753be00724?pvs=4)