### PR TITLE
replace occurrences of engine type realtime with remote 

### DIFF
--- a/docs/core-concepts/async.mdx
+++ b/docs/core-concepts/async.mdx
@@ -13,7 +13,7 @@ import Tag from '@site/src/components/Tag'
 A UDF can be called asynchronously using the [async/await](https://docs.python.org/3/library/asyncio.html) syntax. A common implementation is to call a UDF multiple times in parallel with different parameters then combine the results.
 
 :::note
-    Setting `sync=False` in `fused.run` is intended for asynchronous calls when running in the cloud with `engine='realtime'`. The parameter has no effect if the UDF is ran in the local environment with `engine='local'`.
+    Setting `sync=False` in `fused.run` is intended for asynchronous calls when running in the cloud with `engine='remote'`. The parameter has no effect if the UDF is ran in the local environment with `engine='local'`.
 :::
 
 To illustrate this concept, let's create a simple UDF and save it as `udf_to_run_async` in the workbench:
@@ -43,7 +43,7 @@ async def parent_fn():
     # Invoke the UDF as coroutines
     promises_dfs = []
     for date in dates:
-        df = fused.run("udf_to_run_async", date=date, engine='realtime', sync=False)
+        df = fused.run("udf_to_run_async", date=date, engine='remote', sync=False)
         promises_dfs.append(df)
 
     # Run concurrently and collect the results

--- a/docs/core-concepts/run-udfs/run.mdx
+++ b/docs/core-concepts/run-udfs/run.mdx
@@ -195,7 +195,7 @@ fused.run(commit_udf)
 - `batch`: Run a long-running job in a Fused server. This must first be enabled for the account.
 
 ```python showLineNumbers
-fused.run(my_udf, engine="realtime")
+fused.run(my_udf, engine="remote")
 ```
 
 Set `sync=False` to run a UDF [asynchronously](/core-concepts/async/).

--- a/docs/python-sdk/batch.mdx
+++ b/docs/python-sdk/batch.mdx
@@ -54,7 +54,7 @@ def udf(
 
 ## 2. Run UDF [on an offline instance](/core-concepts/run-udfs/run_large/)
 
-To go beyond the 120s limit of the default [`fused.run(udf)`](/core-concepts/run-udfs/run-small-udfs/#fusedrun) call we'll define a job and use []`job.run_remote()`](/core-concepts/run-udfs/run_large/#running-a-large-job-jobrun_remote) to make kick off a call on a large, offline instance:
+To go beyond the 120s limit of the default [`fused.run(udf)`](/core-concepts/run-udfs/run-small-udfs/#fusedrun) call we'll define a job and use [`job.run_remote()`](/core-concepts/run-udfs/run_large/#running-a-large-job-jobrun_remote) to make kick off a call on a large, offline instance.
 Get in touch with Fused if your account doesn't have batch-mode enabled.
 
 Note: Make sure to replace `<YOUR_DIR>` with your own directory.

--- a/docs/python-sdk/batch.mdx
+++ b/docs/python-sdk/batch.mdx
@@ -52,9 +52,24 @@ def udf(
 
 ```
 
-## 2. Monitor job
+## 2. Run UDF [on an offline instance](/core-concepts/run-udfs/run_large/)
 
-`job_id` has a number of methods to monitor the job. For example `job_tail_logs` streams logs as the job runs.
+To go beyond the 120s limit of the default [`fused.run(udf)`](/core-concepts/run-udfs/run-small-udfs/#fusedrun) call we'll define a job and use []`job.run_remote()`](/core-concepts/run-udfs/run_large/#running-a-large-job-jobrun_remote) to make kick off a call on a large, offline instance:
+Get in touch with Fused if your account doesn't have batch-mode enabled.
+
+Note: Make sure to replace `<YOUR_DIR>` with your own directory.
+
+```python showLineNumbers
+job = udf(
+    source_s3_path = 'https://datadownload-production.s3.amazonaws.com/WCMC_carbon_tonnes_per_ha.zip', 
+    destination_s3_path = 's3://fused-users/fused/<YOUR_DIR>/dswid/WCMC_carbon_tonnes_per_ha_10gb/'
+)
+job_id = job.run_remote()
+```
+
+## 3. Monitor job
+
+`job_id` has a [number of methods to monitor the job](/core-concepts/run-udfs/run_large/#accessing-job-logs). For example `job_tail_logs` streams logs as the job runs.
 
 ```python showLineNumbers
 fused.api.job_tail_logs("df335890-4406-4832-bf93-6a3b092e496d")

--- a/docs/python-sdk/batch.mdx
+++ b/docs/python-sdk/batch.mdx
@@ -52,16 +52,7 @@ def udf(
 
 ```
 
-## 2. Run UDF as a batch job
-
-Run the UDF with `engine='batch'`. Get in touch with Fused if your account doesn't have batch-mode enabled.
-
-```python showLineNumbers
-job_id = fused.run(udf, engine='batch', source_s3_path = 'https://datadownload-production.s3.amazonaws.com/WCMC_carbon_tonnes_per_ha.zip', destination_s3_path = 's3://fused-users/fused/plinio/dswid/WCMC_carbon_tonnes_per_ha_10gb/')
-job_id
-```
-
-## 3. Monitor job
+## 2. Monitor job
 
 `job_id` has a number of methods to monitor the job. For example `job_tail_logs` streams logs as the job runs.
 

--- a/docs/python-sdk/top-level-functions.mdx
+++ b/docs/python-sdk/top-level-functions.mdx
@@ -178,7 +178,7 @@ def run(
     y: Optional[int] = None,
     z: Optional[int] = None,
     sync: bool = True,
-    engine: Optional[Literal["remote", "local", "batch"]] = None,
+    engine: Optional[Literal["remote", "local"]] = None,
     type: Optional[Literal["tile", "file"]] = None,
     max_retry: int = 0,
     cache_max_age: Optional[str] = None,
@@ -206,7 +206,7 @@ path based on the provided parameters.
 - `y` _int | None_ - Tile coordinates for tile-based UDF execution.
 - `z` _int | None_ - Tile coordinates for tile-based UDF execution.
 - `sync` _bool_ - If True, execute the UDF synchronously. If False, execute asynchronously.
-- `engine` _Literal["remote", "local", "batch"] | None_ - The execution engine to use.
+- `engine` _Literal["remote", "local"] | None_ - The execution engine to use.
 - `type` _Literal["tile", "file"] | None_ - The type of UDF execution ('tile' or 'file').
 - `max_retry` _int_ - The maximum number of retries to attempt if the UDF fails. By default does not retry.
 - `cache_max_age` _str | None_ - The maximum age when returning a result from the cache. Default is `None` so a UDF run with `fused.run()` will follow `cache_max_age` defined in `@fused.udf()` unless this value is changed.

--- a/docs/python-sdk/top-level-functions.mdx
+++ b/docs/python-sdk/top-level-functions.mdx
@@ -178,7 +178,7 @@ def run(
     y: Optional[int] = None,
     z: Optional[int] = None,
     sync: bool = True,
-    engine: Optional[Literal["remote", "local"]] = None,
+    engine: Optional[Literal["remote", "local", "batch"]] = None,
     type: Optional[Literal["tile", "file"]] = None,
     max_retry: int = 0,
     cache_max_age: Optional[str] = None,
@@ -206,7 +206,7 @@ path based on the provided parameters.
 - `y` _int | None_ - Tile coordinates for tile-based UDF execution.
 - `z` _int | None_ - Tile coordinates for tile-based UDF execution.
 - `sync` _bool_ - If True, execute the UDF synchronously. If False, execute asynchronously.
-- `engine` _Literal["remote", "local"] | None_ - The execution engine to use ('remote' or 'local').
+- `engine` _Literal["remote", "local", "batch"] | None_ - The execution engine to use.
 - `type` _Literal["tile", "file"] | None_ - The type of UDF execution ('tile' or 'file').
 - `max_retry` _int_ - The maximum number of retries to attempt if the UDF fails. By default does not retry.
 - `cache_max_age` _str | None_ - The maximum age when returning a result from the cache. Default is `None` so a UDF run with `fused.run()` will follow `cache_max_age` defined in `@fused.udf()` unless this value is changed.

--- a/docs/workbench/app-builder/app-overview.mdx
+++ b/docs/workbench/app-builder/app-overview.mdx
@@ -102,10 +102,10 @@ df = fused.run(udf, count=count)
 st.write(df)
 ```
 
-You may also run the UDF on a remote worker by setting `engine='realtime'` in the `fused.run` call.
+You may also run the UDF on a remote worker by setting `engine='remote'` in the `fused.run` call.
 
 ```python showLineNumbers
-df = fused.run(udf, count=count, engine='realtime')
+df = fused.run(udf, count=count, engine='remote')
 ```
 
 ## Call UDFs


### PR DESCRIPTION
- replace all occurrences of engine type `realtime` with `remote` 
- add additional option of `batch` for the engine type - it is supported both in the code as well as used in the docs

(need to update the types in `fused-py` too)