### PR TITLE
Adding COG + Geoparquet to title headers

### DIFF
--- a/docs/core-concepts/data-ingestion/file_formats.mdx
+++ b/docs/core-concepts/data-ingestion/file_formats.mdx
@@ -22,9 +22,9 @@ Take a look at [our benchmark](/core-concepts/data-ingestion/why-ingestion/#benc
 
 To make the most out of Fused, we recommend [ingesting your data](/core-concepts/data-ingestion/ingestion-your-data/) into the following file formats:
 
-### For rasters (images)
+### For rasters (images): Cloud Optimized GeoTIFF
 
-For images (like satellite images) we recommend using **Cloud Optimized GeoTiffs** (COGs). To paraphrase [the Cloud Native Geo guide on them](https://guide.cloudnativegeo.org/cloud-optimized-geotiffs/intro.html):
+For images (like satellite images) we recommend using **Cloud Optimized GeoTIFFs** (COGs). To paraphrase [the Cloud Native Geo guide on them](https://guide.cloudnativegeo.org/cloud-optimized-geotiffs/intro.html):
 
 > Cloud-Optimized GeoTIFF (COG), a raster format, is a variant of the TIFF image format that specifies a particular layout of internal data in the GeoTIFF specification to allow for optimized (subsetted or aggregated) access over a network for display or data reading
 
@@ -33,7 +33,7 @@ For images (like satellite images) we recommend using **Cloud Optimized GeoTiffs
     {/* TODO: Link to how to run CLI commands in Fused once we have this up and running */}
 :::
 
-Cloud Optimized GeoTiffs have multiple different features making them particularly interesting for cloud native applications, namely:
+Cloud Optimized GeoTIFFs have multiple different features making them particularly interesting for cloud native applications, namely:
 - **Tiling**: Images are split into smaller tiles that can be individually accessed, making getting only parts of data a lot faster.
 - **Overviews**: Pre-rendered images of lower zoom levels of images. This makes displaying images at different zoom levels a lot faster
 
@@ -48,7 +48,7 @@ _A simple visual of COG tiling: If we only need the top left part of the image w
 - [Cloud Optimized Geotiff spec dedicated website](https://cogeo.org/)
 - [Cloud Optimized Geotiff page on Cloud Native Geo guide](https://guide.cloudnativegeo.org/cloud-optimized-geotiffs/intro.html)
 
-### For vectors (tables)
+### For vectors (tables): GeoParquet
 
 To handle vector data such as `pandas` `DataFrames` or `geopandas` `GeoDataFrames` we recommend using **[GeoParquet](https://github.com/opengeospatial/geoparquet)** files. To (once again) paraphrase the [Cloud Native Geo guide](https://guide.cloudnativegeo.org/geoparquet/):
 

--- a/docs/user-guide/examples/zonal-stats.mdx
+++ b/docs/user-guide/examples/zonal-stats.mdx
@@ -55,7 +55,7 @@ graph LR
 - We should also provide users with some sample data so they can replicate the whole process. Then explain how to reproduce with their own data
 */}
 
-You'll first upload your own vector table with `fused.ingest`. This spatially partitions the table and writes it in your specified S3 bucket as a [GeoParquet](/core-concepts/data-ingestion/file-formats/#for-vectors-tables) file. You'll then calculate zonal stats over a raster array of alfalfa crops in the [USDA Cropland Data Layer](https://catalog.data.gov/dataset/cropscape-cropland-data-layer) (CDL) dataset.
+You'll first upload your own vector table with `fused.ingest`. This spatially partitions the table and writes it in your specified S3 bucket as a [GeoParquet](/core-concepts/data-ingestion/file-formats/#for-vectors-tables-geoparquet) file. You'll then calculate zonal stats over a raster array of alfalfa crops in the [USDA Cropland Data Layer](https://catalog.data.gov/dataset/cropscape-cropland-data-layer) (CDL) dataset.
 
 This example shows how to geo partition polygons of [Census Block Groups](https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.html) for Utah, which is a Parquet table with a `geometry` column. You can follow along with this file or any vector table you'd like. Read about other supported formats in [Ingest your own data](/core-concepts/data-ingestion/).
 


### PR DESCRIPTION
Goal: Make `Cloud Optimized Geotiff` and `Parquet` show up in search by adding them to header. Currently these sections don't show up:

![CleanShot 2025-04-10 at 11 20 55@2x](https://github.com/user-attachments/assets/70f4bab6-499f-46d7-959b-f71b18289ccb)

![CleanShot 2025-04-10 at 11 21 22@2x](https://github.com/user-attachments/assets/2b717419-0f74-462d-9b17-1c7263503f86)
