### PR TITLE
Updating html display link to public UDF

### DIFF
--- a/docs/user-guide/out/mapbox.mdx
+++ b/docs/user-guide/out/mapbox.mdx
@@ -135,7 +135,7 @@ Use the following snippet to create a raster layer. The layer in the sample map 
     map.addSource('fused-irradiation-source', {
         'type': 'raster',
         'tiles': [ // Raster Tile URL that returns png
-            'https://www.fused.io/server/v1/realtime-shared/af0bc71e64075233b731f316988b323ac28658059db9e87388393fe187752501/run/tiles/{z}/{x}/{y}?dtype_out_raster=png'
+            'https://www.fused.io/server/v1/realtime-shared/UDF_Solar_Irradiance/run/tiles/{z}/{x}/{y}?dtype_out_raster=png'
         ],
         'tileSize': 256,
         'minzoom': 10,

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -5770,6 +5770,28 @@ UDF Builder & File Explorer work well together, so we've made easy to jump from 
 - In UDF Builder, `Cmd + Click` on a `s3://...` path will open it directly in File Explorer
 - In File Explorer double clicking on a file will prompt Fused to do its best at guessing which Catalog UDF to use to load this file in Code Editor
 
+## Organising your work
+
+### Renaming UDFs
+
+You can easily rename UDFs by clicking on the UDF name in the header and hitting `Enter`
+
+Your team can load your own UDFs by calling it with a [team udf name](/core-concepts/run-udfs/run-small-udfs/#team-udf-names) so be sure to give it an explicit name!
+
+### Using tags
+
+You can add tags to your UDF in the [Share](/workbench/udf-builder/navigation/#share) page. This gives yet another way to find & search your UDFs. We recommend giving tags according to:
+- Type of data the UDF works with (e.g. `satellite image`, `elevation model`, `population`)
+- Type of analysis the UDF does (e.g. `zonal stats`, `building footprint extraction`, `flood mapping`)
+- Type of file the UDF loads (e.g. `vector`, `raster`, `point cloud`)
+
+### Using Collections
+
+You can use [Collections](/workbench/udf-builder/collections/) to organise your UDFs into different projects. This allows you to:
+- Have multiple unrelated projects in Workbench
+- Be able to share a set of UDFs at once with your team (by downloading a Collection & sending it to your team mates)
+
+
 ## Troubleshooting
 
 If things feel a bit off, for example your UDF output looks suspicious here are a few things you can do:
@@ -10338,15 +10360,24 @@ import ReactPlayer from 'react-player'
 
 A Collection is a way for users to organize their UDFs into different projects. This allows you to use Workbench for completely different, unrelated projects and organise your UDFs in a cleaner way. 
 
-Currently, all collections are private, meaning only you can see and manage them.
+:::note
+Collection is still in Beta so you need to enable it under "Preferences -> Enable UDF Collections [Beta]" to access it
+
+![Enable UDF Collections](/img/workbench/udf-builder/Collection_beta.png)
+:::
+
+You can:
+- Save all current open UDFs into a Collection (after giving it a name)
+- Upload / Download Collections via Workbench (Click the 3 dots next to Collection name)
+- Delete Collections (this doesn't delete the UDFs inside, only the Collection)
 
 <ReactPlayer playsinline={true} className="video__player" playing={false} muted={true} controls height="100%" url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/collections_edit.mp4" width="100%" />
 
 We are actively working on expanding Collection features!
 
-:::note
-Collection is still in early access so you need to enable it under "Preferences -> Enable UDF Collections [Beta]" to access it
-:::
+### Examples of Collections in use
+
+- See how we recommend using Collections as part of our [Best Practices](/user-guide/best-practices/workbench-best-practices/#organising-your-work)
 
 ---
 


### PR DESCRIPTION
Related to [this ticket](https://www.notion.so/fusedio/Raster-tile-image-is-not-displayed-in-the-map-preview-on-the-Mapbox-HTML-documentation-page-1d5899d3b763806388f2c5b96c209318?pvs=4)

Fix actually isn't this PR, it required [fixing the public UDF](https://github.com/fusedio/udfs/pull/837) that didn't work properly with the new `bounds` 

The change in this PR is only to show the correct public URL in the displayed HTML code block