### PR TITLE
Add script to automate updating the python reference docs

### DIFF
--- a/utils/generate_reference_docs.py
+++ b/utils/generate_reference_docs.py
@@ -1,0 +1,57 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "fused",
+#   "griffe",
+#   "griffe2md",
+# ]
+# ///
+#
+# Use as `python utils/generate_reference_docs.py` in the root of this repo
+
+from pathlib import Path
+
+import griffe
+from griffe2md.rendering import default_config
+from griffe2md.main import render_object_docs
+
+
+mod = griffe.load("fused")#, docstring_parser="google")
+
+
+## Top-level API page
+
+api_listing = [
+    "udf",
+    "cache",
+    "load",
+    "run",
+    "submit",
+    "download",
+    "ingest",
+    "file_path",
+    "get_chunks_metadata",
+    "get_chunk_from_table",
+]
+
+result = """\
+---
+sidebar_label: Top-Level Functions
+title: Top-Level Functions
+toc_max_heading_level: 4
+---
+
+"""
+
+for obj in api_listing:
+    # result += f"## fused.{obj}\n\n"
+    docstring = render_object_docs(mod[obj], default_config)
+    result += docstring + "\n\n"
+
+
+result = result.replace("## fused.udf", "## @fused.udf")
+result = result.replace("## fused.cache", "## @fused.cache")
+
+
+with open(Path(__file__).parent / ".." / "docs" / "python-sdk" / "top-level-functions.mdx", "w") as f:
+    f.write(result)


### PR DESCRIPTION
Initial script to automatically generate the fused API docs from the latest `fused` package.

Some notes:

- Currently does it only for the top-level-functions page, but very similarly could also add it for `fused.api` page
- The actual markdown text formatting needs some work:
  - Right now it is configured to not do any parsing of the docstring, but just include it. However, our docstrings are not exactly valid markdown right now, so we would have to do some formatting updates to the docstrings to have it render here properly.
  - But, the docstring parsing does support various docstring styles like google or numpydoc. So we could also revert the commit reformatting the docstrings and use again the google style. Then this script should convert that to proper markdown formatting.
- There are some visual differences, like no longer showing the type annotations in the signature. There are some options for the rendering that we can tweak, including the type annotations is one of them. Overview: https://github.com/mkdocstrings/griffe2md/blob/167abb2cf76b14120d6504a54a74ee68dbf9ddca/src/griffe2md/rendering.py#L49-L88
- We can also do some manual post-processing if needed. For example, I replaced `## fused.udf` with `## @fused.udf` in case we want to keep that @ sign in the section title. We could do something similar to keep the titles in code formatting.

Current doc page

![image](https://github.com/user-attachments/assets/c53fbbb7-7fee-4f5f-a085-80387adf28a7)


With this script:

![image](https://github.com/user-attachments/assets/9629dff8-768b-4477-9097-6433a0cd5050)

