### PR TITLE
Update blog list border, switch to News

### DIFF
--- a/blog/2024-03-06-pressrelease/index.mdx
+++ b/blog/2024-03-06-pressrelease/index.mdx
@@ -3,7 +3,7 @@ slug: fused-redefines-geospatial-with-instant-maps
 title: "Fused redefines geospatial with instant maps"
 authors: [sina, isaac]
 tags: [press release]
-category: announcements
+category: news
 image: "/img/blog/2024-03-06-pressrelease/cover.png"
 unlisted: false
 ---

--- a/blog/2024-04-22-webinar/index.mdx
+++ b/blog/2024-04-22-webinar/index.mdx
@@ -3,7 +3,7 @@ slug: geospatial-workflows-of-any-size
 title: "Geospatial workflows of any size"
 authors: [isaac, matt]
 tags: [isaac brodsky, flood, linkedin, webinar]
-category: announcements
+category: news
 image: "/img/blog/2024-04-22-webinar/cover.jpg"
 unlisted: false
 ---

--- a/blog/2024-10-17-isaac/index.mdx
+++ b/blog/2024-10-17-isaac/index.mdx
@@ -2,7 +2,7 @@
 slug: blazing-fast-geospatial-sql-in-duckdb
 title: "Blazing Fast Geospatial SQL in DuckDB"
 authors: [isaac]
-category: "announcements"
+category: news
 image: https://fused-magic.s3.us-west-2.amazonaws.com/blog-assets/isaac_foss4g.png
 ---
 

--- a/blog/2024-11-21-foursquare-poi/index.mdx
+++ b/blog/2024-11-21-foursquare-poi/index.mdx
@@ -3,7 +3,7 @@ slug: fused-public-udf-for-foursquare-pois
 title: "The Fastest Way to Download Foursquare's new POI Dataset"
 authors: [max, sina]
 tags: [foursquare, poi]
-category: announcements
+category: news
 image: "/img/blog/2024-11-21-foursquare-poi/cover.png"
 hide_table_of_contents: false
 keywords: [foursquare, poi]

--- a/blog/2025-02-11-overture/index.mdx
+++ b/blog/2025-02-11-overture/index.mdx
@@ -3,7 +3,7 @@ slug: partnering-with-overture
 title: "We're partnering with Overture to make their Data easily accessible with Fused"
 authors: [jennings, plinio]
 tags: [overture, spatial, join]
-category: announcements
+category: news
 image: "/img/blog/2025-02-11-overture/cover.png"
 hide_table_of_contents: false
 keywords: [overture, spatial, join]

--- a/blog/2025-02-25-fused/index.mdx
+++ b/blog/2025-02-25-fused/index.mdx
@@ -3,7 +3,7 @@ slug: announcing-fused-2-0
 title: "Announcing Fused 2.0"
 authors: [max]
 tags: [fused, workbench, announcement]
-category: announcements
+category: news
 image: "/img/announcements/new_ui.png"
 hide_table_of_contents: false
 keywords: [fused, announcement]

--- a/blog/2025-04-01-announcing-ai-builder/index.mdx
+++ b/blog/2025-04-01-announcing-ai-builder/index.mdx
@@ -3,7 +3,7 @@ slug: announcing-fused-ai-builder
 title: "Announcing Fused AI Builder"
 authors: [max]
 tags: [fused, workbench, announcement, ai-builder, agents]
-category: announcements
+category: news
 hide_table_of_contents: false
 keywords: [fused, announcement]
 image: "/img/blog/2025-04-01-announcing-ai-builder/cover.png"

--- a/blog/2025-04-08-TED/index.mdx
+++ b/blog/2025-04-08-TED/index.mdx
@@ -3,7 +3,7 @@ slug: fused-powering-maxar
 title: "Fused featured in Maxar TED Talk"
 authors: [isaac, sina]
 tags: [fused, workbench, announcement, ai-builder,]
-category: "announcements"
+category: news
 image: "/img/announcements/TED_Fused_Maxar.png"
 hide_table_of_contents: false
 keywords: [fused, announcement]

--- a/blog/2025-05-06-cdl-census-hex/index.mdx
+++ b/blog/2025-05-06-cdl-census-hex/index.mdx
@@ -3,7 +3,7 @@ slug: cdl-census-hex
 title: "Repartitioning Crop Data Layer & US Census into H3 hexagons"
 authors: [max, sina]
 tags: [fused, workbench, announcement, hex, census, source-coop]
-category: announcements
+category: news
 image: "/img/blog/2025-05-06-cdl-census-hex/workbench_census_exploring.png"
 hide_table_of_contents: false
 keywords: [fused, h3, hex, census, cdl]

--- a/src/theme/BlogListPage/index.tsx
+++ b/src/theme/BlogListPage/index.tsx
@@ -12,7 +12,7 @@ import styles from './styles.module.css';
 
 const CATEGORIES = {
   all: 'All',
-  announcements: 'Announcements',
+  news: 'News',
   technical: 'Technical blogs',
   use_cases: 'Use cases',
   uncategorized: 'Uncategorized',

--- a/src/theme/BlogListPage/styles.module.css
+++ b/src/theme/BlogListPage/styles.module.css
@@ -77,6 +77,7 @@
   border-radius: 8px;
   overflow: hidden;
   transition: transform 0.2s ease;
+  border: 1px solid #333;
 }
 
 .blogCard:hover {


### PR DESCRIPTION
- Added a discrete border around the blog post cards
- Changed `Announcements` to `News`

<img width="1328" alt="Screenshot 2025-05-19 at 19 51 23" src="https://github.com/user-attachments/assets/25dba3d6-8a0b-4055-b70d-66d971bd8972" />
