### PR TITLE
fix asset link in duckdb example

### DIFF
--- a/docs/user-guide/in/duckdb.mdx
+++ b/docs/user-guide/in/duckdb.mdx
@@ -22,7 +22,7 @@ def udf(agg_factor=3, min_count=5):
         round(pickup_latitude*{agg_factor},3)/{agg_factor} lat,
         count(1) cnt
     FROM
-        read_parquet('s3://fused-users/fused/asset/docs//user_guide/yellow_tripdata_2010-01.parquet')
+        read_parquet('s3://fused-asset/docs/user_guide/yellow_tripdata_2010-01.parquet')
     GROUP BY
         round(pickup_longitude*{agg_factor},3),
         round(pickup_latitude*{agg_factor},3)


### PR DESCRIPTION
The current link does not exist (and would also not be accessible for non-internal users)