### PR TITLE
Python API docs: add page for Udf object

### DIFF
--- a/docs/python-sdk/api-reference/udf.mdx
+++ b/docs/python-sdk/api-reference/udf.mdx
@@ -1,0 +1,124 @@
+---
+sidebar_label: Udf
+title: Udf
+toc_max_heading_level: 5
+---
+
+## Udf
+
+The `Udf` class is the object you get when defining a UDF with the
+[`@fused.udf`](/python-sdk/top-level-functions/#fusedudf) decorator, or when loading
+a saved UDF with [`fused.load()`](/python-sdk/top-level-functions/#fusedload).
+
+### to_fused
+
+```python
+to_fused(
+    slug: str | None = ...,
+    over_id: str | UUID | None = None,
+    as_new: bool | None = None,
+    inplace: bool = True,
+    overwrite: bool | None = None,
+)
+```
+
+Save this UDF on the Fused service.
+
+**Parameters:**
+
+- **slug** (<code>str | None</code>) – ID to refer to this UDF as in URLs.
+- **over_id** (<code>str | UUID | None</code>) – ID to save the UDF over.
+- **as_new** (<code>bool | None</code>) – If True, force saving this UDF as new.
+- **inplace** (<code>bool</code>) – If True (default), update the UDF object with the new saved ID.
+- **overwrite** (<code>bool | None</code>) – If True, overwrite existing remote UDF with the UDF object.
+
+---
+
+### to_directory
+
+```python
+to_directory(where: str | Path | None = None, *, overwrite: bool = False)
+```
+
+Write the UDF to disk as a directory (folder).
+
+**Parameters:**
+
+- **where** (<code>str | Path | None</code>) – A path to a directory. If not provided, uses the UDF function name.
+
+**Other Parameters:**
+
+- **overwrite** (<code>[bool](#bool)</code>) – If true, overwriting is allowed.
+
+---
+
+### to_file
+
+```python
+to_file(where: str | Path | BinaryIO, *, overwrite: bool = False)
+```
+
+Write the UDF to disk or the specified file-like object.
+
+The UDF will be written as a Zip file.
+
+**Parameters:**
+
+- **where** (<code>str | Path | BinaryIO</code>) – A path to a file or a file-like object.
+
+**Other Parameters:**
+
+- **overwrite** (<code>[bool](#bool)</code>) – If true, overwriting is allowed.
+
+---
+
+### create_access_token
+
+```python
+create_access_token(
+    *,
+    client_id: str | Ellipsis | None = ...,
+    public_read: bool | None = None,
+    access_scope: str | None = None,
+    cache: bool = True,
+    metadata_json: dict[str, Any] | None = None,
+    enabled: bool = True
+) -> UdfAccessToken
+```
+
+---
+
+### get_access_tokens
+
+```python
+get_access_tokens() -> UdfAccessTokenList
+```
+
+---
+
+### delete_saved
+
+```python
+delete_saved(inplace: bool = True)
+```
+
+---
+
+### delete_cache
+
+```python
+delete_cache()
+```
+
+---
+
+### catalog_url
+
+```python
+catalog_url: str | None
+```
+
+Returns the link to open this UDF in the Workbench Catalog, or None if the UDF is not saved.
+
+---
+

--- a/utils/generate_reference_docs.py
+++ b/utils/generate_reference_docs.py
@@ -8,7 +8,7 @@
 # ]
 # ///
 #
-# Use as `uv run utils/generate_reference_docs.py` in the root of this repo
+# Use as `uv run --reinstall-package fused utils/generate_reference_docs.py` in the root of this repo
 
 from pathlib import Path
 
@@ -298,4 +298,49 @@ for meth in methods:
     result += docstring + "\n---\n\n"
 
 with open(ROOT / "docs" / "python-sdk" / "api-reference" / "jobpool.mdx", "w") as f:
+    f.write(result)
+
+
+## `Udf` page
+
+result = """\
+---
+sidebar_label: Udf
+title: Udf
+toc_max_heading_level: 5
+---
+
+"""
+
+result += """\
+## Udf
+
+The `Udf` class is the object you get when defining a UDF with the
+[`@fused.udf`](/python-sdk/top-level-functions/#fusedudf) decorator, or when loading
+a saved UDF with [`fused.load()`](/python-sdk/top-level-functions/#fusedload).
+
+"""
+
+# listing and rendering the methods separately to avoid including the Udf 
+# class signature and docstring (which is not public)
+methods = [
+    "to_fused",
+    "to_directory",
+    "to_file",
+    "create_access_token",
+    "get_access_tokens",
+    "delete_saved",
+    "delete_cache",
+    "catalog_url",
+]
+
+config = dict(default_config)
+config["heading_level"] = default_config["heading_level"] + 1
+config["show_root_full_path"] = False
+
+for meth in methods:
+    docstring = render_object_docs(mod["models"]["Udf"][meth], config)
+    result += docstring + "\n---\n\n"
+
+with open(ROOT / "docs" / "python-sdk" / "api-reference" / "udf.mdx", "w") as f:
     f.write(result)


### PR DESCRIPTION
This adds a subset of the `Udf` methods to the docs.

We can easily add more (I added now the ones that I think are most important), although note that some of the methods I currently added don't yet have much of an informative docstring, so that is something that first needs to be improved on the fused-py side.