### PR TITLE
keep run_remote alias mention

### DIFF
--- a/utils/generate_reference_docs.py
+++ b/utils/generate_reference_docs.py
@@ -135,7 +135,7 @@ job_id.cancel()
 
 ---
 
-#### `job.run_batch`
+#### `job.run_remote`
 
 Alias of `job.run_batch` for backwards compatibility. See `job.run_batch` above
 for details.


### PR DESCRIPTION
I had that added as a section in the generation script to keep the link working (and keep a mention of run_remote for people using it, so they understand it is an alias), but I think @MaxLenormand your auto search/replace also updated this one.