### PR TITLE
Fixing changelog video spacing

### DIFF
--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -88,31 +88,37 @@ AI:
 - AI chat can be docker on the right or the left.
 - You can now specify specific UDFs in AI chat.
 
-<LazyReactPlayer 
+<div style={{textAlign: "center", marginBottom: "20px"}}>
+  <LazyReactPlayer 
     playsinline={true}
     className="video__player"
     playing={true}
     muted={true}
     controls
-    height="350px"
-    width="600px"
+    height="100%"
+    width="100%"
+    style={{maxWidth: "600px"}}
     url="https://fused-magic.s3.us-west-2.amazonaws.com/docs_assets/changelog/1_21_6_quote_udf.mp4"
-/>
+  />
+</div>
 
 
 Versioning: 
 - Version control page will ask to confirm pushing to a different repository.
 
-<LazyReactPlayer 
+<div style={{textAlign: "center", marginBottom: "20px"}}>
+  <LazyReactPlayer 
     playsinline={true}
     className="video__player"
     playing={true}
     muted={true}
     controls
-    height="350px"
-    width="600px"
+    height="100%"
+    width="100%"
+    style={{maxWidth: "600px"}}
     url="https://fused-magic.s3.us-west-2.amazonaws.com/docs_assets/changelog/1_21_6_diff_repo_warning.mp4"
-/>
+  />
+</div>
 
 
 Rendering:
@@ -131,16 +137,19 @@ Rendering:
 - Added self service signup for new users!
 - Added voice input to udf.ai and to rich text frames.
 
-<LazyReactPlayer 
+<div style={{textAlign: "center", marginBottom: "20px"}}>
+  <LazyReactPlayer 
     playsinline={true}
     className="video__player"
     playing={true}
     muted={true}
     controls
-    height="350px"
-    width="600px"
+    height="100%"
+    width="100%"
+    style={{maxWidth: "600px"}}
     url="https://fused-magic.s3.us-west-2.amazonaws.com/docs_assets/changelog/1.21.5_mic_demo.mp4"
-/>
+  />
+</div>
 
 
 **Improvements:**
@@ -161,16 +170,19 @@ General:
 Canvas:
 - Canvas now shows controls on hover.
 
-<LazyReactPlayer 
+<div style={{textAlign: "center", marginBottom: "20px"}}>
+  <LazyReactPlayer 
     playsinline={true}
     className="video__player"
     playing={true}
     muted={true}
     controls
-    height="350px"
-    width="600px"
+    height="100%"
+    width="100%"
+    style={{maxWidth: "600px"}}
     url="https://fused-magic.s3.us-west-2.amazonaws.com/docs_assets/changelog/1.21.5_canvas_controls_on_hover.mp4"
-/>
+  />
+</div>
 
 
 **Bug Fixes:**


### PR DESCRIPTION
Before:

<img width="1254" height="882" alt="CleanShot 2025-08-27 at 08 48 05@2x" src="https://github.com/user-attachments/assets/7f2a2fe3-2e52-4b5a-9c7e-60556c53aa0c" />

After Fix:

<img width="1254" height="882" alt="CleanShot 2025-08-27 at 08 49 07@2x" src="https://github.com/user-attachments/assets/cc8080cd-4820-4cc0-849b-a7fd5c910321" />
