### PR TITLE
Redirect older Github pages to current fused docs

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-docs.fused.io

--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,0 @@
-# Jekyll configuration for GitHub Pages redirects
-plugins:
-  - jekyll-redirect-from
-
-# Global redirect for GitHub Pages to main domain
-url: "https://docs.fused.io"
-
-# Redirect all GitHub Pages traffic to main domain
-redirect_to: https://docs.fused.io

--- a/static/_redirect
+++ b/static/_redirect
@@ -1,2 +1,0 @@
-# Netlify-style redirects (if ever deployed on Netlify)
-/* https://docs.fused.io/:splat 301!


### PR DESCRIPTION
Found that ChatGPT was pointing to much older version of the docs 

EDIT: Removed older version of docs as well. Not worth it in the long term 