### PR TITLE
Fixing trailing slashes but still having blog url working properly

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -139,9 +139,15 @@ jobs:
             # Test critical pages on staging
             echo "Testing all critical staging links..."
             curl -f "$STAGING_URL/" || (echo "❌ Staging homepage failed" && exit 1)
-            curl -f "$STAGING_URL/blog/" || (echo "❌ Staging blog failed" && exit 1)
-            curl -f "$STAGING_URL/quickstart/" || (echo "❌ Staging quickstart failed" && exit 1)
-            curl -f "$STAGING_URL/tutorials/" || (echo "❌ Staging tutorials failed" && exit 1)
+            
+            # Test both URL formats to ensure no redirects and both work
+            echo "Testing blog URLs (both formats)..."
+            curl -f "$STAGING_URL/blog" || (echo "❌ Staging blog (no slash) failed" && exit 1)
+            curl -f "$STAGING_URL/blog/" || (echo "❌ Staging blog (with slash) failed" && exit 1)
+            
+            echo "Testing other critical pages..."
+            curl -f "$STAGING_URL/quickstart" || (echo "❌ Staging quickstart failed" && exit 1)
+            curl -f "$STAGING_URL/tutorials" || (echo "❌ Staging tutorials failed" && exit 1)
             
             echo "✅ All critical links work on staging"
             

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -12,7 +12,7 @@ const config: Config = {
     fusedPyVersion: '1.20.1',
   },
 
-  trailingSlash: true,
+  trailingSlash: undefined,
   
   // Production URL configuration
   url: process.env.DEPLOYMENT_URL || "https://docs.fused.io",

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -71,6 +71,8 @@ const config: Config = {
           readingTime: ({ content, frontMatter, defaultReadingTime }) =>
             defaultReadingTime({ content, options: { wordsPerMinute: 300 } }),
           truncateMarker: /(<!--\s*truncate\s*-->)|({\/\*\s*truncate\s*\*\/})/,
+          // Ensure consistent canonical URLs
+          routeBasePath: "blog",
         },
         theme: {
           customCss: "./src/css/custom.css",

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -14329,5 +14329,5 @@ Join us in our journey to break from old geospatial infrastructure. Let's revolu
 
 ---
 
-Generated automatically from Fused documentation. Last updated: 2025-09-23
+Generated automatically from Fused documentation. Last updated: 2025-09-25
 Total sections: 5

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -108,4 +108,4 @@ Learn the fundamental concepts behind Fused's serverless geospatial platform.
 
 ---
 
-Generated automatically from Fused documentation. Last updated: 2025-09-23
+Generated automatically from Fused documentation. Last updated: 2025-09-25


### PR DESCRIPTION
Issues with Google not indexing some of our pages properly

This fixes trailing slashes, so they're not needed anymore and work:
<img width="874" height="340" alt="CleanShot 2025-09-25 at 10 03 22@2x" src="https://github.com/user-attachments/assets/2c794262-4591-4112-aa40-2cead2001eb4" />

And I can move back & forth without issues

https://github.com/user-attachments/assets/cc4bfcd9-8093-4969-be55-616d8703f64c

Also updated the CI to catch this