### PR TITLE
Add changelog entry for Canvas cloning feature

### DIFF
--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -26,7 +26,7 @@ When AI suggests code edits in the editor, you can now review and confirm them b
 - Chart UX: improved zoom stability and donut legend cleanup
 - Duplicate now works for errored UDFs; default UDF description removed
 - Real-time UDF log streaming improvements
-- Cloning a canvas no longer requires a shared token
+- You can now clone a Canvas from a Shared Canvas 
 
 **Bug fixes**
 


### PR DESCRIPTION
Updated changelog to reflect new feature for cloning a Canvas.