### PR TITLE
fix: prevent iframe scroll-jump on canvas embed pages

### DIFF
--- a/docs/examples/sharing-canvas-dashboards.mdx
+++ b/docs/examples/sharing-canvas-dashboards.mdx
@@ -21,7 +21,7 @@ This gives you a few options:
 For example, selecting "Embed mode" allows you to `iframe` a canvas as a dashboard:
 
 
-<iframe
+<CanvasIframe
   src="https://unstable.fused.io/canvas/fc_4Dr6z6OuYHboSbs3VbpdEc?embed=true"
   style={{
     width: "100%",

--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -279,7 +279,7 @@ When the base URL includes a specific widget path (for example, `/orders_widget`
 
 ## Available Widgets
 
-[See a live example →](https://unstable.fused.io/canvas/fc_1IlPjYnRgK5cmhwRlbOnLr?embed=false&outline=false&code=true&bounds=-940%2C922%2C-200%2C1483)
+[See a live example →](https://unstable.fused.io/canvas/fc_1IlPjYnRgK5cmhwRlbOnLr?embed=true&bounds=-940%2C922%2C-200%2C1483)
 
 | Category | Widget | Description | Key Features / Notes |
 | --- | --- | --- | --- |
@@ -301,7 +301,7 @@ When the base URL includes a specific widget path (for example, `/orders_widget`
 | Output | `render` | Meta widget | Renders widgets dynamically from JSON |
 
 <CanvasIframe
-  src="https://unstable.fused.io/canvas/fc_1IlPjYnRgK5cmhwRlbOnLr?embed=false&outline=false&code=true&bounds=-940%2C922%2C-200%2C1483"
+  src="https://unstable.fused.io/canvas/fc_1IlPjYnRgK5cmhwRlbOnLr?embed=true&bounds=-940%2C922%2C-200%2C1483"
   width="100%"
   height="600px"
   frameBorder="0"

--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -266,13 +266,13 @@ When the base URL includes a specific widget path (for example, `/orders_widget`
 :::
 
 
-<iframe
+<CanvasIframe
   src="https://unstable.fused.io/share/fc_1bHh5W6D1Yk6smpCeUuWPy/orders_widget?selected_option=orders"
   width="100%"
   height="500px"
   frameBorder="0"
   style={{borderRadius: '8px'}}
-></iframe>
+/>
 
 *When you share a widget URL, Fused automatically appends all canvas parameters as query parameters so the shared view can be reproduced exactly.* [Try it out →](https://unstable.fused.io/share/fc_1bHh5W6D1Yk6smpCeUuWPy/orders_widget?selected_option=orders)
 
@@ -300,13 +300,13 @@ When the base URL includes a specific widget path (for example, `/orders_widget`
 | Output | `fused-map` | Full interactive map | Supports multiple layer types, tooltips, legends, basemaps |
 | Output | `render` | Meta widget | Renders widgets dynamically from JSON |
 
-<iframe
+<CanvasIframe
   src="https://unstable.fused.io/canvas/fc_1IlPjYnRgK5cmhwRlbOnLr?embed=false&outline=false&code=true&bounds=-940%2C922%2C-200%2C1483"
   width="100%"
   height="600px"
   frameBorder="0"
   style={{borderRadius: '8px'}}
-></iframe>
+/>
 
 ## Multi-Component Widgets
 

--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -279,8 +279,6 @@ When the base URL includes a specific widget path (for example, `/orders_widget`
 
 ## Available Widgets
 
-[See a live example →](https://unstable.fused.io/canvas/fc_1IlPjYnRgK5cmhwRlbOnLr?embed=true&bounds=-940%2C922%2C-200%2C1483)
-
 | Category | Widget | Description | Key Features / Notes |
 | --- | --- | --- | --- |
 | Input | `slider` | Numeric range control | `min`, `max`, `step`, `defaultValue`, binds to `param` |
@@ -299,14 +297,6 @@ When the base URL includes a specific widget path (for example, `/orders_widget`
 | Output | `image` | Image display | URL or base64 |
 | Output | `fused-map` | Full interactive map | Supports multiple layer types, tooltips, legends, basemaps |
 | Output | `render` | Meta widget | Renders widgets dynamically from JSON |
-
-<CanvasIframe
-  src="https://unstable.fused.io/canvas/fc_1IlPjYnRgK5cmhwRlbOnLr?embed=true&bounds=-940%2C922%2C-200%2C1483"
-  width="100%"
-  height="600px"
-  frameBorder="0"
-  style={{borderRadius: '8px'}}
-/>
 
 ## Multi-Component Widgets
 

--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -298,6 +298,14 @@ When the base URL includes a specific widget path (for example, `/orders_widget`
 | Output | `fused-map` | Full interactive map | Supports multiple layer types, tooltips, legends, basemaps |
 | Output | `render` | Meta widget | Renders widgets dynamically from JSON |
 
+<CanvasIframe
+  src="https://unstable.fused.io/canvas/fc_1IlPjYnRgK5cmhwRlbOnLr?embed=false&outline=false&code=true&bounds=-940%2C922%2C-200%2C1483"
+  width="100%"
+  height="600px"
+  frameBorder="0"
+  style={{borderRadius: '8px'}}
+/>
+
 ## Multi-Component Widgets
 
 A single widget node can hold multiple widgets — sliders, charts, tables, text, maps — stacked or laid out together. You wrap them in a `div` with `children`.

--- a/src/components/CanvasIframe.jsx
+++ b/src/components/CanvasIframe.jsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useRef } from "react";
+
+/**
+ * Wrapper around <iframe> that prevents the browser from scrolling the
+ * parent page to the iframe when the embedded content loads and steals focus.
+ */
+export default function CanvasIframe({ src, width = "100%", height = "500px", style, title, ...rest }) {
+  const iframeRef = useRef(null);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+
+    // Capture scroll position before the iframe can steal it
+    const scrollX = window.scrollX;
+    const scrollY = window.scrollY;
+
+    const handleLoad = () => {
+      // Restore scroll position in the next frame to override any browser auto-scroll
+      requestAnimationFrame(() => {
+        window.scrollTo(scrollX, scrollY);
+      });
+    };
+
+    iframe.addEventListener("load", handleLoad);
+    return () => iframe.removeEventListener("load", handleLoad);
+  }, [src]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      src={src}
+      width={width}
+      height={height}
+      style={style}
+      title={title || src}
+      {...rest}
+    />
+  );
+}

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -4,6 +4,7 @@ import ReactPlayer from "react-player";
 import LazyReactPlayer from "@site/src/components/LazyReactPlayer";
 import Tag from "@site/src/components/Tag";
 import ClickZoomImage from "@site/src/components/ClickZoomImage";
+import CanvasIframe from "@site/src/components/CanvasIframe";
 
 export default {
   ...MDXComponents,
@@ -11,4 +12,5 @@ export default {
   ReactPlayer,
   Tag,
   ClickZoomImage,
+  CanvasIframe,
 };


### PR DESCRIPTION
## Summary

- Adds a `CanvasIframe` component that captures the page scroll position at mount time and restores it after the iframe loads, preventing the browser from jumping to the iframe when embedded canvas content steals focus
- Registers `CanvasIframe` globally in `MDXComponents` so it can be used in any MDX file without an import
- Replaces raw `<iframe>` tags on the widgets page and sharing-canvas-dashboards page with `<CanvasIframe>`

## How it works

When an embedded iframe loads its content, the browser may auto-scroll the parent page to bring the newly focused element into view. `CanvasIframe` saves `window.scrollY` at mount time and restores it inside a `requestAnimationFrame` callback on the `load` event — running after any browser-initiated scroll.

## Test plan

- [ ] Visit `/guide/data-input-outputs/import-connection/widgets` — page should not scroll down to the embedded canvas iframes on load
- [ ] Visit `/examples/sharing-canvas-dashboards` — same check
- [ ] Verify embedded canvases still render and are interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)