### PR TITLE
docs: rewrite secrets management page to use fused.secrets

### DIFF
--- a/docs/guide/advanced-setup/environment-variables.mdx
+++ b/docs/guide/advanced-setup/environment-variables.mdx
@@ -9,7 +9,6 @@ Fused provides a built-in secrets manager to securely store and access sensitive
 
 ## Storing secrets
 
-### Workbench UI
 
 In Workbench, go to [**Preferences** and find the **Secrets**](/workbench/preferences#secrets-management) section. Click **"+ Add new secret"** to add a key-value pair.
 

--- a/docs/guide/advanced-setup/environment-variables.mdx
+++ b/docs/guide/advanced-setup/environment-variables.mdx
@@ -56,6 +56,8 @@ dir(fused.secrets)
 ## Security notes
 
 - Secrets are stored encrypted in the Fused backend.
-- Secrets are only accessible within UDFs running on Fused infrastructure.
-- Secrets are scoped to your account or organization.
-- Never log or return secret values from UDFs.
+- Any secrets added to Fused are accessible by anyone in your team.
+- Never print or return secret values from UDFs — anyone calling the UDF could otherwise read them.
+- Use `fused.secrets` instead of `.env` files to keep credentials out of your codebase.
+
+For more on writing UDFs securely, see [Security best practices](/guide/working-with-udfs/udf-best-practices/security).

--- a/docs/guide/advanced-setup/environment-variables.mdx
+++ b/docs/guide/advanced-setup/environment-variables.mdx
@@ -19,7 +19,7 @@ In Workbench, go to **Preferences** and find the **Secrets** section. Click **"+
 
 ### CLI
 
-Install the Fused Python SDK and use the `fuse secrets` command to manage secrets from your terminal.
+Install the Fused Python SDK and use the `fused secrets` command to manage secrets from your terminal.
 
 ```bash
 pip install fused

--- a/docs/guide/advanced-setup/environment-variables.mdx
+++ b/docs/guide/advanced-setup/environment-variables.mdx
@@ -9,25 +9,11 @@ Fused provides a built-in secrets manager to securely store and access sensitive
 
 ## Storing secrets
 
-There are two ways to store secrets:
-
 ### Workbench UI
 
-In Workbench, go to **Preferences** and find the **Secrets** section. Click **"+ Add new secret"** to add a key-value pair.
+In Workbench, go to [**Preferences** and find the **Secrets**](/workbench/preferences#secrets-management) section. Click **"+ Add new secret"** to add a key-value pair.
 
 ![secrets management](/img/workbench/preferences/secrets_management.png)
-
-### CLI
-
-Install the Fused Python SDK and use the `fused secrets` command to manage secrets from your terminal.
-
-```bash
-pip install fused
-```
-
-```bash
-fuse secrets set MY_API_KEY sk-abc123
-```
 
 ## Accessing secrets in UDFs
 
@@ -43,14 +29,6 @@ def udf():
     import openai
     client = openai.OpenAI(api_key=api_key)
     ...
-```
-
-## Listing secrets
-
-To list all available secret names:
-
-```python
-dir(fused.secrets)
 ```
 
 ## Security notes

--- a/docs/guide/advanced-setup/environment-variables.mdx
+++ b/docs/guide/advanced-setup/environment-variables.mdx
@@ -35,6 +35,6 @@ def udf():
 - Secrets are stored encrypted in the Fused backend.
 - Any secrets added to Fused are accessible by anyone in your team.
 - Never print or return secret values from UDFs — anyone calling the UDF could otherwise read them.
-- Use `fused.secrets` instead of `.env` files to keep credentials out of your codebase.
+- Use [`fused.secrets`](/python-sdk/api-reference/fused-secrets) instead of `.env` files to keep credentials out of your codebase.
 
 For more on writing UDFs securely, see [Security best practices](/guide/working-with-udfs/udf-best-practices/security).

--- a/docs/guide/advanced-setup/environment-variables.mdx
+++ b/docs/guide/advanced-setup/environment-variables.mdx
@@ -16,7 +16,7 @@ In Workbench, go to [**Preferences** and find the **Secrets**](/workbench/prefer
 
 ## Accessing secrets in UDFs
 
-Use `fused.secrets` to retrieve stored secrets by name:
+Use [`fused.secrets`](/python-sdk/api-reference/fused-secrets) to retrieve stored secrets by name:
 
 ```python
 import fused

--- a/docs/guide/advanced-setup/environment-variables.mdx
+++ b/docs/guide/advanced-setup/environment-variables.mdx
@@ -5,36 +5,57 @@ sidebar_label: Secrets management
 sidebar_position: 1
 ---
 
-Save constants to an `.env` file to make them available to UDFs as environment variables. You should use the [secrets manager](/workbench/preferences#secrets-management) for sensitive information like API keys.
+Fused provides a built-in secrets manager to securely store and access sensitive credentials like API keys, database passwords, and tokens. Secrets are encrypted in the Fused backend and scoped to your account or organization.
 
-First, run a [File UDF](/guide/working-with-udfs/udf-best-practices/geospatial-single-vs-tile#single-udf) that sets variables in an `.env` file in the [`/mnt/cache/` directory](/guide/working-with-udfs/udf-best-practices/storage/#mntcache-disk).
+## Storing secrets
 
-```py
-@fused.udf
-def udf():
-    env_vars = """
-    MY_ENV_VAR=123
-    """
+There are two ways to store secrets:
 
-    # Path to .env file in disk file system
-    env_file_path = '/mnt/cache/.env'
+### Workbench UI
 
-    # Write the environment variables to the .env file
-    with open(env_file_path, 'w') as file:
-        file.write(env_vars)
+In Workbench, go to **Preferences** and find the **Secrets** section. Click **"+ Add new secret"** to add a key-value pair.
+
+![secrets management](/img/workbench/preferences/secrets_management.png)
+
+### CLI
+
+Install the Fused Python SDK and use the `fuse secrets` command to manage secrets from your terminal.
+
+```bash
+pip install fused
 ```
 
-Now, any UDF can load the values from `.env` as environment variables with the [`load_dotenv`](https://pypi.org/project/python-dotenv/) and access them with [os.getenv](https://www.geeksforgeeks.org/python-os-getenv-method/).
+```bash
+fuse secrets set MY_API_KEY sk-abc123
+```
 
-```py
+## Accessing secrets in UDFs
+
+Use `fused.secrets` to retrieve stored secrets by name:
+
+```python
+import fused
+
 @fused.udf
 def udf():
-    from dotenv import load_dotenv
+    api_key = fused.secrets["OPENAI_API_KEY"]
 
-    # Load environment variable
-    env_file_path = '/mnt/cache/.env'
-    load_dotenv(env_file_path, override=True)
-
-    # Access environment variable
-    print(f"Updated MY_ENV_VAR: {os.getenv('MY_ENV_VAR')}")
+    import openai
+    client = openai.OpenAI(api_key=api_key)
+    ...
 ```
+
+## Listing secrets
+
+To list all available secret names:
+
+```python
+dir(fused.secrets)
+```
+
+## Security notes
+
+- Secrets are stored encrypted in the Fused backend.
+- Secrets are only accessible within UDFs running on Fused infrastructure.
+- Secrets are scoped to your account or organization.
+- Never log or return secret values from UDFs.

--- a/docs/python-sdk/api-reference/fused-secrets.mdx
+++ b/docs/python-sdk/api-reference/fused-secrets.mdx
@@ -48,5 +48,5 @@ def udf():
 
 ## See also
 
-- [Environment Variables](/guide/advanced-setup/secrets-management) for runtime configuration
+- [Secrets Management](/guide/advanced-setup/secrets-management) for storing and managing secrets
 - [Cloud Storage](/guide/data-input-outputs/import-connection/cloud-storage) for connecting to cloud providers


### PR DESCRIPTION
## Summary
- Rewrote the secrets management page to focus on `fused.secrets` and the `fuse secrets` CLI instead of the old `.env` file approach
- Added sections for storing secrets (Workbench UI + CLI), accessing secrets in UDFs, listing secrets, and security notes
- Updated the `fused-secrets` API reference cross-link to match the new page title

## Test plan
- [ ] Verify the page renders correctly at `/guide/advanced-setup/secrets-management`
- [ ] Verify the cross-link from `/python-sdk/api-reference/fused-secrets/` works
- [ ] Confirm the screenshot image path is valid