### PR TITLE
docs: add iframe widget to widgets page

### DIFF
--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -299,6 +299,7 @@ When the base URL includes a specific widget path (for example, `/orders_widget`
 | Output | `image` | Image display | URL or base64 |
 | Output | `fused-map` | Full interactive map | Supports multiple layer types, tooltips, legends, basemaps |
 | Output | `render` | Meta widget | Renders widgets dynamically from JSON |
+| Output | `iframe` | Embedded web page | Embeds an external URL; supports `title`, `sandbox`, `allow`, `style` |
 
 <iframe
   src="https://unstable.fused.io/canvas/fc_1IlPjYnRgK5cmhwRlbOnLr?embed=false&outline=false&code=true&bounds=-940%2C922%2C-200%2C1483"

--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -299,7 +299,7 @@ When the base URL includes a specific widget path (for example, `/orders_widget`
 | Output | `image` | Image display | URL or base64 |
 | Output | `fused-map` | Full interactive map | Supports multiple layer types, tooltips, legends, basemaps |
 | Output | `render` | Meta widget | Renders widgets dynamically from JSON |
-| Output | `iframe` | Embedded web page | Embeds an external URL; supports `title`, `sandbox`, `allow`, `style` |
+| Output | `iframe` | Embedded web page | Pass any URL — a video, GIF, image, or web page |
 
 <iframe
   src="https://unstable.fused.io/canvas/fc_1IlPjYnRgK5cmhwRlbOnLr?embed=false&outline=false&code=true&bounds=-940%2C922%2C-200%2C1483"

--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -279,7 +279,7 @@ When the base URL includes a specific widget path (for example, `/orders_widget`
 
 ## Available Widgets
 
-[See a live example →](https://unstable.fused.io/canvas/fc_1IlPjYnRgK5cmhwRlbOnLr?embed=false&outline=false&code=true&bounds=-940%2C922%2C-200%2C1483)
+{/* [See a live example →](https://unstable.fused.io/canvas/fc_1IlPjYnRgK5cmhwRlbOnLr?embed=false&outline=false&code=true&bounds=-940%2C922%2C-200%2C1483) */}
 
 | Category | Widget | Description | Key Features / Notes |
 | --- | --- | --- | --- |
@@ -301,13 +301,13 @@ When the base URL includes a specific widget path (for example, `/orders_widget`
 | Output | `render` | Meta widget | Renders widgets dynamically from JSON |
 | Output | `iframe` | Embedded web page | Pass any URL — a video, GIF, image, or web page |
 
-<iframe
+{/* <iframe
   src="https://unstable.fused.io/canvas/fc_1IlPjYnRgK5cmhwRlbOnLr?embed=false&outline=false&code=true&bounds=-940%2C922%2C-200%2C1483"
   width="100%"
   height="600px"
   frameBorder="0"
   style={{borderRadius: '8px'}}
-></iframe>
+></iframe> */}
 
 ## Multi-Component Widgets
 


### PR DESCRIPTION
## Summary
- Adds the new `iframe` widget to the Available Widgets table on the Widgets [Experimental] page

## Test plan
- [ ] Verify the table row renders correctly on the docs site