### PR TITLE
docs: use plain text header for Slack [Experimental] page

### DIFF
--- a/docs/guide/data-input-outputs/export-api/slack.mdx
+++ b/docs/guide/data-input-outputs/export-api/slack.mdx
@@ -1,0 +1,14 @@
+---
+id: slack
+title: Slack
+sidebar_label: Slack [Experimental]
+sidebar_position: 6
+---
+
+# Slack [Experimental]
+
+Send data and notifications from your UDFs directly to Slack channels.
+
+:::tip Enable Slack integration
+To use this feature, enable it in **Preferences**. Navigate to your account settings and toggle on the Slack integration.
+:::


### PR DESCRIPTION
## Summary
- Changes `# Slack` heading from a styled badge to plain `# Slack [Experimental]`, matching the Widgets page convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)