### PR TITLE
docs: embed Loom videos on Slack integration page

### DIFF
--- a/docs/guide/data-input-outputs/export-api/slack.mdx
+++ b/docs/guide/data-input-outputs/export-api/slack.mdx
@@ -1,0 +1,14 @@
+---
+id: slack
+title: Slack
+sidebar_label: Slack [Experimental]
+sidebar_position: 6
+---
+
+# Slack [Experimental]
+
+Send data and notifications from your UDFs directly to Slack channels.
+
+:::tip Enable Slack integration
+To use this feature, enable it in **Preferences**. Navigate to your account settings and toggle on the Slack integration.
+:::

--- a/docs/guide/data-input-outputs/export-api/slack.mdx
+++ b/docs/guide/data-input-outputs/export-api/slack.mdx
@@ -12,3 +12,25 @@ Send data and notifications from your UDFs directly to Slack channels.
 :::tip Enable Slack integration
 To use this feature, enable it in **Preferences**. Navigate to your account settings and toggle on the Slack integration.
 :::
+
+## Part 1 - Setting up Canvas
+
+<div style={{position: 'relative', paddingBottom: '56.25%', height: 0}}>
+<iframe
+  src="https://www.loom.com/embed/57eeade8806b4d0a99c94da7c5677c3b"
+  frameBorder="0"
+  allowFullScreen
+  style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%'}}
+/>
+</div>
+
+## Part 2 - Talking to Canvas in Slack
+
+<div style={{position: 'relative', paddingBottom: '56.25%', height: 0}}>
+<iframe
+  src="https://www.loom.com/embed/00d91a4976d34b89b75820fdba926b54"
+  frameBorder="0"
+  allowFullScreen
+  style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%'}}
+/>
+</div>


### PR DESCRIPTION
## Summary
- Embeds two Loom walkthrough videos on the Slack [Experimental] page
  - Part 1: Setting up Canvas
  - Part 2: Talking to Canvas in Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)