### PR TITLE
docs: move visible/hidden UDFs visual into Building for Agents guide

### DIFF
--- a/docs/examples/google-calendar-meetings.mdx
+++ b/docs/examples/google-calendar-meetings.mdx
@@ -273,13 +273,11 @@ def udf(date: str = "2026-04-08"):
 
 Only the final `nyc_meeting_routes` UDF is made **visible** on the Canvas — the upstream `gcal_today_events` and `gcal_events_geocode` UDFs are hidden. This means the agent only sees the schedule analysis tool, not the intermediate geocoding or calendar-fetching steps. The agent gets a clean interface: it can query meeting routes and lateness status without needing to understand the pipeline internals.
 
-![Only visible UDFs appear in OpenAPI](/img/hidden-udfs-hidden-api.png)
-
 :::tip
 Return only a small amount of data from the exposed UDF so the agent's context isn't overloaded.
 :::
 
-The Canvas publishes the visible UDF as an agent-callable endpoint via its OpenAPI specification. See [Expose your Canvas to agents](/guide/working-with-udfs/udf-best-practices/agents/#expose-your-canvas-to-agents) for details.
+The Canvas publishes the visible UDF as an agent-callable endpoint via its OpenAPI specification. See [Expose your Canvas to agents](/guide/working-with-udfs/udf-best-practices/agents/#expose-your-canvas-to-agents) for how visible vs. hidden UDFs map to the OpenAPI tool list.
 
 ![Canvas OpenAPI specification for agents](https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/google-calender-openapi.gif)
 

--- a/docs/guide/working-with-udfs/udf-best-practices/agents.mdx
+++ b/docs/guide/working-with-udfs/udf-best-practices/agents.mdx
@@ -372,6 +372,10 @@ Click **Share → Open API** in Workbench to generate an MCP-compatible endpoint
 
 **Only visible UDFs are included.** UDFs that are hidden in Workbench are excluded from the MCP endpoint. Use this to keep helper UDFs, internal utilities, or anything you don't want agents to call directly out of the tool list — they'll still run when called by other UDFs, they just won't be surfaced.
 
+![Only visible UDFs appear in OpenAPI](/img/hidden-udfs-hidden-api.png)
+
+In the example above, the top canvas exposes all three UDFs to the agent, while the bottom canvas hides the two upstream UDFs and surfaces only the final analysis tool. Hiding intermediate steps keeps the agent's tool list focused on the UDFs that answer questions directly.
+
 ### Organize your canvas
 
 All UDFs on a canvas are exposed together through a single canvas token (`fc_XXX`). Group agent-facing UDFs on a dedicated canvas and move large batch jobs or internal utilities to a separate one:


### PR DESCRIPTION
## Summary
- Moves the `hidden-udfs-hidden-api.png` visual from the Google Calendar example into the **Share via MCP** section of the Building for Agents guide, so the conceptual detail lives with the guidance rather than the example.
- Adds a short caption in the guide explaining what the top/bottom canvases illustrate.
- Updates the example to link readers to the guide for the visible/hidden explanation.

## Test plan
- [ ] Verify `/guide/working-with-udfs/udf-best-practices/agents` renders the image under **Share via MCP** with the new caption.
- [ ] Verify `/examples/google-calendar-meetings#3-expose-to-an-ai-agent` reads cleanly without the removed image and the updated link text points to the guide anchor.