### PR TITLE
feat: add /changelog slash command for Claude Code

### DIFF
--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -1,0 +1,97 @@
+# Changelog entry generator
+
+Generate a new changelog entry for `docs/python-sdk/changelog.mdx`.
+
+## Step 1 — Gather the inputs
+
+Ask the user for:
+1. **Version number** (e.g. `v2.6.0`)
+2. **Release date** (default to today's date if not provided)
+3. **Source of changes** — one of:
+   - A list of GitHub PR numbers or URLs
+   - A Notion page / Linear ticket with the release summary
+   - A raw list of bullet points describing what changed
+   - "I'll paste the git log" — in which case, prompt them to paste it
+
+If the user gives PR numbers, use `gh pr view <number> --json title,body` to fetch each one.
+
+## Step 2 — Categorize the changes
+
+Read through all the provided changes and sort them into three buckets:
+
+| Bucket | What goes here |
+|--------|----------------|
+| **Named features** (0–3 items) | The most impactful, user-visible new capabilities. Each gets its own bold heading + 1–2 sentence description + optional screenshot/video embed. |
+| **Improvements** | Smaller enhancements, UI polish, new options, performance wins that users notice. |
+| **Bug fixes** | Fixed regressions or broken behaviors. Start each bullet with "Fixed:". |
+
+**Exclude entirely** (do not mention):
+- Infrastructure upgrades (Amazon Linux, Kubernetes, DB versions)
+- Internal refactors, state management changes, SQL query handling
+- Caching optimizations invisible to users
+- Admin-only endpoints or agent infrastructure fixes
+- Anything that is purely internal and has no user-facing effect
+
+## Step 3 — Apply the writing rules
+
+### Feature naming conventions
+- JSON-UI / widget builder → always write as **[Experimental] [Widgets](/guide/data-input-outputs/import-connection/widgets)**
+- Canvas → [Canvas](/workbench/udf-builder/canvas)
+- H3 analytics → [H3 analytics](/guide/h3-analytics/h3-overview)
+- Shared tokens / API endpoints → [tokens & endpoints](/guide/data-input-outputs/export-api/tokens-endpoints)
+- Slack integration → [Slack integration](/guide/data-input-outputs/export-api/slack)
+
+Use Docusaurus-style relative paths for all internal links. Link to relevant docs pages wherever it makes sense.
+
+### Section structure
+- **0–3 named feature sections** — bold heading (`**Feature name**`), followed by 1–2 sentences of plain English description. Add a screenshot or video embed if one exists.
+- **Improvements** — flat unordered list, grouped by topic (all canvas items together, all AI items together, all home page items together, etc.). Do not list in PR order.
+- **Bug fixes** — flat unordered list, each starting with `Fixed:`.
+
+### Tone
+- Write for end users, not engineers. Avoid jargon.
+- Be concise. One sentence per bullet.
+- Don't repeat the section heading in the bullet text.
+
+## Step 4 — Draft the entry
+
+Insert the new entry at the top of `docs/python-sdk/changelog.mdx`, immediately after the frontmatter block and the `# Changelog` heading. Use this template:
+
+```mdx
+## v{VERSION} ({DATE})
+
+**{Feature 1 heading}**
+
+{1–2 sentence description.}
+
+{Optional: screenshot or video embed — copy the JSX pattern from a nearby entry}
+
+See the [{relevant docs page}]({path}) to get started.
+
+**{Feature 2 heading}** *(if applicable)*
+
+{1–2 sentence description.}
+
+**Improvements**
+
+- {bullet}
+- {bullet}
+
+**Bug fixes**
+
+- Fixed: {bullet}
+- Fixed: {bullet}
+```
+
+## Step 5 — Open a PR
+
+1. Create a branch named `changelog_{version_underscored}` (e.g. `changelog_2_6_0`)
+2. Commit with message: `docs: add v{VERSION} changelog entry`
+3. Open a draft PR with title `docs: add v{VERSION} changelog entry`
+4. PR description should include: version, date, list of PRs included, and a note to add screenshots/videos before merging if they are missing
+
+**Do not include Notion links in the PR description.**
+
+## Reference: recent entry format
+
+See `## v2.5.0` in `docs/python-sdk/changelog.mdx` for a complete example of the expected output format.

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -43,7 +43,7 @@ See the [Slack integration docs](/guide/data-input-outputs/export-api/slack) to 
 **Bug fixes**
 
 - Fixed: share token no longer carried over when copying a canvas in Workbench
-- Fixed: README metadata preserved when pulling UDFs
+- Fixed: README metadata preserved when pulling UDFs from GitHub
 - Fixed: reading and pushing modified public UDFs
 - Fixed: initial canvas tab state in the UDF Collection modal
 - Fixed: Slack integration channel name handling

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -35,7 +35,8 @@ See the [Slack integration docs](/guide/data-input-outputs/export-api/slack) to 
 **Improvements**
 
 - [Experimental] [Widgets](/guide/data-input-outputs/import-connection/widgets): new `w` hotkey to open the widget builder
-- Canvas team access tokens: tokens in UDF settings are now truncated for clarity; "Open API" button activates when a session token is present
+- Canvas team access tokens: tokens in UDF settings are now truncated for clarity
+- Team-scoped shared canvases can now have an API endpoint created with a session token; "Open API" button activates when a session token is present
 - Canvas and share page performance improvements
 - UDF thumbnail now falls back gracefully if canvas-level capture fails
 - Home page UI polish

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -36,7 +36,7 @@ See the [Slack integration docs](/guide/data-input-outputs/export-api/slack) to 
 
 - [Experimental] [Widgets](/guide/data-input-outputs/import-connection/widgets): new `w` hotkey to open the widget builder
 - Canvas team access tokens: tokens in UDF settings are now truncated for clarity
-- [Team-scoped shared canvases](/guide/data-input-outputs/export-api/securing-shared-tokens) can now have an API endpoint created with a session token; "Open API" button activates when a session token is present
+- [Team-scoped shared canvases](/guide/data-input-outputs/export-api/securing-shared-tokens#team-access) can now have an API endpoint created with a session token; "Open API" button activates when a session token is present
 - Canvas and share page performance improvements
 - UDF thumbnail now falls back gracefully if canvas-level capture fails
 - Home page UI polish

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -8,6 +8,30 @@ hide_table_of_contents: true
 
 # Changelog
 
+## v2.5.0 (2026-04-16)
+
+**[Experimental] Talk to your data in Slack!**
+
+Connect any Canvas to a Slack bot and let anyone on your team ask questions directly in Slack — no Workbench needed.
+
+<video
+    style={{
+        width: "80%",
+        aspectRatio: "16/9",
+        height: "auto",
+        margin: "0 auto",
+        display: "block",
+        marginBottom: "1.5rem"
+    }}
+    autoPlay
+    muted
+    loop
+    playsInline>
+    <source src="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/examples/slack/slack_integration_demo.mp4" type="video/mp4" />
+</video>
+
+See the [Slack integration docs](/guide/data-input-outputs/export-api/slack) to get started.
+
 ## v2.4.2 (2026-04-13)
 
 **New home page**

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -36,7 +36,7 @@ See the [Slack integration docs](/guide/data-input-outputs/export-api/slack) to 
 
 - [Experimental] [Widgets](/guide/data-input-outputs/import-connection/widgets): new `w` hotkey to open the widget builder
 - Canvas team access tokens: tokens in UDF settings are now truncated for clarity
-- Team-scoped shared canvases can now have an API endpoint created with a session token; "Open API" button activates when a session token is present
+- [Team-scoped shared canvases](/guide/data-input-outputs/export-api/securing-shared-tokens) can now have an API endpoint created with a session token; "Open API" button activates when a session token is present
 - Canvas and share page performance improvements
 - UDF thumbnail now falls back gracefully if canvas-level capture fails
 - Home page UI polish

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -32,6 +32,22 @@ Connect any Canvas to a Slack bot and let anyone on your team ask questions dire
 
 See the [Slack integration docs](/guide/data-input-outputs/export-api/slack) to get started.
 
+**Improvements**
+
+- [Experimental] [Widgets](/guide/data-input-outputs/import-connection/widgets): new `w` hotkey to open the widget builder
+- Canvas team access tokens: tokens in UDF settings are now truncated for clarity; "Open API" button activates when a session token is present
+- Canvas and share page performance improvements
+- UDF thumbnail now falls back gracefully if canvas-level capture fails
+- Home page UI polish
+
+**Bug fixes**
+
+- Fixed: share token no longer carried over when copying a canvas in Workbench
+- Fixed: README metadata preserved when pulling UDFs
+- Fixed: reading and pushing modified public UDFs
+- Fixed: initial canvas tab state in the UDF Collection modal
+- Fixed: Slack integration channel name handling
+
 ## v2.4.2 (2026-04-13)
 
 **New home page**

--- a/scripts/generate_llms_txt_udf.py
+++ b/scripts/generate_llms_txt_udf.py
@@ -1,0 +1,219 @@
+@fused.udf
+def udf(
+    base_url: str = "https://docs.fused.io",
+    mode: str = "curated",  # "curated" | "full"
+    sitemap_path: str = "/sitemap.xml",
+    site_title: str = "Fused Documentation",
+    site_description: str = "Fused is an end-to-end cloud platform for data analytics, built around User Defined Functions (UDFs): Python functions that can be run via HTTPS requests from anywhere, without any install required.",
+    max_pages: int = 0,  # 0 = no limit, useful for testing
+    output_path: str = "",  # e.g. "fd://my_org/llms.txt" — leave empty to return as string
+):
+    """
+    Generate an llms.txt file from any public docs site with a sitemap.
+
+    Two modes:
+    - "curated": one line per page — title, URL, short description
+    - "full": full page content, lightly cleaned
+
+    Works with any static docs site (Docusaurus, MkDocs, Astro, etc.).
+    """
+    import re
+    import time
+    import requests
+    from xml.etree import ElementTree
+    from bs4 import BeautifulSoup
+
+    # ------------------------------------------------------------------ #
+    # Helpers
+    # ------------------------------------------------------------------ #
+
+    def fetch(url: str, retries: int = 3, timeout: int = 15) -> str | None:
+        headers = {"User-Agent": "llms-txt-generator/1.0 (sitemap crawler)"}
+        for attempt in range(retries):
+            try:
+                r = requests.get(url, headers=headers, timeout=timeout)
+                r.raise_for_status()
+                return r.text
+            except Exception as e:
+                if attempt == retries - 1:
+                    print(f"  ✗ Failed {url}: {e}")
+                    return None
+                time.sleep(1.5 ** attempt)
+
+    def parse_sitemap(xml_text: str) -> list[str]:
+        """Parse a sitemap or sitemap index and return all page URLs."""
+        try:
+            root = ElementTree.fromstring(xml_text)
+        except ElementTree.ParseError:
+            return []
+
+        ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+        urls = []
+
+        # Sitemap index — recurse into sub-sitemaps
+        for sitemap_tag in root.findall("sm:sitemap", ns):
+            loc = sitemap_tag.find("sm:loc", ns)
+            if loc is not None and loc.text:
+                sub_xml = fetch(loc.text.strip())
+                if sub_xml:
+                    urls.extend(parse_sitemap(sub_xml))
+
+        # Regular sitemap
+        for url_tag in root.findall("sm:url", ns):
+            loc = url_tag.find("sm:loc", ns)
+            if loc is not None and loc.text:
+                urls.append(loc.text.strip())
+
+        return urls
+
+    def extract_page(html: str, url: str) -> dict:
+        """
+        Extract title, description, and main content from a docs page HTML.
+
+        Tries common docs site content selectors in order:
+        - <article> (Docusaurus, most static site generators)
+        - .md-content (MkDocs)
+        - .content, .documentation, main
+        - Falls back to <body>
+        """
+        soup = BeautifulSoup(html, "html.parser")
+
+        # Remove nav, sidebar, footer, TOC, scripts, styles
+        for tag in soup.select(
+            "nav, footer, aside, .sidebar, .toc, .table-of-contents, "
+            ".navbar, .pagination, .edit-this-page, script, style, "
+            "[class*='sidebar'], [class*='navbar'], [class*='footer'], "
+            "[class*='toc'], [class*='pagination'], [class*='breadcrumb'], "
+            "[aria-hidden='true']"
+        ):
+            tag.decompose()
+
+        # Title — prefer <h1> inside content, fall back to <title>
+        title = ""
+        h1 = soup.find("h1")
+        if h1:
+            title = h1.get_text(strip=True)
+        if not title:
+            title_tag = soup.find("title")
+            if title_tag:
+                # Strip site name suffix (e.g. " | Fused Docs")
+                title = re.sub(r"\s*[|–—-].*$", "", title_tag.get_text(strip=True))
+
+        # Main content area
+        content_el = (
+            soup.find("article")
+            or soup.find(class_=re.compile(r"md-content|markdown|content|documentation"))
+            or soup.find("main")
+            or soup.body
+        )
+
+        if content_el is None:
+            return {"title": title, "description": "", "content": ""}
+
+        raw_text = content_el.get_text(separator="\n", strip=True)
+
+        # Description: first non-empty, non-heading paragraph-ish line (≥ 40 chars)
+        description = ""
+        for line in raw_text.splitlines():
+            line = line.strip()
+            if len(line) >= 40 and not line.startswith("#"):
+                description = line[:160] + ("..." if len(line) > 160 else "")
+                break
+
+        # Full cleaned content: collapse excessive blank lines
+        content = re.sub(r"\n{3,}", "\n\n", raw_text).strip()
+
+        return {"title": title, "description": description, "content": content}
+
+    # ------------------------------------------------------------------ #
+    # Step 1: fetch + parse sitemap
+    # ------------------------------------------------------------------ #
+
+    sitemap_url = base_url.rstrip("/") + sitemap_path
+    print(f"Fetching sitemap: {sitemap_url}")
+    sitemap_xml = fetch(sitemap_url)
+    if not sitemap_xml:
+        raise RuntimeError(f"Could not fetch sitemap at {sitemap_url}")
+
+    all_urls = parse_sitemap(sitemap_xml)
+    print(f"Found {len(all_urls)} URLs in sitemap")
+
+    # Filter to doc-like pages — skip tag pages, search, 404, assets
+    skip_patterns = re.compile(
+        r"/(tags?|search|404|sitemap|assets|_|static)/|"
+        r"\.(xml|json|txt|png|jpg|svg|css|js)$",
+        re.IGNORECASE,
+    )
+    page_urls = [u for u in all_urls if not skip_patterns.search(u)]
+    page_urls = sorted(set(page_urls))  # deduplicate + stable order
+
+    if max_pages > 0:
+        page_urls = page_urls[:max_pages]
+
+    print(f"Processing {len(page_urls)} doc pages (mode={mode})")
+
+    # ------------------------------------------------------------------ #
+    # Step 2: crawl pages
+    # ------------------------------------------------------------------ #
+
+    pages = []
+    for i, url in enumerate(page_urls):
+        html = fetch(url)
+        if not html:
+            continue
+        page = extract_page(html, url)
+        page["url"] = url
+        pages.append(page)
+        if (i + 1) % 20 == 0:
+            print(f"  {i + 1}/{len(page_urls)} pages crawled...")
+        time.sleep(0.1)  # be polite
+
+    print(f"Successfully extracted {len(pages)} pages")
+
+    # ------------------------------------------------------------------ #
+    # Step 3: assemble llms.txt
+    # ------------------------------------------------------------------ #
+
+    header = f"# {site_title}\n\n> {site_description}\n\n"
+
+    if mode == "curated":
+        lines = [header]
+        lines.append("## Pages\n")
+        for p in pages:
+            line = f"- [{p['title']}]({p['url']})"
+            if p["description"]:
+                line += f" - {p['description']}"
+            lines.append(line)
+        lines.append(
+            f"\n---\n\nGenerated from {base_url} sitemap. "
+            f"Total pages: {len(pages)}"
+        )
+        output = "\n".join(lines)
+
+    else:  # full
+        sep = "=" * 80
+        sections = [header, sep + "\n"]
+        for p in pages:
+            sections.append(f"## {p['title']}")
+            sections.append(f"URL: {p['url']}\n")
+            if p["content"]:
+                sections.append(p["content"])
+            sections.append("\n" + sep + "\n")
+        sections.append(
+            f"\n---\n\nGenerated from {base_url} sitemap. "
+            f"Total pages: {len(pages)}"
+        )
+        output = "\n".join(sections)
+
+    # ------------------------------------------------------------------ #
+    # Step 4: write or return
+    # ------------------------------------------------------------------ #
+
+    if output_path:
+        import fused
+        with fused.open(output_path, "w") as f:
+            f.write(output)
+        print(f"Written to {output_path}")
+        return output_path
+    else:
+        return output


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/changelog.md` — a project-level Claude Code slash command invokable with `/changelog`
- Encodes the release notes writing process (gather inputs → categorize → apply style rules → draft entry → open PR)
- Bakes in existing conventions: Widget=[Experimental], link templates, bullet grouping, backend internals exclusion list

## How to use

Any team member with Claude Code can run `/changelog` from this repo to generate a new changelog entry.

## Notes

- Draft PR — open for review/iteration before merging
- Consider also adding a `CLAUDE.md` at the repo root so the style rules are auto-loaded outside the command