### PR TITLE
docs: rename render widget to widget-builder

### DIFF
--- a/docs/examples/airbnb-explore-on-the-fly.mdx
+++ b/docs/examples/airbnb-explore-on-the-fly.mdx
@@ -42,15 +42,15 @@ def udf():
     return df
 ```
 
-### 2. Connect a render widget to visualize the data
+### 2. Connect a `widget-builder` to visualize the data
 
 The `airbnb_data` UDF returns a DataFrame. To visualize it, we [connect it to a widget](/guide/data-input-outputs/import-connection/widgets#step-2-connect-it-to-a-udf) by drawing an edge from the UDF node to the widget node in the Canvas.
 
-We use a [`render` widget](/guide/data-input-outputs/import-connection/widgets#ai-driven-widget) here because it wraps any chart type and layers on an AI panel — so users can modify the visualization with natural language without touching JSON. In this example we plot a bar chart of the top 15 neighbourhoods by average price:
+We use a [`widget-builder`](/guide/data-input-outputs/import-connection/widgets#ai-driven-widget) here because it wraps any chart type and layers on an AI panel — so users can modify the visualization with natural language without touching JSON. In this example we plot a bar chart of the top 15 neighbourhoods by average price:
 
 ```json
 {
-  "type": "render",
+  "type": "widget-builder",
   "props": {
     "defaultValue": {
       "type": "bar-chart",
@@ -101,5 +101,5 @@ The Canvas can be shared as a link or as a standalone widget. [Share the full Ca
 Open the [Fused Canvas](https://www.fused.io/canvas/fc_5SyzybeWalreHjKfpAymBL?outline=false&bounds=1096%2C-674%2C2648%2C1204) to explore the live Airbnb dataset, or go straight to the [interactive widget](https://www.fused.io/share/fc_5SyzybeWalreHjKfpAymBL/widget_2) to ask questions directly.
 
 :::tip Make it your own
-Clone the Canvas to customize it. Swap the data source, change the default chart, or adjust the AI panel position. See the [Widgets guide](/guide/data-input-outputs/import-connection/widgets#available-props) for the full list of `render` widget props.
+Clone the Canvas to customize it. Swap the data source, change the default chart, or adjust the AI panel position. See the [Widgets guide](/guide/data-input-outputs/import-connection/widgets#available-props) for the full list of `widget-builder` props.
 :::

--- a/docs/examples/airbnb-explore-on-the-fly.mdx
+++ b/docs/examples/airbnb-explore-on-the-fly.mdx
@@ -42,7 +42,7 @@ def udf():
     return df
 ```
 
-### 2. Connect a `widget-builder` to visualize the data
+### 2. Connect a Widget Builder to visualize the data
 
 The `airbnb_data` UDF returns a DataFrame. To visualize it, we [connect it to a widget](/guide/data-input-outputs/import-connection/widgets#step-2-connect-it-to-a-udf) by drawing an edge from the UDF node to the widget node in the Canvas.
 

--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -148,24 +148,24 @@ Open this in a browser to get a live, interactive widget — the chart renders d
 
 ## AI driven Widget
 
-This section uses the `render` widget type — a wrapper widget that takes any other widget definition as input and displays it on the canvas. Because it wraps other widgets, it can layer on an AI panel and a live JSON editor, letting you iterate on the inner widget without leaving the canvas.
+This section uses the `widget-builder` widget type — a wrapper widget that takes any other widget definition as input and displays it on the canvas. Because it wraps other widgets, it can layer on an AI panel and a live JSON editor, letting you iterate on the inner widget without leaving the canvas.
 
-With the `render` widget, you can:
+With the `widget-builder` widget, you can:
 
 - **Wrap any widget** — pass an inner `{ type, props }` definition and render it at runtime.
 - **Edit live with AI** — prompt the built-in AI panel to rewrite the inner definition in place.
 - **Tweak JSON inline** — open the optional JSON editor to change SQL, chart type, or styling without leaving the canvas.
 
-### Structure of a Render Widget
+### Structure of a `widget-builder`
 
-A render widget is always a two-layer schema:
+A `widget-builder` is always a two-layer schema:
 
-- The **outer shell** is `{ "type": "render", "props": { ... } }`.
+- The **outer shell** is `{ "type": "widget-builder", "props": { ... } }`.
 - The **inner definition** is the widget you want to display, stored under `props.defaultValue` as `{ "type": "…", "props": { … } }`.
 
 ```json
 {
-  "type": "render",
+  "type": "widget-builder",
   "props": {
     "defaultValue": {
       "type": "<inner-widget-type>",
@@ -178,9 +178,9 @@ A render widget is always a two-layer schema:
 }
 ```
 
-### How to create and use a Render Widget
+### How to create and use a `widget-builder`
 
-Click the widget icon to create a new widget node, then paste in the JSON below. Once you [connect the widget to the `my_udf` UDF](#step-2-connect-it-to-a-udf), the render widget will display a bar chart with an AI panel and code editor.
+Click the widget icon to create a new widget node, then paste in the JSON below. Once you [connect the widget to the `my_udf` UDF](#step-2-connect-it-to-a-udf), the `widget-builder` will display a bar chart with an AI panel and code editor.
 
 <details>
 <summary>Show the <code>my_udf</code> UDF code</summary>
@@ -201,11 +201,11 @@ def udf(path: str = "s3://fused-sample/demo_data/airbnb_listings_sf.parquet"):
 </details>
 
 <details>
-<summary>Show the render widget JSON</summary>
+<summary>Show the <code>widget-builder</code> JSON</summary>
 
 ```json
 {
-  "type": "render",
+  "type": "widget-builder",
   "props": {
     "defaultValue": {
       "type": "bar-chart",
@@ -228,12 +228,12 @@ def udf(path: str = "s3://fused-sample/demo_data/airbnb_listings_sf.parquet"):
 
 With `aiBuilderMode: "enabled"`, you can describe what you want in plain English (for example, *"switch this to a line chart"* or *"add a filter for price > 100"*), and the AI rewrites the inner `{ type, props }` definition for you. Use `aiPanel` to place the panel (`"right"`, `"left"`, `"top"`, or `"bottom"`).
 
-![AI panel rewriting render widget config from a prompt](/img/widgets/render-widget-ai-prompt.gif)
+![AI panel rewriting widget-builder config from a prompt](/img/widgets/render-widget-ai-prompt.gif)
 
 *Prompting the AI panel to change the chart type to a line chart — the widget updates in real time.* [Try it out →](https://unstable.fused.io/canvas/fc_15tsijBQ8tPM5T2X4r09vP?bounds=846%2C-408%2C2964%2C1270)
 
 :::note
-The AI edits the inner `defaultValue` definition only — the outer `render` shell stays the same. This means you can iterate on chart type, SQL, or styling without touching the widget container itself.
+The AI edits the inner `defaultValue` definition only — the outer `widget-builder` shell stays the same. This means you can iterate on chart type, SQL, or styling without touching the widget container itself.
 :::
 
 ### Available props
@@ -249,7 +249,7 @@ The AI edits the inner `defaultValue` definition only — the outer `render` she
 | `allowedWidgetTypes` | string | `"all"` | Comma-separated list of permitted widget types |
 | `style` | string | — | Inline CSS for the outer container |
 
-For the full list of widgets you can nest inside `render`, see the [available widgets](#available-widgets).
+For the full list of widgets you can nest inside `widget-builder`, see the [available widgets](#available-widgets).
 
 ## Sharing a Widget from Canvas
 
@@ -298,7 +298,7 @@ When the base URL includes a specific widget path (for example, `/orders_widget`
 | Output | `text` | Static/dynamic text | Supports markdown + variants (`h1`, `muted`, etc.) |
 | Output | `image` | Image display | URL or base64 |
 | Output | `fused-map` | Full interactive map | Supports multiple layer types, tooltips, legends, basemaps |
-| Output | `render` | Meta widget | Renders widgets dynamically from JSON |
+| Output | `widget-builder` | Meta widget | Renders widgets dynamically from JSON |
 | Output | `iframe` | Embedded web page | Pass any URL — a video, GIF, image, or web page |
 
 {/* <iframe

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -30,7 +30,7 @@ A redesigned home page with a landing experience, quick-access menu, recents sec
 - [H3 analytics](/guide/h3-analytics/h3-overview): `run_partition` now supports non-count metrics
 - AI edit confirmation: blocking modals replaced with inline gate UI
 - AI usage tracking corrected for basic-tier accounts
-- [Experimental] [Widgets](/guide/data-input-outputs/import-connection/widgets): new `iframe` component for embedding URLs in a render widget
+- [Experimental] [Widgets](/guide/data-input-outputs/import-connection/widgets): new `iframe` component for embedding URLs in a `widget-builder`
 - Export chat conversations from the chat history sidebar
 - Google Drive integration bug fixes
 - Workbench now shows an access-denied page when an environment has been disabled
@@ -41,7 +41,7 @@ A redesigned home page with a landing experience, quick-access menu, recents sec
 - Fixed: [Canvas](/workbench/udf-builder/canvas): serialization error when DataFrame index and column names conflict
 - Fixed: AI running badge overlapping the top bar
 - Fixed: AI edit confirmation flow edge cases
-- Fixed: [Experimental] [Widgets](/guide/data-input-outputs/import-connection/widgets): CodeMirror text selection inside render widgets
+- Fixed: [Experimental] [Widgets](/guide/data-input-outputs/import-connection/widgets): CodeMirror text selection inside `widget-builder`
 
 - Fixed: [Experimental] [Widgets](/guide/data-input-outputs/import-connection/widgets): shared AI widgets now show a login CTA for unauthenticated users
 - Fixed: home page recents card count not updating after reload
@@ -106,7 +106,7 @@ Workbench now automatically creates a session token for UDFs in Team-scoped canv
 **Improvements**
 
 - [Experimental] [Widgets](/guide/data-input-outputs/import-connection/widgets): Map Widget — deck.gl hybrid rendering, tooltip/color updates, and hex-tile polish
-- [Experimental] [Widgets](/guide/data-input-outputs/import-connection/widgets): line chart and more chart types; switch layouts from a dropdown via `render`; SQL-backed widgets use a higher automatic row limit
+- [Experimental] [Widgets](/guide/data-input-outputs/import-connection/widgets): line chart and more chart types; switch layouts from a dropdown via `widget-builder`; SQL-backed widgets use a higher automatic row limit
 - [Experimental] [Widgets](/guide/data-input-outputs/import-connection/widgets): editor and AI tweaks; `$param` references included in share URLs and param discovery
 - Shared canvases support session tokens end-to-end; canvas passcode is generally available
 - Session tokens in the canvas workflow; streamlined top bar


### PR DESCRIPTION
## Summary

- Renames the experimental `render` widget type to `widget-builder` across the docs (Widgets guide, Airbnb example, changelog entries).
- Updates JSON snippets, prose, headings, and table of available widgets so the type string matches the official name.

## Test plan

- [ ] Preview the Widgets guide — AI-driven widget section reads correctly and JSON snippets use `"type": "widget-builder"`.
- [ ] Preview the Airbnb example — anchor link to `#ai-driven-widget` still resolves.
- [ ] Preview the changelog — entries still render cleanly.