### PR TITLE
docs: link to Secrets management from Integrations & Secrets page

### DIFF
--- a/docs/workbench/integrations-secrets.mdx
+++ b/docs/workbench/integrations-secrets.mdx
@@ -16,6 +16,6 @@ Connect external services (like Slack) to Fused so canvases and UDFs can interac
 
 ## Secrets
 
-Store any keys or credentials you want to use in Workbench here. They're encrypted in the Fused backend and attached to your selected kernel.
+Store any keys or credentials you want to use in Workbench here. They're encrypted in the Fused backend and attached to your selected kernel. For details on managing secrets, see the [Secrets management](/guide/advanced-setup/secrets-management) guide.
 
 To use a stored secret from a UDF, see [`fused.secrets`](/python-sdk/api-reference/fused-secrets).


### PR DESCRIPTION
## Summary
- Add link to the [Secrets management](/guide/advanced-setup/secrets-management) guide from the Secrets section of the Integrations & Secrets page

Follow-up to #1035 per [review comment](https://github.com/fusedio/fused-docs/pull/1035#discussion_r3098807451).

## Test plan
- [ ] `npm run build` succeeds with no broken links
- [ ] Link to Secrets management guide resolves correctly