### PR TITLE
docs: move Editing with AI section above widget-builder structure

### DIFF
--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -156,6 +156,18 @@ With the `widget-builder` widget, you can:
 - **Edit live with AI** — prompt the built-in AI panel to rewrite the inner definition in place.
 - **Tweak JSON inline** — open the optional JSON editor to change SQL, chart type, or styling without leaving the canvas.
 
+### Editing with AI
+
+With `aiBuilderMode: "enabled"`, you can describe what you want in plain English (for example, *"switch this to a line chart"* or *"add a filter for price > 100"*), and the AI rewrites the inner `{ type, props }` definition for you. Use `aiPanel` to place the panel (`"right"`, `"left"`, `"top"`, or `"bottom"`).
+
+![AI panel rewriting widget-builder config from a prompt](/img/widgets/render-widget-ai-prompt.gif)
+
+*Prompting the AI panel to change the chart type to a line chart — the widget updates in real time.* [Try it out →](https://unstable.fused.io/canvas/fc_15tsijBQ8tPM5T2X4r09vP?bounds=846%2C-408%2C2964%2C1270)
+
+:::note
+The AI edits the inner `defaultValue` definition only — the outer `widget-builder` shell stays the same. This means you can iterate on chart type, SQL, or styling without touching the widget container itself.
+:::
+
 ### Structure of a `widget-builder`
 
 A `widget-builder` is always a two-layer schema:
@@ -223,18 +235,6 @@ def udf(path: str = "s3://fused-sample/demo_data/airbnb_listings_sf.parquet"):
 ```
 
 </details>
-
-### Editing with AI
-
-With `aiBuilderMode: "enabled"`, you can describe what you want in plain English (for example, *"switch this to a line chart"* or *"add a filter for price > 100"*), and the AI rewrites the inner `{ type, props }` definition for you. Use `aiPanel` to place the panel (`"right"`, `"left"`, `"top"`, or `"bottom"`).
-
-![AI panel rewriting widget-builder config from a prompt](/img/widgets/render-widget-ai-prompt.gif)
-
-*Prompting the AI panel to change the chart type to a line chart — the widget updates in real time.* [Try it out →](https://unstable.fused.io/canvas/fc_15tsijBQ8tPM5T2X4r09vP?bounds=846%2C-408%2C2964%2C1270)
-
-:::note
-The AI edits the inner `defaultValue` definition only — the outer `widget-builder` shell stays the same. This means you can iterate on chart type, SQL, or styling without touching the widget container itself.
-:::
 
 ### Available props
 


### PR DESCRIPTION
## Summary
- Moves the `### Editing with AI` subsection (with the `render-widget-ai-prompt.gif`) up to sit directly after the **Tweak JSON inline** bullet in the **AI driven Widget** section, so the demo video appears near the top of the section for more immediate impact.

## Test plan
- [ ] Verify the `widgets.mdx` page renders correctly and the GIF appears above `### Structure of a widget-builder`.
- [ ] Confirm no duplicate "Editing with AI" section remains later on the page.