### PR TITLE
fix: add missing breadcrumb item property for Google structured data

### DIFF
--- a/src/theme/DocBreadcrumbs/index.tsx
+++ b/src/theme/DocBreadcrumbs/index.tsx
@@ -1,0 +1,119 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {useSidebarBreadcrumbs} from '@docusaurus/plugin-content-docs/client';
+import {useHomePageRoute} from '@docusaurus/theme-common/internal';
+import Link from '@docusaurus/Link';
+import {translate} from '@docusaurus/Translate';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import HomeBreadcrumbItem from '@theme/DocBreadcrumbs/Items/Home';
+
+import styles from './styles.module.css';
+
+function BreadcrumbsItemLink({
+  children,
+  href,
+  isLast,
+  siteUrl,
+}: {
+  children: ReactNode;
+  href: string | undefined;
+  isLast: boolean;
+  siteUrl: string;
+}): ReactNode {
+  const className = 'breadcrumbs__link';
+  if (isLast) {
+    const itemUrl = href ? `${siteUrl}${href}` : undefined;
+    return (
+      <>
+        {itemUrl && <meta itemProp="item" content={itemUrl} />}
+        <span className={className} itemProp="name">
+          {children}
+        </span>
+      </>
+    );
+  }
+  return href ? (
+    <Link className={className} href={href} itemProp="item">
+      <span itemProp="name">{children}</span>
+    </Link>
+  ) : (
+    <span className={className}>{children}</span>
+  );
+}
+
+function BreadcrumbsItem({
+  children,
+  active,
+  index,
+  addMicrodata,
+}: {
+  children: ReactNode;
+  active?: boolean;
+  index: number;
+  addMicrodata: boolean;
+}): ReactNode {
+  return (
+    <li
+      {...(addMicrodata && {
+        itemScope: true,
+        itemProp: 'itemListElement',
+        itemType: 'https://schema.org/ListItem',
+      })}
+      className={clsx('breadcrumbs__item', {
+        'breadcrumbs__item--active': active,
+      })}>
+      {children}
+      <meta itemProp="position" content={String(index + 1)} />
+    </li>
+  );
+}
+
+export default function DocBreadcrumbs(): ReactNode {
+  const breadcrumbs = useSidebarBreadcrumbs();
+  const homePageRoute = useHomePageRoute();
+  const {siteConfig} = useDocusaurusContext();
+  const siteUrl = siteConfig.url;
+
+  if (!breadcrumbs) {
+    return null;
+  }
+
+  return (
+    <nav
+      className={clsx(
+        ThemeClassNames.docs.docBreadcrumbs,
+        styles.breadcrumbsContainer,
+      )}
+      aria-label={translate({
+        id: 'theme.docs.breadcrumbs.navAriaLabel',
+        message: 'Breadcrumbs',
+        description: 'The ARIA label for the breadcrumbs',
+      })}>
+      <ul
+        className="breadcrumbs"
+        itemScope
+        itemType="https://schema.org/BreadcrumbList">
+        {homePageRoute && <HomeBreadcrumbItem />}
+        {breadcrumbs.map((item, idx) => {
+          const isLast = idx === breadcrumbs.length - 1;
+          const href =
+            item.type === 'category' && item.linkUnlisted
+              ? undefined
+              : item.href;
+          return (
+            <BreadcrumbsItem
+              key={idx}
+              active={isLast}
+              index={idx}
+              addMicrodata={!!href}>
+              <BreadcrumbsItemLink href={href} isLast={isLast} siteUrl={siteUrl}>
+                {item.label}
+              </BreadcrumbsItemLink>
+            </BreadcrumbsItem>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/theme/DocBreadcrumbs/styles.module.css
+++ b/src/theme/DocBreadcrumbs/styles.module.css
@@ -1,0 +1,4 @@
+.breadcrumbsContainer {
+  --ifm-breadcrumb-size-multiplier: 0.8;
+  margin-bottom: 0.8rem;
+}


### PR DESCRIPTION
## Summary

- Swizzles the Docusaurus `DocBreadcrumbs` component to fix a Google Search Console structured data error
- Adds `<meta itemProp="item" content="<absolute-url>">` to the last breadcrumb (current page), which Docusaurus omits by default
- Resolves "Missing field 'item' (in itemListElement)" flagged for `https://docs.fused.io/tutorials/Geospatial%20with%20Fused/h3-tiling/` and any other page with breadcrumbs

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] After deploy, use Google's Rich Results Test on a docs page and confirm BreadcrumbList schema is valid
- [ ] Click "Validate Fix" in Google Search Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)