### PR TITLE
docs: promote Widgets from experimental to GA

### DIFF
--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -35,7 +35,7 @@ Read through all the provided changes and sort them into three buckets:
 ## Step 3 — Apply the writing rules
 
 ### Feature naming conventions
-- JSON-UI / widget builder → always write as **[Experimental] [Widgets](/guide/data-input-outputs/import-connection/widgets)**
+- JSON-UI / widget builder → always write as **[Widgets](/guide/data-input-outputs/import-connection/widgets)**
 - Canvas → [Canvas](/workbench/udf-builder/canvas)
 - H3 analytics → [H3 analytics](/guide/h3-analytics/h3-overview)
 - Shared tokens / API endpoints → [tokens & endpoints](/guide/data-input-outputs/export-api/tokens-endpoints)

--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -35,7 +35,7 @@ Read through all the provided changes and sort them into three buckets:
 ## Step 3 — Apply the writing rules
 
 ### Feature naming conventions
-- JSON-UI / widget builder → always write as **[Widgets](/guide/data-input-outputs/import-connection/widgets)**
+- Widget builder → always write as **[Widgets](/guide/data-input-outputs/import-connection/widgets)**
 - Canvas → [Canvas](/workbench/udf-builder/canvas)
 - H3 analytics → [H3 analytics](/guide/h3-analytics/h3-overview)
 - Shared tokens / API endpoints → [tokens & endpoints](/guide/data-input-outputs/export-api/tokens-endpoints)

--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -1,19 +1,11 @@
 ---
 id: widgets
 title: Widgets
-sidebar_label: Widgets [Experimental] 
+sidebar_label: Widgets
 sidebar_position: 7
 ---
 
-# Widgets [Experimental]
-
-:::info Enable Widgets
-Widgets are an experimental feature and need to be turned on before you can use them:
-
-1. Click your profile and go to **Preferences**.
-2. Open the **Experimental features** tab.
-3. Toggle **Widget nodes** on.
-:::
+# Widgets
 
 Widgets are interactive, declarative UI nodes you can drop onto the Fused canvas. Unlike UDFs that run Python, widgets are defined in JSON — no code required. They can be inputs (sliders, dropdowns, text inputs) that drive parameters across the canvas, or outputs (charts, maps, tables, big numbers) that display live data from any UDF. Every widget is shareable as a standalone URL, embeddable anywhere, and fully accessible to AI for generation and editing.
 

--- a/docs/workbench/preferences.mdx
+++ b/docs/workbench/preferences.mdx
@@ -12,5 +12,5 @@ Open Preferences from the Workbench profile menu (top-right) to configure your s
 The page covers:
 
 - **Environment** — pick your [kernel](/workbench/integrations-secrets) and set default raster/vector transfer formats and timing for running UDFs.
-- **Experimental features** — opt in to in-development features by toggling them on. Some integrations (like the [Slack integration](/guide/data-input-outputs/export-api/slack)) and features (like [Widget nodes](/guide/data-input-outputs/import-connection/widgets)) require enabling a flag here.
+- **Experimental features** — opt in to in-development features by toggling them on. Some integrations (like the [Slack integration](/guide/data-input-outputs/export-api/slack)) require enabling a flag here.
 - **General preferences** — theme and UI toggles, including **Show shared tokens**, which exposes the legacy per-UDF shared tokens (`fsh_***`) UI used in [Tokens & endpoints](/guide/data-input-outputs/export-api/tokens-endpoints).


### PR DESCRIPTION
## Summary

- Removed `[Experimental]` label from the Widgets sidebar and page heading
- Removed the "Enable Widgets" info block that instructed users to toggle the feature flag in Preferences
- Updated `preferences.mdx` to no longer list Widget nodes as requiring an experimental flag
- Updated the changelog command template so future entries no longer mark Widgets as experimental

## Test plan

- [ ] Verify Widgets page renders correctly without the experimental callout
- [ ] Verify Preferences page text is accurate
- [ ] Spot-check sidebar label in the docs site