### PR TITLE
docs: remove experimental feature flag steps for Airtable and Snowflake

### DIFF
--- a/docs/workbench/integrations/airtable.mdx
+++ b/docs/workbench/integrations/airtable.mdx
@@ -14,11 +14,7 @@ Read and write Airtable records from Fused UDFs by connecting to your Airtable a
 
 ## Setup
 
-### 1. Enable the feature flag
-
-In the Fused workbench, open **Settings > Experimental Features** and toggle **Airtable integration** on.
-
-### 2. Connect your Airtable account
+### 1. Connect your Airtable account
 
 1. Open **Settings > Integrations & Secrets**, find the Airtable section, and click **Connect**.
 2. You will be redirected to Airtable to authorize access. During this flow you can grant access to **all bases** or select **specific bases**.

--- a/docs/workbench/integrations/snowflake.mdx
+++ b/docs/workbench/integrations/snowflake.mdx
@@ -77,17 +77,16 @@ Do **not** sign in with an administrator account during the OAuth step. Snowflak
 
 **Step 5 -- Connect in Workbench:**
 
-1. Enable the **Snowflake integration** feature flag in **Preferences > Experimental Features**.
-2. Open **Integration & secrets > Integrations** and click **Connect Snowflake**.
-3. Enter your account identifier (e.g. `ORGNAME-ACCTNAME`), the `OAUTH_CLIENT_ID`, both client secrets, and optionally a role.
+1. Open **Integration & secrets > Integrations** and click **Connect Snowflake**.
+2. Enter your account identifier (e.g. `ORGNAME-ACCTNAME`), the `OAUTH_CLIENT_ID`, both client secrets, and optionally a role.
 
    ![Connect Snowflake modal in Fused Workbench](/img/snowflake_modal_fused.png)
 
-4. A Snowflake sign-in popup will open. Sign in with the **service account** user you created in Step 4 (not an administrator account) to complete the OAuth flow.
+3. A Snowflake sign-in popup will open. Sign in with the **service account** user you created in Step 4 (not an administrator account) to complete the OAuth flow.
 
    ![Snowflake OAuth sign-in screen](/img/snowflake_login_screen.png)
 
-5. Click **Allow** on the OAuth consent screen to grant Fused access to your Snowflake account.
+4. Click **Allow** on the OAuth consent screen to grant Fused access to your Snowflake account.
 
    ![Snowflake OAuth confirmation screen](/img/snowflake_oauth_confirmation.png)
 


### PR DESCRIPTION
## Summary

- Removes the \"Enable the feature flag\" step from Airtable setup (Airtable is now GA)
- Removes the \"Enable the Snowflake integration feature flag in Preferences > Experimental Features\" step from Snowflake setup (Snowflake is now GA)
- Renumbers remaining setup steps in both files
- No cross-links broken — `preferences.mdx` only references Slack as a flag example, not Airtable/Snowflake

## Changes

- `docs/guide/data-input-outputs/import-connection/airtable.mdx`
- `docs/guide/data-input-outputs/import-connection/snowflake.mdx`