### PR TITLE
docs: add new output and utility widgets to available widgets table

### DIFF
--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -369,6 +369,14 @@ When the base URL includes a specific widget path (for example, `/orders_widget`
 | Output | `fused-map` | Full interactive map | Supports multiple layer types, tooltips, legends, basemaps |
 | Output | `widget-builder` | Meta widget | Renders widgets dynamically from JSON |
 | Output | `iframe` | Embedded web page | Pass any URL — a video, GIF, image, or web page |
+| Output | `stacked-bar-chart` | Stacked bar chart via DuckDB SQL | Multiple series stacked, `label` + `value` + `series` columns, driven by SQL query |
+| Output | `stacked-area-chart` | Stacked area chart via DuckDB SQL | Area version of stacked bar, good for time-series proportions, driven by SQL query |
+| Output | `scatter-chart` | Scatter/XY plot via DuckDB SQL | `x` and `y` axis columns, optional color/size encoding, driven by SQL query |
+| Output | `donut-chart` | Donut/pie chart via DuckDB SQL | `label` + `value` columns, shows proportions, driven by SQL query |
+| Output | `heatmap-chart` | Heatmap grid via DuckDB SQL | `x`, `y`, and `value` columns, color intensity encoding, driven by SQL query |
+| Utility | `sql-runner` | Named SQL data source | Shared SQL context for descendant components, avoids duplicating queries |
+| Utility | `div` | Layout container | Groups and wraps child components, supports layout/spacing control |
+| Utility | `ai-chat` | AI chat interface | Connects to a UDF for AI-powered Q&A, streams responses |
 
 {/* <iframe
   src="https://unstable.fused.io/canvas/fc_1IlPjYnRgK5cmhwRlbOnLr?embed=false&outline=false&code=true&bounds=-940%2C922%2C-200%2C1483"


### PR DESCRIPTION
## Summary
- Adds 5 new Output widgets: `stacked-bar-chart`, `stacked-area-chart`, `scatter-chart`, `donut-chart`, `heatmap-chart`
- Adds 3 new Utility widgets: `sql-runner`, `div`, `ai-chat`

## Test plan
- [ ] Verify the Available Widgets table renders correctly on the widgets docs page
- [ ] Check that new rows are consistent in style with existing table entries