### PR TITLE
docs: convert What is Fused? headings to sentence case

### DIFF
--- a/docs/guide/overview.mdx
+++ b/docs/guide/overview.mdx
@@ -22,7 +22,7 @@ We ship an opinionated and tested set of dependencies that covers most modern da
 
 ---
 
-## Scalable Serverless Engine
+## Scalable serverless engine
 
 Python alone isn't enough. Scaling up compute on demand normally means deploying a new Docker container. Fused lets you create **User Defined Functions (UDFs)**: simple, self-contained Python functions that run on our serverless compute infrastructure. All you need is a `@fused.udf` decorator:
 
@@ -51,7 +51,7 @@ To put that in perspective: two thousand 90-second jobs complete in 120 wall-clo
 
 ---
 
-## Expose Everything as an API
+## Expose everything as an API
 
 Every project you build in Fused lives in a **Canvas**: a freeform board where every component is either a UDF running Python, a sticky note, or a widget to explore data.
 
@@ -69,7 +69,7 @@ Every UDF you create can instantly become a parameterized endpoint callable from
 
 ---
 
-## Version Control & Team Collaboration
+## Version control & team collaboration
 
 Since users are doing real work in Fused, version control matters. The Canvas can be collaborated on and connected directly to GitHub to store and version-control your code.
 
@@ -79,7 +79,7 @@ Teams can make edits directly from GitHub and push or pull changes to update das
 
 ---
 
-## Scoped Security & Access Control
+## Scoped security & access control
 
 Every Fused project can be shared and turned into a Fused MCP server, with fine-grained control over who can access what:
 
@@ -90,7 +90,7 @@ You control the scope of each UDF individually.
 
 ---
 
-## Example: RAG Your Docs
+## Example: RAG your docs
 
 We built a bot that answers questions about Fused documentation directly in Slack, all built inside Fused itself.
 
@@ -112,7 +112,7 @@ All on S3, simple Python, smart caching, and parallel processing, no additional 
 
 ---
 
-## Get Started
+## Get started
 
 - ⚡️ [Quickstart Guide](/guide/getting-started/first-udf-basics): Write your first UDF in minutes
 - 💻 [Writing UDFs](/guide/working-with-udfs/writing-udfs): Learn UDF structure and best practices


### PR DESCRIPTION
## Summary
- Converts all `##` section headings in the What is Fused? overview page to sentence case, matching the style used across the rest of the docs
- Proper nouns (Fused, Python, GitHub, API, RAG, MCP) remain capitalized

🤖 Generated with [Claude Code](https://claude.com/claude-code)