### PR TITLE
docs: document @fused.cache shared cache behavior across UDFs

### DIFF
--- a/docs/guide/working-with-udfs/udf-best-practices/caching.mdx
+++ b/docs/guide/working-with-udfs/udf-best-practices/caching.mdx
@@ -137,47 +137,43 @@ for every run of `child_udf`.
 
 ### @fused.cache is shared across UDFs
 
-`@fused.cache` keys the cache on a **hash of the function's source code**, not on which UDF the function belongs to. Two UDFs that define a cached function with identical source code (same name, same body, same comments, same print statements) will share the same cache entry.
+The cache key is a **hash of [function source code + parameters]**. Two UDFs with byte-for-byte identical cached function bodies, called with the same arguments, share the same cache entry.
 
+**UDF 1**
 ```python
-# UDF 1
 @fused.udf
 def udf():
     import pandas as pd
 
     @fused.cache
-    def cached_sleep():
+    def cached_sleep():  # identical source → same cache key
         import time
         time.sleep(5)
-        return
 
-    cached_sleep()
+    cached_sleep()  # populates the cache on first run
     return pd.DataFrame({"hello": ['world']})
+```
 
-# UDF 2
+**UDF 2**
+```python
 @fused.udf
 def udf(name: str = "world"):
     import pandas as pd
 
     @fused.cache
-    def cached_sleep():
+    def cached_sleep():  # identical source → hits UDF 1's cache entry
         import time
         time.sleep(5)
-        return
 
-    cached_sleep()
+    cached_sleep()  # returns instantly if UDF 1 ran first
     return pd.DataFrame({"hello": [name]})
 ```
 
-Because `cached_sleep` is byte-for-byte identical in both UDFs, they share the same cache entry. If UDF 1 runs first, UDF 2 will return the cached result immediately without executing the function body again.
+:::tip
+Any change to function source — a comment, print statement, or different call arguments — produces a different hash and causes a cache miss.
+:::
 
-Note that any modification to the function source, including a comment or a print statement, produces a different hash and results in a cache miss.
-
-**This can be useful:** shared utility functions, such as loading a reference dataset, automatically reuse the same cache across all UDFs that define them identically.
-
-**Watch out for:** if two UDFs have cached functions with the same name but different logic, they will silently return each other's cached output.
-
-To avoid accidental cache sharing, use distinct function names across UDFs:
+To avoid accidental cache sharing, use distinct function names:
 
 ```python
 @fused.cache

--- a/docs/guide/working-with-udfs/udf-best-practices/caching.mdx
+++ b/docs/guide/working-with-udfs/udf-best-practices/caching.mdx
@@ -137,7 +137,7 @@ for every run of `child_udf`.
 
 ### @fused.cache is shared across UDFs
 
-The cache key is a **hash of [function source code + parameters]**. Two UDFs with byte-for-byte identical cached function bodies, called with the same arguments, share the same cache entry.
+If two UDFs define the same cached function — identical source code, called with the same arguments — the second will reuse the cached result from the first instead of recomputing. This is because the cache key is based on function source code and call arguments, not on which UDF the function belongs to. Here's an example:
 
 **UDF 1**
 ```python

--- a/docs/guide/working-with-udfs/udf-best-practices/caching.mdx
+++ b/docs/guide/working-with-udfs/udf-best-practices/caching.mdx
@@ -135,6 +135,60 @@ def child_udf():
 Use this when you want to force-refresh `parent_udf` without disabling caching
 for every run of `child_udf`.
 
+### @fused.cache is shared across UDFs
+
+`@fused.cache` keys the cache on a **hash of the function's source code**, not on which UDF the function belongs to. Two UDFs that define a cached function with identical source code (same name, same body, same comments, same print statements) will share the same cache entry.
+
+```python
+# UDF 1
+@fused.udf
+def udf():
+    import pandas as pd
+
+    @fused.cache
+    def cached_sleep():
+        import time
+        time.sleep(5)
+        return
+
+    cached_sleep()
+    return pd.DataFrame({"hello": ['world']})
+
+# UDF 2
+@fused.udf
+def udf(name: str = "world"):
+    import pandas as pd
+
+    @fused.cache
+    def cached_sleep():
+        import time
+        time.sleep(5)
+        return
+
+    cached_sleep()
+    return pd.DataFrame({"hello": [name]})
+```
+
+Because `cached_sleep` is byte-for-byte identical in both UDFs, they share the same cache entry. If UDF 1 runs first, UDF 2 will return the cached result immediately without executing the function body again.
+
+Note that any modification to the function source, including a comment or a print statement, produces a different hash and results in a cache miss.
+
+**This can be useful:** shared utility functions, such as loading a reference dataset, automatically reuse the same cache across all UDFs that define them identically.
+
+**Watch out for:** if two UDFs have cached functions with the same name but different logic, they will silently return each other's cached output.
+
+To avoid accidental cache sharing, use distinct function names across UDFs:
+
+```python
+@fused.cache
+def cached_sleep_udf1():
+    ...
+
+@fused.cache
+def cached_sleep_udf2():
+    ...
+```
+
 ### Each execution context has its own cache
 
 Workbench and HTTP endpoints maintain **separate caches**, even when running the exact same UDF with the same parameters. Clearing cache in one context does not affect the others.


### PR DESCRIPTION
## Summary

- Documents that `@fused.cache` keys the cache on a hash of the function's source code, not the UDF it belongs to
- Two UDFs with a cached function of identical source (name, body, comments, print statements) will share the same cache entry
- Adds a new gotcha section with code examples and guidance on avoiding accidental cache sharing

## Test plan

- [ ] Verify the new section renders correctly in the docs site
- [ ] Check that code examples are accurate against the described behavior