### PR TITLE
Fix iframe and canvas URL for Overture Maps MCP agent page

### DIFF
--- a/docs/examples/overture-maps-mcp-agent.mdx
+++ b/docs/examples/overture-maps-mcp-agent.mdx
@@ -5,10 +5,10 @@ sidebar_label: Overture Maps MCP Agent
 sidebar_position: 16
 ---
 
-This example shows how to wrap [Overture Maps Foundation](https://overturemaps.org/) open data as MCP tools on a Fused Canvas, so an AI agent can query buildings, places, and more by location or GERS ID without pulling raw geospatial data into the chat context. [Try the chatbot](https://unstable.udf.ai/fc_7OKlCRLA5FeqcwXkB5wvsq/ai_chat.html) or [explore the Canvas](https://unstable.fused.io/canvas/fc_7OKlCRLA5FeqcwXkB5wvsq).
+This example shows how to wrap [Overture Maps Foundation](https://overturemaps.org/) open data as MCP tools on a Fused Canvas, so an AI agent can query buildings, places, and more by location or GERS ID without pulling raw geospatial data into the chat context. [Explore the Canvas](https://unstable.fused.io/canvas/fc_7OKlCRLA5FeqcwXkB5wvsq?bounds=-771%2C-22%2C4547%2C2716).
 
 <iframe
-  src="https://unstable.udf.ai/fc_7OKlCRLA5FeqcwXkB5wvsq/ai_chat.html"
+  src="https://unstable.fused.io/share/fc_7OKlCRLA5FeqcwXkB5wvsq/overture_ai_chat_widget"
   width="100%"
   height="600px"
   style={{border: 'none'}}


### PR DESCRIPTION
## Summary
- Replace `ai_chat.html` iframe with new `overture_ai_chat_widget` share URL
- Remove the "Try the chatbot" link (which pointed to the old `ai_chat` endpoint)
- Update canvas URL to include `?bounds=` query string for a better default view