### PR TITLE
docs: move airbnb, rag, branded-image examples to top of agentic workflows sidebar

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -139,13 +139,13 @@ const sidebars: SidebarsConfig = {
       label: "Agentic Workflows",
       collapsible: false,
       items: [
+        "examples/airbnb-explore-on-the-fly",
+        "examples/rag-overture-docs",
+        "examples/branded-text-to-image",
         "examples/overture-buildings-agents",
         "examples/overture-maps-mcp-agent",
         "examples/google-calendar-meetings",
         "examples/messy-data-agents",
-        "examples/airbnb-explore-on-the-fly",
-        "examples/rag-overture-docs",
-        "examples/branded-text-to-image",
       ],
     },
 


### PR DESCRIPTION
## Summary
- Moves "Explore Airbnb on the fly", "RAG Docs with Fused", and "Branded text to image" to the top of the Agentic Workflows sidebar section
- Remaining items follow in their original order