### PR TITLE
Update canvas link to Chart_Examples

### DIFF
--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -379,7 +379,7 @@ When the base URL includes a specific widget path (for example, `/orders_widget`
 | Utility | `ai-chat` | AI chat interface | Connects to a UDF for AI-powered Q&A, streams responses |
 
 {/* <iframe
-  src="https://unstable.fused.io/canvas/fc_1IlPjYnRgK5cmhwRlbOnLr?embed=false&outline=false&code=true&bounds=-940%2C922%2C-200%2C1483"
+  src="https://unstable.fused.io/canvas/fc_fused/Chart_Examples"
   width="100%"
   height="600px"
   frameBorder="0"

--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -378,13 +378,13 @@ When the base URL includes a specific widget path (for example, `/orders_widget`
 | Utility | `div` | Layout container | Groups and wraps child components, supports layout/spacing control |
 | Utility | `ai-chat` | AI chat interface | Connects to a UDF for AI-powered Q&A, streams responses |
 
-{/* <iframe
+<iframe
   src="https://unstable.fused.io/canvas/fc_fused/Chart_Examples"
   width="100%"
   height="600px"
   frameBorder="0"
   style={{borderRadius: '8px'}}
-></iframe> */}
+></iframe>
 
 ## Multi-Component Widgets
 


### PR DESCRIPTION
Updates the canvas link in widgets.mdx to point to Chart_Examples instead of the previous canvas.