### PR TITLE
docs: add v2.8.0 changelog entry

### DIFF
--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -12,11 +12,19 @@ hide_table_of_contents: true
 
 **Canvas MCP**
 
-The [Canvas](/workbench/udf-builder/canvas) now exposes an MCP (Model Context Protocol) server, letting AI tools like Claude and Cursor connect directly to your canvas — read node outputs, inspect UDF code, and drive canvas actions from any MCP-compatible client. You can also register the MCP server from the CLI with a single command.
+The [Canvas](/workbench/udf-builder/canvas) now exposes an MCP server so AI tools like Claude and Cursor can connect directly to your canvas. Register it from the CLI with a single command.
+
+<img
+  src="https://fused-magic.s3.us-west-2.amazonaws.com/changelog_assets/v2_8_0/v_2_8_0_integration.gif"
+  alt="Anthropic integration in Fused"
+  style={{ maxWidth: "800px", borderRadius: "12px", margin: "24px 0" }}
+/>
+
 
 **Anthropic integration**
 
-You can now add your Anthropic API key under team integrations and call Claude models directly inside UDFs using `fused.api.anthropic_connect()` — no manual credential wiring required.
+Add your Anthropic API key under team integrations to call Claude models inside UDFs via `fused.api.anthropic_connect()`.
+
 
 **Widget UDF data access**
 

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -8,6 +8,39 @@ hide_table_of_contents: true
 
 # Changelog
 
+## v2.8.0 (2026-05-19)
+
+**Canvas MCP**
+
+The [Canvas](/workbench/udf-builder/canvas) now exposes an MCP (Model Context Protocol) server, letting AI tools like Claude and Cursor connect directly to your canvas — read node outputs, inspect UDF code, and drive canvas actions from any MCP-compatible client. You can also register the MCP server from the CLI with a single command.
+
+**Anthropic integration**
+
+You can now add your Anthropic API key under team integrations and call Claude models directly inside UDFs using `fused.api.anthropic_connect()` — no manual credential wiring required.
+
+**Widget UDF data access**
+
+[Widgets](/guide/data-input-outputs/import-connection/widgets) can now reference UDF outputs directly using template syntax — for example `{{ udf_1.col_name[0]?param=100 }}` — so widget content can react to live UDF results without extra plumbing.
+
+**Improvements**
+
+- [Widgets](/guide/data-input-outputs/import-connection/widgets): presets let you start new widgets from common templates instead of from scratch
+- [Widgets](/guide/data-input-outputs/import-connection/widgets): choose which AI model powers the widget builder when generating or editing widget code
+- [Widgets](/guide/data-input-outputs/import-connection/widgets): new form input components — text area, number, datetime, camera, and color picker — available in the JSON UI editor
+- [Widgets](/guide/data-input-outputs/import-connection/widgets): gallery input now supports additional layout modes and display options
+- [Canvas](/workbench/udf-builder/canvas): AI chat widgets can be added directly as canvas nodes
+- [Canvas](/workbench/udf-builder/canvas): auto-save shows a warning when a save encounters a problem
+- [Canvas](/workbench/udf-builder/canvas): folder node descriptions improved — consistent with canvas-level description behavior
+- Integrations modal now has a search bar to quickly find personal and team integrations
+
+**Bug fixes**
+
+- Fixed: toolbar position rendering offset on canvas
+- Fixed: canvas loading indicator style inconsistency
+- Fixed: description panel height inside folder nodes
+- Fixed: canvas selection history not restoring correctly
+- Fixed: UDF name not shown on canvas node when no custom title is set
+
 ## v2.7.1 (2026-05-14)
 
 **Widgets: new components and capabilities**


### PR DESCRIPTION
## Summary

- Adds v2.8.0 changelog entry (2026-05-19)
- Covers Canvas MCP, Anthropic integration, Widget UDF data access, and improvements/bug fixes
- Includes GIF showcase for Anthropic integration

