### PR TITLE
fix: point pydoc-markdown output to python-sdk/api-reference

### DIFF
--- a/pydoc-markdown.yml
+++ b/pydoc-markdown.yml
@@ -18,7 +18,7 @@ processors:
 renderer:
   type: docusaurus
   docs_base_path: docs/
-  relative_output_path: automated
+  relative_output_path: python-sdk/api-reference
   relative_sidebar_path: sidebar.json
   sidebar_top_level_label: "API Reference"
   markdown:


### PR DESCRIPTION
## Summary

- Fixes `relative_output_path` in `pydoc-markdown.yml` from `automated` → `python-sdk/api-reference`
- `docs/automated/` never existed; the live API reference is at `docs/python-sdk/api-reference/`
- Keeps pydoc-markdown config consistent with `utils/generate_reference_docs.py` (the tool actually used by the automated workflow)

## Related

Part of the automated API docs sync setup: fusedlabs/application#7572

Notion: https://www.notion.so/fusedio/Find-better-way-to-sync-application-repo-docstrings-to-API-Reference-in-docs-350899d3b76380c2b569e9334bad250f