### PR TITLE
docs: update Connecting AI to Data with real canvas examples

### DIFF
--- a/docs/examples/overture-maps-mcp-agent.mdx
+++ b/docs/examples/overture-maps-mcp-agent.mdx
@@ -7,6 +7,8 @@ sidebar_position: 16
 
 This example shows how to wrap [Overture Maps Foundation](https://overturemaps.org/) open data as MCP tools on a Fused Canvas, so an AI agent can query buildings, places, and more by location or GERS ID without pulling raw geospatial data into the chat context. [Explore the Canvas](https://unstable.fused.io/canvas/fc_7OKlCRLA5FeqcwXkB5wvsq?bounds=-771%2C-22%2C4547%2C2716).
 
+To connect any canvas to Claude Code via MCP, see [Connecting AI to Data](/guide/data-input-outputs/import-connection/ai-data-connection).
+
 <iframe
   src="https://unstable.fused.io/share/fc_7OKlCRLA5FeqcwXkB5wvsq/overture_ai_chat_widget"
   width="100%"

--- a/docs/guide/data-input-outputs/import-connection/ai-data-connection.mdx
+++ b/docs/guide/data-input-outputs/import-connection/ai-data-connection.mdx
@@ -1,186 +1,130 @@
 ---
 id: ai-data-connection
-title: Connecting the AI to data
-sidebar_label: Connecting AI to data
+title: Connecting AI to Data
+sidebar_label: Connecting AI to Data
 sidebar_position: 6
 ---
 
-# Connecting the AI to data
+# Connecting AI to Data
 
-User Defined Tools let you use UDFs as tools to provide the AI with extra context about your data. This enables the AI to query your databases, search your documents, or interact with any data source you configure.
+Every Fused Canvas can be turned into an MCP server in one click — giving AI coding tools like Claude Code direct access to your UDFs as callable tools. You can also embed an AI chat interface directly on the canvas using the `ai-chat` widget.
 
-## Try it out
+<img
+  src="https://fused-magic.s3.us-west-2.amazonaws.com/changelog_assets/v2_8_0/v_2_8_0_integration.gif"
+  alt="Connecting a Fused Canvas to Claude Code via MCP"
+  style={{ width: "100%", borderRadius: "8px", margin: "24px 0" }}
+/>
 
-See the demo canvas below with all the live demos:
+## Connect your canvas to Claude Code via MCP
 
-<div style={{
-  display: "flex",
-  justifyContent: "center",
-  margin: "32px 0"
-}}>
-  <a
-    href="https://www.fused.io/canvas/fc_2CWlAm2U1N3BeZckZdorH9?bounds=-1853%2C14780%2C2240%2C20062"
-    target="_blank"
-    rel="noopener noreferrer"
-    style={{
-      display: "inline-flex",
-      alignItems: "center",
-      gap: "12px",
-      padding: "18px 40px",
-      fontSize: "1.2rem",
-      fontWeight: "700",
-      color: "#1a1a1a",
-      background: "linear-gradient(135deg, #E5FF44 0%, #f0f0f0 100%)",
-      border: "none",
-      borderRadius: "12px",
-      textDecoration: "none",
-      boxShadow: "0 4px 20px rgba(229, 255, 68, 0.4)",
-      transition: "all 0.2s ease",
-      height: "64px",
-      lineHeight: "64px",
-      verticalAlign: "middle"
-    }}
-    onMouseOver={e => {
-      e.currentTarget.style.transform = "translateY(-3px)";
-      e.currentTarget.style.boxShadow = "0 8px 30px rgba(229, 255, 68, 0.5)";
-    }}
-    onMouseOut={e => {
-      e.currentTarget.style.transform = "translateY(0)";
-      e.currentTarget.style.boxShadow = "0 4px 20px rgba(229, 255, 68, 0.4)";
-    }}
-  >
-    <span style={{ display: "flex", alignItems: "center", height: "100%" }}>Open Template Canvas</span>
-  </a>
-</div>
+### Step 1: Copy the MCP command from your canvas
 
-Or try this one out, asking any questions about Population & Income from Census data:
+Open your canvas in Workbench, click **Share**, then **Copy MCP**. This copies a ready-to-run terminal command. For example, the [connecting_ai_agents_mcp](https://www.fused.io/canvas/fc_fused/connecting_ai_agents_mcp) canvas generates:
 
-> "What is the population of Brooklyn, NY in 2024?"
-
-<div style={{
-  display: "flex",
-  justifyContent: "center",
-  margin: "32px 0"
-}}>
-  <iframe
-    src="https://udf.ai/fsh_F6IZLVnNBbhzbW0YQGgQl.html"
-    style={{
-      width: "100%",
-      maxWidth: "900px",
-      height: "600px",
-      border: "1px solid #e3e3e6",
-      borderRadius: "12px",
-      boxShadow: "0 2px 16px rgba(0,0,0,0.06)"
-    }}
-    allow="clipboard-write"
-    loading="lazy"
-    title="UDF AI Census Population & Income Demo"
-  ></iframe>
-</div>
-
-## Setting up AI profiles
-
-Profiles are a way of "scoping" your AI's data access. You can connect specific data sources, rules, and tools to a profile, allowing you to create different configurations for different use cases.
-
-### Accessing the profile settings
-
-1. Open the AI chat window
-2. Click the profile dropdown menu
-3. Hover over any profile and click the edit icon to configure your tools
-
-![Profile dropdown navigation](/img/ai/ai-user-profile.png)
-
-## User defined tools
-
-![Profile page tools configuration](/img/ai/profile-page-tool.png)
-
-Inside a profile, you can configure what we call "MCP JSON" - a configuration format that tells the AI how to call your UDFs as tools. Despite the name, this isn't actual MCP (Model Context Protocol) JSON, but uses a similar concept to make it easy to understand: it defines how the AI can call your UDFs to fetch data.
-
-### How it works
-
-1. **Create a UDF** that acts as a pure function - it takes some input and returns a response
-2. **Generate the MCP JSON** configuration for your UDF
-3. **Add the configuration** to your AI profile
-
-The input to your UDF can be:
-- A list of columns names to return or aggregate together
-- A plain text query for RAG (Retrieval Augmented Generation) searches
-- Any other structured input that determines the query result
-
-{/* TODO: Add screenshot of MCP JSON configuration in profile */}
-{/* ![MCP JSON configuration](/img/ai-tools/mcp-json-config.png) */}
-
-### Example: RAG search tool
-
-A common use case is creating a RAG search tool that queries your vector database. Here's how it works:
-
-1. Create a UDF that takes a string query parameter
-2. The UDF queries your vector database and returns relevant results
-3. Generate the MCP JSON for this UDF
-4. The AI can now search your data using natural language
-
-```python showLineNumbers
-@fused.udf
-def udf(query: str = "how does fused.cache work?"):
-    """
-    Fused SDK search function for finding methods, types, and functions.
-    Searches through the Fused SDK documentation using vector embeddings
-    to return relevant code examples and function signatures.
-    """
-    TABLE_NAME = "fused_sdk_chunker_demo"
-    TOP_K = 5
-
-    rag = fused.load("https://github.com/fusedio/udfs/tree/5c526cc/community/joey/RAG_Utils_new/")
-
-    print(f"Searching for: {query}")
-    query_embedding = rag.embed_text(query, provider="qwen")
-
-    results = rag.search_vector_table(
-        table_name=TABLE_NAME,
-        query_vec=query_embedding,
-        top_k=TOP_K,
-    )
-
-    display_cols = ['method', 'signature', 'similarity']
-    available_cols = [c for c in display_cols if c in results.columns]
-
-    return results[available_cols + ['content']]
+```bash
+claude mcp add --transport http fused-connecting_ai_agents_mcp \
+  "https://udf.ai/fc_5jBXLhLiXluY9yCtcHbOTV.mcp"
 ```
 
-Note about security of this approach: The `query` string is turned into an embedding before the database runs vector search.
-parameters like **table names** and caps like **TOP_K** stay in the UDF code hardcoded, not as exposed parameters. 
-For SQL, paths, and other tool-UDF hygiene, see [Security best practices for UDFs](/guide/working-with-udfs/udf-best-practices/security).
+The command uses `--transport http` so Claude can authenticate with your canvas immediately.
 
-### Generating MCP JSON
+### Step 2: Run the command in your terminal
 
-To generate the MCP JSON configuration for your UDF, simply ask the AI chat:
+Paste and run the command. Claude Code adds the MCP server to its config and responds with:
 
-> "Generate an MCP JSON for this UDF"
+```
+Added MCP server fused-connecting_ai_agents_mcp
+```
 
-The AI will create a JSON configuration like this:
+### Step 3: Ask Claude about your data
+
+Claude can now discover and call all visible UDFs on your canvas as tools. Using the [connecting_ai_agents_mcp](https://www.fused.io/canvas/fc_fused/connecting_ai_agents_mcp) canvas as an example, try:
+
+> "What UDFs do you have available?"
+> "Call greeting_user_data with name=Alice"
+
+Only UDFs that are **visible** on the canvas are exposed through the MCP endpoint. Hide internal or helper UDFs in Workbench to keep the tool list focused on what agents should call directly.
+
+:::tip Managing which UDFs are exposed
+Use the visibility toggle on each UDF node in Workbench to control what Claude sees. Hidden UDFs still run when called by other UDFs — they just won't appear as MCP tools.
+:::
+
+### Works with any MCP-compatible client
+
+The same MCP URL works with Cursor, VS Code (with MCP extensions), and any other tool that supports the Model Context Protocol — not just Claude Code.
+
+---
+
+## Add an AI chat widget to your canvas
+
+The `ai-chat` widget embeds a persistent chat interface directly on your canvas. It has access to all UDFs connected to the widget node and can answer questions, stream responses, and return structured data — no separate AI tool required. You can try a live example at the [connecting_ai_agents_mcp](https://www.fused.io/canvas/fc_fused/connecting_ai_agents_mcp) canvas.
+
+The canvas exposes a single UDF connected to the chat widget:
+
+```python
+@fused.udf(cache_max_age="0s")
+def udf(name: str = "world"):
+    import pandas as pd
+
+    return pd.DataFrame({
+        "hello": [name, "Alice", "Bob", "Charlie"],
+        "age": [25, 30, 35, 40],
+        "score": [85.5, 92.3, 78.9, 88.1],
+        "active": [True, True, False, True]
+    })
+```
+
+<img
+  src="https://fused-magic.s3.us-west-2.amazonaws.com/docs_assets/ai-connect-data/ai-chat_gif.gif"
+  alt="AI chat widget on a Fused Canvas"
+  style={{ width: "100%", borderRadius: "8px", margin: "24px 0" }}
+/>
+
+:::note Login required
+The `ai-chat` widget requires you to be logged in to [fused.io](https://www.fused.io). Unauthenticated viewers will see a login prompt.
+:::
+
+### How to add it
+
+1. Click the **Widget** icon in the canvas toolbar to add a new widget node
+2. In the widget JSON editor, click **Presets** and select **ai-chat**
+3. Connect the UDF nodes you want the chat to query by drawing edges from them to the widget node
+
+The preset inserts this widget JSON — here's the actual widget from the [connecting_ai_agents_mcp](https://www.fused.io/canvas/fc_fused/connecting_ai_agents_mcp) canvas:
 
 ```json
 {
-    "udf_name": "census_income_fetch",
-    "link": "https://udf.ai/fsh_RSuSMvR2wc3uf2CX3TjIc/run",
-    "description": "This UDF fetches demographic and income data from the US Census API for a specific state and county. It accepts parameters for state_fips (default 13 for Georgia), county_fips (default 121 for a specific county), and year (default 2023). The function returns a pandas DataFrame containing population and median income data along with the geographic name.",
-    "parameters": {
-        "state_fips": "str",
-        "county_fips": "str",
-        "year": "int"
-    }
+  "type": "ai-chat",
+  "props": {
+    "title": "Ask About UDFs",
+    "description": "Ask questions about the UDFs connected to this workspace",
+    "style": "height: 400px; border-radius: 8px;"
+  }
 }
 ```
 
-Paste this configuration into your profile settings to enable the tool.
+All props are optional. You can add a `systemPromptExtra` string to give the AI extra instructions specific to your data:
 
-{/* TODO: Add screenshot showing the generated MCP JSON output */}
-{/* ![Generated MCP JSON](/img/ai-tools/generated-mcp-json.png) */}
+```json
+{
+  "type": "ai-chat",
+  "props": {
+    "title": "Ask About UDFs",
+    "description": "Ask questions about the UDFs connected to this workspace",
+    "style": "height: 400px; border-radius: 8px;",
+    "systemPromptExtra": "Always respond with row-level breakdowns. Format numbers with commas."
+  }
+}
+```
 
-## Best practices
+For full widget documentation including all available props and how to compose widgets, see [Widgets](/guide/data-input-outputs/import-connection/widgets).
 
-- **Read the [secure UDF best practices](/guide/working-with-udfs/udf-best-practices/security)**: This is especially important for UDFs that are used as tools in the AI profile.
-- **Write detailed docstrings**: The AI uses docstrings to decide when and how to call your tool. Be specific about use cases and expected inputs/outputs.
-- **Keep UDFs focused**: Each tool should do one thing well
-- **Use descriptive parameter names**: This helps the AI understand what inputs are expected
-- **Return structured data**: JSON or tabular formats work best for AI consumption
+---
+
+## See also
+
+- [Widgets](/guide/data-input-outputs/import-connection/widgets) — full reference for all widget types including `ai-chat`
+- [Building for Agents](/guide/working-with-udfs/udf-best-practices/agents) — how to design UDFs that work well as MCP tools
+- [Overture Maps MCP Agent](/examples/overture-maps-mcp-agent) — a complete example of a canvas exposed as an MCP server
+- [Tokens & endpoints](/guide/data-input-outputs/export-api/tokens-endpoints) — managing canvas access and session tokens
+- [Write UDFs securely](/guide/working-with-udfs/udf-best-practices/security) — security considerations for agent-facing UDFs

--- a/docs/guide/working-with-udfs/udf-best-practices/agents.mdx
+++ b/docs/guide/working-with-udfs/udf-best-practices/agents.mdx
@@ -368,7 +368,7 @@ def udf(path: str, value_col: str, agg: str = "count", output_col: str = ""):
 
 ### Share via MCP
 
-Click **Share → Open API** in Workbench to generate an MCP-compatible endpoint for your canvas. AI tools (Claude, Cursor, VS Code with MCP extensions) can connect to this endpoint directly and discover your UDFs as callable tools.
+Click **Share → Copy MCP** in Workbench to get a ready-to-run `claude mcp add` command for your canvas. AI tools (Claude, Cursor, VS Code with MCP extensions) can connect to this endpoint directly and discover your UDFs as callable tools. For a step-by-step walkthrough, see [Connecting AI to Data](/guide/data-input-outputs/import-connection/ai-data-connection).
 
 **Only visible UDFs are included.** UDFs that are hidden in Workbench are excluded from the MCP endpoint. Use this to keep helper UDFs, internal utilities, or anything you don't want agents to call directly out of the tool list — they'll still run when called by other UDFs, they just won't be surfaced.
 
@@ -406,8 +406,8 @@ See [Write UDFs securely](/guide/working-with-udfs/udf-best-practices/security) 
 
 ## See also
 
+- [Connecting AI to Data](/guide/data-input-outputs/import-connection/ai-data-connection) — how to connect your canvas to Claude Code via MCP and add an AI chat widget
 - [Widgets](/guide/data-input-outputs/import-connection/widgets) — build charts and maps from UDF output
-- [Connecting AI to Data](/guide/data-input-outputs/import-connection/ai-data-connection) — MCP JSON configs and AI profiles
 - [Write UDFs securely](/guide/working-with-udfs/udf-best-practices/security)
 - [Run UDFs efficiently](/guide/working-with-udfs/udf-best-practices/realtime)
 - [Efficient caching](/guide/working-with-udfs/udf-best-practices/caching)


### PR DESCRIPTION
## Summary

- Replaces all placeholder MCP commands and widget JSON with real content from the live [`connecting_ai_agents_mcp`](https://www.fused.io/canvas/fc_fused/connecting_ai_agents_mcp) canvas
- Shows actual `greeting_user_data` UDF and `ai_chat_widget.json` from the canvas export
- Links to the live canvas in Step 1, Step 3, and the widget section so readers can try it immediately
- Adds the `ai-chat_gif.gif` asset to illustrate the widget in action
- Fixes `agents.mdx` share step: "Open API" → "Copy MCP" with a link to the walkthrough page

## Test plan

- [ ] Check that the MCP command code block renders correctly
- [ ] Verify the GIF loads at `https://fused-magic.s3.us-west-2.amazonaws.com/docs_assets/ai-connect-data/ai-chat_gif.gif`
- [ ] Confirm canvas links resolve to the correct page