### PR TITLE
docs: add Modal, Hugging Face, Daytona, Baseten, and ComfyOrg integration pages

### DIFF
--- a/docs/workbench/integrations-secrets.mdx
+++ b/docs/workbench/integrations-secrets.mdx
@@ -18,6 +18,11 @@ Connect external services to Fused so canvases and UDFs can interact with them. 
 - [Google Cloud Storage](/workbench/integrations/gcs)
 - [Airtable](/workbench/integrations/airtable)
 - [Slack [Experimental]](/workbench/integrations/slack)
+- [Modal](/workbench/integrations/modal)
+- [Hugging Face](/workbench/integrations/huggingface)
+- [Daytona](/workbench/integrations/daytona)
+- [Baseten](/workbench/integrations/baseten)
+- [ComfyOrg](/workbench/integrations/comfy)
 
 ## Secrets
 

--- a/docs/workbench/integrations/baseten.mdx
+++ b/docs/workbench/integrations/baseten.mdx
@@ -1,0 +1,156 @@
+---
+id: baseten
+title: Baseten Integration
+sidebar_label: Baseten
+keywords: [baseten, integration, inference, llm, model serving]
+---
+
+# Baseten Integration
+
+Call models served on [Baseten](https://baseten.co) — both [model APIs](https://docs.baseten.co/development/model-apis) and your own [dedicated deployments](https://docs.baseten.co/development/model/overview) — from Fused UDFs. Your API key is stored securely as a Fused secret, no keys need to be hardcoded.
+
+## Prerequisites
+
+1. A Fused account on a paid plan (execution environment required).
+2. A [Baseten API key](https://docs.baseten.co/organization/api-keys).
+
+## Setup
+
+### Add your API key
+
+Open **Settings > Integrations & Secrets**, find the Baseten section, and paste your API key. It is stored as a Fused secret under the name `BASETEN_API_KEY`.
+
+Inside UDFs, retrieve it with `fused.secrets["BASETEN_API_KEY"]`.
+
+## Quick start
+
+Baseten exposes an OpenAI-compatible inference endpoint at `https://inference.baseten.co/v1`. The easiest way to call it is with the `openai` SDK, which is pre-installed in the Fused runtime.
+
+```python
+@fused.udf()
+def udf(prompt: str = "Summarize what GeoParquet is in one sentence."):
+    import fused
+    from openai import OpenAI
+
+    client = OpenAI(
+        api_key=fused.secrets["BASETEN_API_KEY"],
+        base_url="https://inference.baseten.co/v1",
+    )
+
+    response = client.chat.completions.create(
+        model="deepseek-ai/DeepSeek-V3.1",
+        messages=[{"role": "user", "content": prompt}],
+        max_tokens=256,
+    )
+    return response.choices[0].message.content
+```
+
+## Common operations
+
+### Chat completion
+
+```python
+@fused.udf()
+def udf():
+    import fused
+    from openai import OpenAI
+
+    client = OpenAI(
+        api_key=fused.secrets["BASETEN_API_KEY"],
+        base_url="https://inference.baseten.co/v1",
+    )
+
+    response = client.chat.completions.create(
+        model="moonshotai/Kimi-K2-Instruct",
+        messages=[
+            {"role": "system", "content": "You are a concise geospatial assistant."},
+            {"role": "user", "content": "Which projection should I use for area calculations in California?"},
+        ],
+        max_tokens=512,
+    )
+    return response.choices[0].message.content
+```
+
+### Streaming
+
+```python
+@fused.udf()
+def udf():
+    import fused
+    from openai import OpenAI
+
+    client = OpenAI(
+        api_key=fused.secrets["BASETEN_API_KEY"],
+        base_url="https://inference.baseten.co/v1",
+    )
+
+    stream = client.chat.completions.create(
+        model="deepseek-ai/DeepSeek-V3.1",
+        messages=[{"role": "user", "content": "Write a haiku about S3."}],
+        stream=True,
+    )
+
+    chunks = []
+    for chunk in stream:
+        delta = chunk.choices[0].delta.content or ""
+        chunks.append(delta)
+    return "".join(chunks)
+```
+
+### Batched calls in a DataFrame
+
+```python
+@fused.udf()
+def udf():
+    import fused
+    import pandas as pd
+    from openai import OpenAI
+
+    client = OpenAI(
+        api_key=fused.secrets["BASETEN_API_KEY"],
+        base_url="https://inference.baseten.co/v1",
+    )
+
+    prompts = [
+        "Define remote sensing in one sentence.",
+        "Define spatial join in one sentence.",
+        "Define raster tiling in one sentence.",
+    ]
+
+    rows = []
+    for p in prompts:
+        r = client.chat.completions.create(
+            model="deepseek-ai/DeepSeek-V3.1",
+            messages=[{"role": "user", "content": p}],
+            max_tokens=80,
+        )
+        rows.append({"prompt": p, "response": r.choices[0].message.content})
+    return pd.DataFrame(rows)
+```
+
+### Call a dedicated model deployment
+
+For models you have deployed to your own Baseten workspace, call the model-specific endpoint directly with the API key in the `Authorization` header.
+
+```python
+@fused.udf()
+def udf():
+    import fused
+    import requests
+
+    api_key = fused.secrets["BASETEN_API_KEY"]
+    model_id = "abcd1234"  # your Baseten model ID
+
+    response = requests.post(
+        f"https://model-{model_id}.api.baseten.co/production/predict",
+        headers={"Authorization": f"Api-Key {api_key}"},
+        json={"prompt": "Hello, world!"},
+        timeout=60,
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+## Disconnecting
+
+To revoke the integration, go to **Settings > Integrations & Secrets**, find the Baseten section, and remove your API key. You should also [revoke the key](https://docs.baseten.co/organization/api-keys) in the Baseten dashboard if it is no longer needed.

--- a/docs/workbench/integrations/comfy.mdx
+++ b/docs/workbench/integrations/comfy.mdx
@@ -1,0 +1,158 @@
+---
+id: comfy
+title: ComfyOrg Integration
+sidebar_label: ComfyOrg
+keywords: [comfy, comfyui, comfy cloud, integration, image generation, video generation, diffusion]
+---
+
+# ComfyOrg Integration
+
+Run [ComfyUI](https://www.comfy.org) workflows on [Comfy Cloud](https://cloud.comfy.org) from Fused UDFs — image generation, video generation, and any other node-based diffusion pipeline. Your API key is stored as a Fused secret so workflows are reproducible and shareable without exposing credentials.
+
+## Prerequisites
+
+1. A Fused account on a paid plan (execution environment required).
+2. A [Comfy Cloud API key](https://platform.comfy.org).
+3. A ComfyUI workflow exported as JSON (**Graph → Export (API)** in ComfyUI), uploaded somewhere Fused can read — typically S3.
+
+## Setup
+
+### Add your API key
+
+Open **Settings > Integrations & Secrets**, find the Comfy section, and paste your API key. It is stored as a Fused secret under the name `COMFY_API_KEY`. UDFs read it with `fused.secrets["COMFY_API_KEY"]`.
+
+## Quick start
+
+Comfy Cloud exposes a REST API at `https://cloud.comfy.org`. The pattern is:
+
+1. Load a workflow JSON (typically from S3 via [`fused.api.sign_url`](/python-sdk/api-reference/fused-api#sign_url)).
+2. Patch the input nodes (prompt, seed, image references, etc.).
+3. `POST /api/prompt` to submit the job.
+4. Poll `/api/job/{prompt_id}/status` until it completes.
+5. Download the output files from `/api/view`.
+
+```python
+@fused.udf()
+def udf(prompt: str = "A high-resolution satellite image of a coastline"):
+    import io, time
+    import requests
+    from PIL import Image
+    import numpy as np
+    import fused
+
+    BASE_URL = "https://cloud.comfy.org"
+    headers = {"X-API-Key": fused.secrets["COMFY_API_KEY"]}
+
+    # 1. Load workflow JSON from S3
+    workflow_path = "s3://your-bucket/text_to_image_workflow.json"
+    workflow = requests.get(fused.api.sign_url(workflow_path)).json()
+
+    # 2. Patch input nodes — node IDs are top-level keys in the exported JSON
+    workflow["104:90"]["inputs"]["text"] = prompt
+    workflow["104:92"]["inputs"]["seed"] = 42
+
+    # 3. Submit
+    api_key = fused.secrets["COMFY_API_KEY"]
+    prompt_id = requests.post(
+        f"{BASE_URL}/api/prompt",
+        headers={**headers, "Content-Type": "application/json"},
+        json={"prompt": workflow, "extra_data": {"api_key_comfy_org": api_key}},
+    ).json()["prompt_id"]
+
+    # 4. Poll until complete
+    history = {}
+    for _ in range(120):
+        job = requests.get(f"{BASE_URL}/api/job/{prompt_id}/status", headers=headers).json()
+        if job.get("status") in ("failed", "cancelled", "error"):
+            raise RuntimeError(f"Comfy job failed: {job.get('error_message')}")
+        if job.get("status") in ("success", "completed"):
+            history = requests.get(f"{BASE_URL}/api/history_v2/{prompt_id}", headers=headers).json().get(prompt_id, {})
+            break
+        time.sleep(5)
+
+    # 5. Download the first output image
+    for node_outputs in history.get("outputs", {}).values():
+        for file_info in node_outputs.get("images", []):
+            data = requests.get(
+                f"{BASE_URL}/api/view",
+                headers=headers,
+                params={"filename": file_info["filename"], "type": file_info.get("type", "output")},
+            ).content
+            return np.array(Image.open(io.BytesIO(data)))
+```
+
+:::note Node IDs are workflow-specific
+The keys `"104:90"`, `"104:92"` come from a particular workflow's exported JSON. Open your own exported API JSON and look up the top-level keys for the nodes you want to control — they will be different in every workflow.
+:::
+
+## Patterns
+
+### Cache the expensive job, wrap with a thin UDF
+
+Generation jobs are slow and expensive; you only want to run them once per parameter combination. Split the work in two:
+
+- A [`@fused.cache`](/python-sdk/api-reference/fused-cache) helper that submits the workflow, waits, and uploads results to S3.
+- A thin [`@fused.udf`](/guide/working-with-udfs/writing-udfs) wrapper that calls the helper and returns a signed URL or array.
+
+```python
+import fused
+
+@fused.cache
+def run_comfy_job(workflow_s3_path, prompt, seed, s3_base):
+    # ...submit, poll, download, upload to s3_base...
+    return output_s3_path
+
+@fused.udf(engine="small")
+def udf(prompt: str = "a vineyard at sunset", seed: int = 0):
+    output_s3 = run_comfy_job(
+        "s3://your-bucket/workflow.json",
+        prompt, seed,
+        "s3://your-bucket/outputs/",
+    )
+    return fused.api.sign_url(output_s3)
+```
+
+Use `engine="small"` to run as a [batch job](/guide/working-with-udfs/udf-best-practices/scaling-out) when generation takes longer than the 120-second realtime UDF limit (common for video).
+
+### Upload images as workflow inputs
+
+If your workflow takes images as inputs (e.g. image-to-video, style transfer), upload them with `POST /api/upload/image`:
+
+```python
+def _upload_to_comfy(image_path: str) -> str:
+    import requests
+    from pathlib import Path
+    import fused
+
+    BASE_URL = "https://cloud.comfy.org"
+    headers = {"X-API-Key": fused.secrets["COMFY_API_KEY"]}
+
+    if image_path.startswith("s3://"):
+        img_bytes = requests.get(fused.api.sign_url(image_path)).content
+        fname = image_path.split("/")[-1]
+    else:
+        fname = Path(image_path).name
+        img_bytes = Path(image_path).read_bytes()
+
+    resp = requests.post(
+        f"{BASE_URL}/api/upload/image",
+        headers=headers,
+        files={"image": (fname, img_bytes, "image/png")},
+    )
+    resp.raise_for_status()
+    return resp.json()["name"]
+```
+
+Then reference the returned filename in the workflow:
+
+```python
+workflow["3"]["inputs"]["image"] = _upload_to_comfy("s3://your-bucket/scene.png")
+```
+
+## Full example
+
+See the [Run ComfyUI workflows in Fused](/examples/comfyui-fused-workflows) example for end-to-end **Text to Image** and **Images to Video** pipelines built on the patterns above.
+
+## Disconnecting
+
+To revoke the integration, go to **Settings > Integrations & Secrets**, find the Comfy section, and remove your API key. You should also revoke the key in your [Comfy account](https://platform.comfy.org) if it is no longer needed.

--- a/docs/workbench/integrations/daytona.mdx
+++ b/docs/workbench/integrations/daytona.mdx
@@ -1,0 +1,186 @@
+---
+id: daytona
+title: Daytona Integration
+sidebar_label: Daytona
+keywords: [daytona, integration, sandbox, code execution, dev environment]
+---
+
+# Daytona Integration
+
+Use [Daytona](https://daytona.io) cloud sandboxes to run untrusted code, manage files, and clone repositories from Fused UDFs. Your API key is stored securely as a Fused secret — no keys need to be hardcoded.
+
+## Prerequisites
+
+1. A Fused account on a paid plan (execution environment required).
+2. A [Daytona API key](https://app.daytona.io/dashboard/keys).
+
+## Setup
+
+### Add your API key
+
+Open **Settings > Integrations & Secrets**, find the Daytona section, and enter your API key. It is stored as a Fused secret under the name `DAYTONA_API_KEY`.
+
+### Install the SDK (optional)
+
+The `daytona` package is pre-installed in the Fused runtime. Locally, install it with:
+
+```bash
+pip install daytona
+```
+
+## Quick start
+
+`fused.api.daytona_connect()` returns an authenticated [`Daytona`](https://www.daytona.io/docs/en/python-sdk/sync/daytona/) client, pre-configured with the API key from `fused.secrets["DAYTONA_API_KEY"]`. The full SDK surface is available.
+
+```python
+@fused.udf()
+def udf():
+    import fused
+
+    daytona = fused.api.daytona_connect()
+    sandbox = daytona.create()
+
+    response = sandbox.process.code_run('print("Hello from Daytona!")')
+    daytona.delete(sandbox)
+    return response.result
+```
+
+## API reference
+
+### `fused.api.daytona_connect() -> Daytona`
+
+Return a [`Daytona`](https://www.daytona.io/docs/en/python-sdk/sync/daytona/) client initialized with the API key from `fused.secrets["DAYTONA_API_KEY"]`.
+
+Key methods on the returned client:
+
+- `daytona.create()` — create a new sandbox
+- `daytona.get(sandbox_id)` — retrieve an existing sandbox
+- `daytona.list()` — list all sandboxes
+- `daytona.delete(sandbox)` — delete a sandbox
+
+See the [Daytona Python SDK documentation](https://www.daytona.io/docs/en/python-sdk/sync/daytona/) for the complete reference.
+
+## Common operations
+
+### Create a sandbox and run code
+
+```python
+@fused.udf()
+def udf():
+    import fused
+
+    daytona = fused.api.daytona_connect()
+    sandbox = daytona.create()
+
+    try:
+        response = sandbox.process.code_run('''
+import math
+print(f"Pi to 10 decimals: {math.pi:.10f}")
+''')
+        return response.result
+    finally:
+        daytona.delete(sandbox)
+```
+
+### Stateful code execution
+
+Use `code_interpreter` when you need variables to persist across executions:
+
+```python
+@fused.udf()
+def udf():
+    import fused
+
+    daytona = fused.api.daytona_connect()
+    sandbox = daytona.create()
+
+    try:
+        sandbox.code_interpreter.run_code("data = [1, 2, 3, 4, 5]")
+        result = sandbox.code_interpreter.run_code("print(sum(data))")
+        return result.result  # 15
+    finally:
+        daytona.delete(sandbox)
+```
+
+### Upload and download files
+
+```python
+@fused.udf()
+def udf():
+    import fused
+
+    daytona = fused.api.daytona_connect()
+    sandbox = daytona.create()
+
+    try:
+        sandbox.fs.upload_file("/home/daytona/input.txt", b"Hello, world!")
+        content = sandbox.fs.download_file("/home/daytona/input.txt")
+        return content.decode()
+    finally:
+        daytona.delete(sandbox)
+```
+
+### Clone a Git repository
+
+```python
+@fused.udf()
+def udf():
+    import fused
+
+    daytona = fused.api.daytona_connect()
+    sandbox = daytona.create()
+
+    try:
+        sandbox.git.clone(
+            url="https://github.com/fusedio/udfs",
+            path="/home/daytona/udfs",
+        )
+        listing = sandbox.process.code_run('import os; print(os.listdir("/home/daytona/udfs"))')
+        return listing.result
+    finally:
+        daytona.delete(sandbox)
+```
+
+### Custom sandbox configuration
+
+```python
+@fused.udf()
+def udf():
+    import fused
+    from daytona import CreateSandboxFromSnapshotParams
+
+    daytona = fused.api.daytona_connect()
+    params = CreateSandboxFromSnapshotParams(
+        language="python",
+        env_vars={"DEBUG": "true"},
+        auto_stop_interval=0,
+    )
+    sandbox = daytona.create(params, timeout=40)
+
+    try:
+        response = sandbox.process.code_run('import os; print(os.environ["DEBUG"])')
+        return response.result
+    finally:
+        daytona.delete(sandbox)
+```
+
+### Run user-supplied code from a UDF parameter
+
+```python
+@fused.udf()
+def udf(code: str = "print('hello')"):
+    import fused
+
+    daytona = fused.api.daytona_connect()
+    sandbox = daytona.create()
+
+    try:
+        response = sandbox.process.code_run(code)
+        return {"result": response.result, "exit_code": response.exit_code}
+    finally:
+        daytona.delete(sandbox)
+```
+
+## Disconnecting
+
+To revoke the integration, go to **Settings > Integrations & Secrets**, find the Daytona section, and remove your API key. You should also [revoke the key](https://app.daytona.io/dashboard/keys) in the Daytona dashboard if it is no longer needed.

--- a/docs/workbench/integrations/huggingface.mdx
+++ b/docs/workbench/integrations/huggingface.mdx
@@ -1,0 +1,185 @@
+---
+id: huggingface
+title: Hugging Face Integration
+sidebar_label: Hugging Face
+keywords: [huggingface, hugging face, integration, inference, models, datasets]
+---
+
+# Hugging Face Integration
+
+Use the Hugging Face Hub — models, datasets, repos, and inference endpoints — from Fused UDFs. Your access token is stored securely as a Fused secret; no keys need to be hardcoded.
+
+## Prerequisites
+
+1. A Fused account on a paid plan (execution environment required).
+2. A [Hugging Face access token](https://huggingface.co/settings/tokens) with the scopes you need (read for downloading models/datasets, write for pushing to repos).
+
+## Setup
+
+### Add your access token
+
+Open **Settings > Integrations & Secrets**, find the Hugging Face section, and paste your token. It is stored as a Fused secret under the name `HUGGINGFACE_API_KEY`.
+
+### Install the SDK (optional)
+
+The `huggingface_hub` package is pre-installed in the Fused runtime. Locally, install it with:
+
+```bash
+pip install huggingface-hub
+```
+
+## Quick start
+
+There are two Fused helpers, one for each common use case:
+
+- `fused.api.huggingface_connect()` → `HfApi` — work with repos, models, datasets, files
+- `fused.api.huggingface_inference()` → `InferenceClient` — call hosted models for inference
+
+Both are pre-authenticated with the token from `fused.secrets["HUGGINGFACE_API_KEY"]`.
+
+```python
+@fused.udf()
+def udf():
+    import fused
+
+    # Repo / dataset operations
+    hf = fused.api.huggingface_connect()
+    info = hf.model_info("meta-llama/Llama-3.2-1B-Instruct")
+    print(info.id, info.downloads)
+
+    # Inference
+    client = fused.api.huggingface_inference()
+    reply = client.chat_completion(
+        model="meta-llama/Llama-3.2-1B-Instruct",
+        messages=[{"role": "user", "content": "Hello!"}],
+        max_tokens=64,
+    )
+    print(reply.choices[0].message.content)
+```
+
+## API reference
+
+### `fused.api.huggingface_connect() -> HfApi`
+
+Return an authenticated [`huggingface_hub.HfApi`](https://huggingface.co/docs/huggingface_hub/en/package_reference/hf_api) client. Use it for repos, models, datasets, files, and Spaces.
+
+### `fused.api.huggingface_inference() -> InferenceClient`
+
+Return an authenticated [`huggingface_hub.InferenceClient`](https://huggingface.co/docs/huggingface_hub/en/package_reference/inference_client) for hosted-model inference (chat, embeddings, image generation, ASR, and more).
+
+Both helpers read the token from `fused.secrets["HUGGINGFACE_API_KEY"]`.
+
+## Common operations
+
+### List or inspect models
+
+```python
+@fused.udf()
+def udf():
+    import fused
+    import pandas as pd
+
+    hf = fused.api.huggingface_connect()
+    models = hf.list_models(author="meta-llama", limit=20)
+    return pd.DataFrame([
+        {"id": m.id, "downloads": m.downloads, "likes": m.likes}
+        for m in models
+    ])
+```
+
+### Download a file from a repo
+
+```python
+@fused.udf()
+def udf():
+    import fused
+    from huggingface_hub import hf_hub_download
+
+    fused.api.huggingface_connect()  # configures token
+
+    path = hf_hub_download(
+        repo_id="meta-llama/Llama-3.2-1B-Instruct",
+        filename="config.json",
+    )
+    with open(path) as f:
+        return f.read()
+```
+
+### Load a dataset
+
+```python
+@fused.udf()
+def udf():
+    import fused
+    from datasets import load_dataset
+
+    fused.api.huggingface_connect()  # configures token
+
+    ds = load_dataset("squad", split="validation[:100]")
+    return ds.to_pandas()
+```
+
+### Chat completion (hosted inference)
+
+```python
+@fused.udf()
+def udf(question: str = "What is GeoParquet?"):
+    import fused
+
+    client = fused.api.huggingface_inference()
+    reply = client.chat_completion(
+        model="meta-llama/Llama-3.2-3B-Instruct",
+        messages=[{"role": "user", "content": question}],
+        max_tokens=256,
+    )
+    return reply.choices[0].message.content
+```
+
+### Embeddings
+
+```python
+@fused.udf()
+def udf():
+    import fused
+    import pandas as pd
+
+    client = fused.api.huggingface_inference()
+    texts = ["coastal erosion", "urban heat island", "permafrost thaw"]
+    vectors = [
+        client.feature_extraction(t, model="sentence-transformers/all-MiniLM-L6-v2")
+        for t in texts
+    ]
+    return pd.DataFrame({"text": texts, "embedding": vectors})
+```
+
+### Image generation
+
+```python
+@fused.udf()
+def udf(prompt: str = "an aerial photo of a vineyard at sunset"):
+    import fused
+
+    client = fused.api.huggingface_inference()
+    image = client.text_to_image(prompt, model="black-forest-labs/FLUX.1-schnell")
+    return image  # PIL.Image
+```
+
+### Push to a repo
+
+```python
+@fused.udf()
+def udf():
+    import fused
+
+    hf = fused.api.huggingface_connect()
+    hf.upload_file(
+        path_or_fileobj="results.parquet",
+        path_in_repo="results.parquet",
+        repo_id="my-org/my-dataset",
+        repo_type="dataset",
+    )
+```
+
+## Disconnecting
+
+To revoke the integration, go to **Settings > Integrations & Secrets**, find the Hugging Face section, and remove your token. You should also [revoke the token](https://huggingface.co/settings/tokens) in the Hugging Face dashboard if it is no longer needed.

--- a/docs/workbench/integrations/modal.mdx
+++ b/docs/workbench/integrations/modal.mdx
@@ -1,0 +1,142 @@
+---
+id: modal
+title: Modal Integration
+sidebar_label: Modal
+keywords: [modal, integration, inference, gpu, serverless]
+---
+
+# Modal Integration
+
+Run [Modal](https://modal.com) functions, apps, and serverless GPU workloads from Fused UDFs. Your Modal credentials are stored securely as Fused secrets — no tokens need to be hardcoded.
+
+## Prerequisites
+
+1. A Fused account on a paid plan (execution environment required).
+2. A Modal token. Generate one at [modal.com/settings/tokens](https://modal.com/settings/tokens) or run `modal token new` locally — you will get a **Token ID** (starts with `ak-`) and a **Token Secret** (starts with `as-`).
+
+## Setup
+
+### Add your Modal tokens
+
+Open **Settings > Integrations & Secrets**, find the Modal section, and paste both values:
+
+- `MODAL_TOKEN_ID`
+- `MODAL_TOKEN_SECRET`
+
+Each is stored as a Fused secret under the corresponding name.
+
+### Install the SDK (optional)
+
+The `modal` package is pre-installed in the Fused runtime. If you are working locally, install it with:
+
+```bash
+pip install modal
+```
+
+## Quick start
+
+`fused.api.modal_connect()` returns an authenticated [`modal.Client`](https://modal.com/docs/reference/modal.Client), pre-configured with the credentials stored in `fused.secrets`. From there you can look up deployed Modal apps and functions and invoke them.
+
+```python
+@fused.udf()
+def udf():
+    import fused
+    import modal
+
+    # Authenticate using the stored Modal token
+    fused.api.modal_connect()
+
+    # Look up a deployed function and call it
+    embed = modal.Function.from_name("my-app", "embed_text")
+    return embed.remote("Hello from Fused!")
+```
+
+## API reference
+
+### `fused.api.modal_connect() -> modal.Client`
+
+Return a [`modal.Client`](https://modal.com/docs/reference/modal.Client) initialized from `fused.secrets["MODAL_TOKEN_ID"]` and `fused.secrets["MODAL_TOKEN_SECRET"]`.
+
+```python
+import fused
+client = fused.api.modal_connect()
+```
+
+Calling `modal_connect()` configures the Modal SDK for the current process — subsequent calls to `modal.Function.from_name(...).remote(...)`, `modal.Cls.from_name(...)`, etc. authenticate automatically.
+
+See the [Modal Python SDK reference](https://modal.com/docs/reference) for the full API surface.
+
+## Common operations
+
+### Invoke a deployed function
+
+```python
+@fused.udf()
+def udf(prompt: str = "A high-resolution satellite image of a coastline"):
+    import fused
+    import modal
+
+    fused.api.modal_connect()
+
+    generate = modal.Function.from_name("image-gen", "generate")
+    image_bytes = generate.remote(prompt)
+    return image_bytes
+```
+
+### Map over inputs in parallel
+
+Use `.map()` to fan out work across Modal's serverless GPUs.
+
+```python
+@fused.udf()
+def udf():
+    import fused
+    import modal
+    import pandas as pd
+
+    fused.api.modal_connect()
+
+    embed = modal.Function.from_name("embeddings", "embed")
+    texts = ["hello", "world", "fused", "modal"]
+    vectors = list(embed.map(texts))
+
+    return pd.DataFrame({"text": texts, "embedding": vectors})
+```
+
+### Call a class-based service
+
+```python
+@fused.udf()
+def udf():
+    import fused
+    import modal
+
+    fused.api.modal_connect()
+
+    Model = modal.Cls.from_name("llm-app", "Llama")
+    model = Model()
+    return model.complete.remote("Explain GeoParquet in one paragraph.")
+```
+
+### Asynchronous invocation
+
+For long-running jobs, spawn the call and poll for the result instead of blocking the UDF.
+
+```python
+@fused.udf()
+def udf():
+    import fused
+    import modal
+
+    fused.api.modal_connect()
+
+    train = modal.Function.from_name("trainer", "train_model")
+    call = train.spawn(epochs=10)
+    return {"call_id": call.object_id}
+```
+
+You can then retrieve the result in a follow-up UDF with `modal.FunctionCall.from_id(call_id).get()`.
+
+## Disconnecting
+
+To revoke the integration, go to **Settings > Integrations & Secrets**, find the Modal section, and remove your tokens. You should also [revoke the token](https://modal.com/settings/tokens) in the Modal dashboard if it is no longer needed.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -306,6 +306,11 @@ const sidebars: SidebarsConfig = {
         { type: "doc", id: "workbench/integrations/slack", label: "Slack [Experimental]" },
         { type: "doc", id: "workbench/integrations/notion", label: "Notion" },
         { type: "doc", id: "workbench/integrations/gdrive", label: "Google Drive" },
+        { type: "doc", id: "workbench/integrations/modal", label: "Modal" },
+        { type: "doc", id: "workbench/integrations/huggingface", label: "Hugging Face" },
+        { type: "doc", id: "workbench/integrations/daytona", label: "Daytona" },
+        { type: "doc", id: "workbench/integrations/baseten", label: "Baseten" },
+        { type: "doc", id: "workbench/integrations/comfy", label: "ComfyOrg" },
       ],
     },
 


### PR DESCRIPTION
## Summary
- Adds five new integration pages under `docs/workbench/integrations/`: Modal, Hugging Face, Daytona, Baseten, and ComfyOrg.
- Modal, Hugging Face, and Daytona docs are built around their `fused.api.*_connect()` helpers; Baseten and ComfyOrg use the secret-based pattern (`fused.secrets["..."]`) against their REST / OpenAI-compatible endpoints.
- Wires each new page into the **Integrations** sidebar (`sidebars.ts`) and the `integrations-secrets` index.

## Test plan
- [ ] `npm run start` — dev server compiles cleanly (verified locally: client compiled in 7.54s, no broken-link errors).
- [ ] Visit each new page in the sidebar and confirm the **Integrations** category lists all five:
  - `/workbench/integrations/modal`
  - `/workbench/integrations/huggingface`
  - `/workbench/integrations/daytona`
  - `/workbench/integrations/baseten`
  - `/workbench/integrations/comfy`
- [ ] Confirm the new links also appear on `/workbench/integrations-secrets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)