### PR TITLE
docs: generalize Connecting AI to Data page

### DIFF
--- a/docs/guide/data-input-outputs/import-connection/ai-data-connection.mdx
+++ b/docs/guide/data-input-outputs/import-connection/ai-data-connection.mdx
@@ -19,29 +19,37 @@ Every Fused Canvas can be turned into an MCP server in one click — giving AI c
 
 ### Step 1: Copy the MCP command from your canvas
 
-Open your canvas in Workbench, click **Share**, then **Copy MCP**. This copies a ready-to-run terminal command. For example, the [connecting_ai_agents_mcp](https://www.fused.io/canvas/fc_fused/connecting_ai_agents_mcp) canvas generates:
+Open your canvas in Workbench, click **Share**, then **Copy MCP**. This copies a ready-to-run terminal command:
 
+```bash
+claude mcp add --transport http fused-your-canvas-name \
+  "https://udf.ai/fc_YOUR_CANVAS_TOKEN.mcp"
+```
+
+The command uses `--transport http` so Claude can authenticate with your canvas immediately.
+
+:::tip Try a live example
+The [connecting_ai_agents_mcp](https://www.fused.io/canvas/fc_fused/connecting_ai_agents_mcp) canvas is already set up as a public example — run the command below to connect it and follow the steps:
 ```bash
 claude mcp add --transport http fused-connecting_ai_agents_mcp \
   "https://udf.ai/fc_5jBXLhLiXluY9yCtcHbOTV.mcp"
 ```
-
-The command uses `--transport http` so Claude can authenticate with your canvas immediately.
+:::
 
 ### Step 2: Run the command in your terminal
 
 Paste and run the command. Claude Code adds the MCP server to its config and responds with:
 
 ```
-Added MCP server fused-connecting_ai_agents_mcp
+Added MCP server fused-your-canvas-name
 ```
 
 ### Step 3: Ask Claude about your data
 
-Claude can now discover and call all visible UDFs on your canvas as tools. Using the [connecting_ai_agents_mcp](https://www.fused.io/canvas/fc_fused/connecting_ai_agents_mcp) canvas as an example, try:
+Claude can now discover and call all visible UDFs on your canvas as tools. Try:
 
 > "What UDFs do you have available?"
-> "Call greeting_user_data with name=Alice"
+> "Run [your-udf-name] with [param]=value"
 
 Only UDFs that are **visible** on the canvas are exposed through the MCP endpoint. Hide internal or helper UDFs in Workbench to keep the tool list focused on what agents should call directly.
 
@@ -57,22 +65,11 @@ The same MCP URL works with Cursor, VS Code (with MCP extensions), and any other
 
 ## Add an AI chat widget to your canvas
 
-The `ai-chat` widget embeds a persistent chat interface directly on your canvas. It has access to all UDFs connected to the widget node and can answer questions, stream responses, and return structured data — no separate AI tool required. You can try a live example at the [connecting_ai_agents_mcp](https://www.fused.io/canvas/fc_fused/connecting_ai_agents_mcp) canvas.
+The `ai-chat` widget embeds a persistent chat interface directly on your canvas. It has access to all UDFs connected to the widget node and can answer questions, stream responses, and return structured data — no separate AI tool required.
 
-The canvas exposes a single UDF connected to the chat widget:
-
-```python
-@fused.udf(cache_max_age="0s")
-def udf(name: str = "world"):
-    import pandas as pd
-
-    return pd.DataFrame({
-        "hello": [name, "Alice", "Bob", "Charlie"],
-        "age": [25, 30, 35, 40],
-        "score": [85.5, 92.3, 78.9, 88.1],
-        "active": [True, True, False, True]
-    })
-```
+:::tip Try a live example
+Open the [connecting_ai_agents_mcp](https://www.fused.io/canvas/fc_fused/connecting_ai_agents_mcp) canvas to see the `ai-chat` widget connected to a live UDF.
+:::
 
 <img
   src="https://fused-magic.s3.us-west-2.amazonaws.com/docs_assets/ai-connect-data/ai-chat_gif.gif"
@@ -90,7 +87,7 @@ The `ai-chat` widget requires you to be logged in to [fused.io](https://www.fuse
 2. In the widget JSON editor, click **Presets** and select **ai-chat**
 3. Connect the UDF nodes you want the chat to query by drawing edges from them to the widget node
 
-The preset inserts this widget JSON — here's the actual widget from the [connecting_ai_agents_mcp](https://www.fused.io/canvas/fc_fused/connecting_ai_agents_mcp) canvas:
+The preset inserts this widget JSON:
 
 ```json
 {

--- a/docs/workbench/integrations/comfy.mdx
+++ b/docs/workbench/integrations/comfy.mdx
@@ -25,7 +25,7 @@ Open **Settings > Integrations & Secrets**, find the Comfy section, and paste yo
 
 Comfy Cloud exposes a REST API at `https://cloud.comfy.org`. The pattern is:
 
-1. Load a workflow JSON (typically from S3 via [`fused.api.sign_url`](/python-sdk/api-reference/fused-api#sign_url)).
+1. Load a workflow JSON (typically from S3 via [`fused.api.sign_url`](/python-sdk/api-reference/api#sign_url)).
 2. Patch the input nodes (prompt, seed, image references, etc.).
 3. `POST /api/prompt` to submit the job.
 4. Poll `/api/job/{prompt_id}/status` until it completes.


### PR DESCRIPTION
## Summary

- Replace specific canvas token and name in MCP command with generic placeholders (`fc_YOUR_CANVAS_TOKEN`, `fused-your-canvas-name`)
- Move live canvas link out of inline prose and into `:::tip Try a live example` callouts (one per section)
- Generic Step 2 success message and Step 3 example prompts
- Remove specific `greeting_user_data` UDF code block from the widget section — replaced by a tip callout pointing to the live canvas
- Widget JSON header simplified to "The preset inserts this widget JSON:"

The live `connecting_ai_agents_mcp` canvas link is preserved but scoped to callouts, so the main explanation reads generically for any canvas.