### PR TITLE
[NEEDS DEPLOY] [Docs] Quickstart: Using AI should mention building with Claude Code 

### DIFF
--- a/docs/guide/getting-started/using-ai.mdx
+++ b/docs/guide/getting-started/using-ai.mdx
@@ -1,54 +1,22 @@
 ---
-id: using-ai
 title: Using AI
 sidebar_label: Using AI
-sidebar_position: 4
 ---
 
-# Using AI
+# Using AI with Fused
 
-AI is built into Workbench to help you write, edit, and debug UDFs. There are 2 main ways to use AI in Fused:
+Fused supports multiple ways to use AI to help you write and iterate on UDFs.
 
-- [**AI Chat**](#ai-chat) for large changes
-- [**Inline Edit**](#inline-edit) for small quick edits
+## Claude Code & AI Coding Tools (Recommended)
 
-For more details, tips, and video tutorials, see the [AI Chat](/workbench/ai-chat/) reference.
+For the best AI-assisted development experience, we recommend using AI coding tools like **Claude Code** directly through the CLI with Fused SKILLs. This approach gives you a powerful, context-aware coding assistant that understands your UDFs and can help you build, debug, and iterate faster.
 
-## AI Chat
+➡️ **[Get started with AI coding tools (Claude Code, Cursor, and more)](/guide/working-with-udfs/udf-best-practices/ai-coding-tools)**
 
-Open AI Chat to make large changes to your UDF or start from scratch. AI Chat can now operate on all UDFs on the Canvas, allowing you to make changes across multiple UDFs at once, not just the currently selected one.
+This is the recommended path for most development workflows, especially when working on complex UDFs or larger projects.
 
-![AI Chat is associated with the currently selected UDF, not the whole canvas.](/img/quickstart/ai_tab_associated_to_udf.png)
+## AI Chat in Workbench
 
-**Good for:**
-- Rewriting or restructuring entire UDFs (for example, joining datasets with complex queries)
-- Customizing templates (like [standalone maps](/examples/standalone-html-maps) or [charts](/examples/creating-charts))
-- Getting feedback on your code & asking questions about your data
+Fused Workbench also includes a built-in AI Chat assistant. This is still available and works well for quick, smaller tasks — such as asking a quick question about a UDF or getting a short snippet.
 
-## Inline Edit
-
-Use inline edit for quick, targeted changes to specific code sections.
-
-![inline edit](/img/quickstart/inline_edit.png)
-
-**Good for:**
-- Small edits when you know exactly what needs to change (filtering, simple joins, etc.)
-- When you know exactly what needs to change, but don't want to rewrite the entire UDF
-
-## Handling Changes
-
-AI changes are shown as a green/red diff. Changes are applied by default, but you control what to accept or reject.
-
-![inline edit](/img/quickstart/inline_edit_change.png)
-
-## Error Summaries
-
-When a UDF errors, Fused provides an AI-generated summary explaining the issue.
-
-For [**realtime UDFs**](/guide/working-with-udfs/udf-best-practices/realtime), you also get two fix options:
-- **Deep Fix** — Opens AI Chat for larger changes
-- **Quick Fix** — Inline edit on the lines around the error
-
-For [**dedicated jobs**](/guide/working-with-udfs/udf-best-practices/scaling-out#dedicated-instances), only the error summary is shown.
-
-{/* TODO: Add screenshot of error summary */}
+For more involved development, we recommend the CLI-based approach with Claude Code or other AI coding tools described above.

--- a/docs/guide/getting-started/using-ai.mdx
+++ b/docs/guide/getting-started/using-ai.mdx
@@ -1,22 +1,33 @@
 ---
 title: Using AI
-sidebar_label: Using AI
+description: Use AI coding tools to build with Fused
 ---
 
-# Using AI with Fused
+# Using AI
 
-Fused supports multiple ways to use AI to help you write and iterate on UDFs.
+Fused supports multiple ways to leverage AI when building and working with UDFs.
 
 ## Claude Code & AI Coding Tools (Recommended)
 
-For the best AI-assisted development experience, we recommend using AI coding tools like **Claude Code** directly through the CLI with Fused SKILLs. This approach gives you a powerful, context-aware coding assistant that understands your UDFs and can help you build, debug, and iterate faster.
+The recommended approach for building with AI is to use AI coding tools like **Claude Code** directly through the CLI with Fused SKILLs. This gives you a powerful, full-featured development experience where AI can read, write, and iterate on your UDFs locally.
 
-➡️ **[Get started with AI coding tools (Claude Code, Cursor, and more)](/guide/working-with-udfs/udf-best-practices/ai-coding-tools)**
+See the full guide: [AI Coding Tools (Claude Code & others)](/guide/working-with-udfs/udf-best-practices/ai-coding-tools)
 
-This is the recommended path for most development workflows, especially when working on complex UDFs or larger projects.
+This approach is recommended for:
+- Building and iterating on UDFs
+- Complex multi-file or multi-step tasks
+- Full project context and code generation
+- Using Claude Code via the CLI with Fused SKILLs
 
 ## AI Chat in Workbench
 
-Fused Workbench also includes a built-in AI Chat assistant. This is still available and works well for quick, smaller tasks — such as asking a quick question about a UDF or getting a short snippet.
+Fused Workbench also includes a built-in AI Chat interface. This is still available and works well for smaller, quick tasks directly in the browser.
 
-For more involved development, we recommend the CLI-based approach with Claude Code or other AI coding tools described above.
+AI Chat is recommended for:
+- Quick questions about a UDF
+- Small edits or fixes
+- Exploring Fused capabilities inline
+
+:::tip
+For most development workflows, we recommend using [AI coding tools like Claude Code](/guide/working-with-udfs/udf-best-practices/ai-coding-tools) through the CLI for the best experience.
+:::


### PR DESCRIPTION
Automated fix for: https://www.notion.so/fusedio/Docs-Quickstart-Using-AI-should-mention-building-with-Claude-Code-367899d3b76380ea8640c0fa0d93ffc1?source=copy_link

We’re moving away from using the AI Chat directly in Fused Workbench directly
Current Overview page: https://docs.fused.io/guide/getting-started/using-ai should mention Claude Code implementation:
Link out to this page: https://docs.fused.io/guide/working-with-udfs/udf-best-practices/ai-coding-tools to directly work with coding tools like Claude Code through the CLI + SKILLs
AI Chat is still available but recommended for smaller approaches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy and structure changes with no application or API impact.
> 
> **Overview**
> The **Using AI** getting-started page is reframed so **Claude Code and other CLI AI coding tools with Fused SKILLs** are the primary, recommended path, with a link to the [AI coding tools](/guide/working-with-udfs/udf-best-practices/ai-coding-tools) guide.
> 
> **Workbench AI Chat** is repositioned as a secondary option for quick, in-browser tasks (small edits and questions). Content for **inline edit**, diff accept/reject, and **error-summary / Deep Fix / Quick Fix** flows is removed, along with related screenshots and frontmatter (`sidebar_label`, `sidebar_position`).
> 
> A short **description** is added to the page frontmatter and a tip block steers most workflows toward the CLI + SKILLs approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a8f6a5b8dc6e3d90c459272a1b7d5faef97e463. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->