### PR TITLE
docs: remove 'experimental' label from Slack integration

### DIFF
--- a/docs/workbench/integrations-secrets.mdx
+++ b/docs/workbench/integrations-secrets.mdx
@@ -17,7 +17,7 @@ Connect external services to Fused so canvases and UDFs can interact with them. 
 - [Amazon S3](/workbench/integrations/s3)
 - [Google Cloud Storage](/workbench/integrations/gcs)
 - [Airtable](/workbench/integrations/airtable)
-- [Slack [Experimental]](/workbench/integrations/slack)
+- [Slack](/workbench/integrations/slack)
 - [Modal](/workbench/integrations/modal)
 - [Hugging Face](/workbench/integrations/huggingface)
 - [Daytona](/workbench/integrations/daytona)

--- a/docs/workbench/integrations/slack.mdx
+++ b/docs/workbench/integrations/slack.mdx
@@ -1,11 +1,11 @@
 ---
 id: slack
 title: Slack
-sidebar_label: Slack [Experimental]
+sidebar_label: Slack
 sidebar_position: 6
 ---
 
-# Slack [Experimental]
+# Slack
 
 Let anyone in your team talk to your Canvas with a Slack Bot!
 
@@ -26,7 +26,7 @@ Let anyone in your team talk to your Canvas with a Slack Bot!
 </video>
 
 :::tip Enable Slack integration
-This is an experimental feature. Enable it in **Preferences** by toggling on the Slack integration.
+Enable it in **Preferences** by toggling on the Slack integration.
 :::
 
 Check your Fused home page — the **Integrations** panel shows whether Slack is connected for your team.

--- a/docs/workbench/preferences.mdx
+++ b/docs/workbench/preferences.mdx
@@ -12,5 +12,5 @@ Open Preferences from the Workbench profile menu (top-right) to configure your s
 The page covers:
 
 - **Environment** — pick your [kernel](/workbench/integrations-secrets) and set default raster/vector transfer formats and timing for running UDFs.
-- **Experimental features** — opt in to in-development features by toggling them on. Some integrations (like the [Slack integration](/workbench/integrations/slack)) require enabling a flag here.
+- **Experimental features** — opt in to in-development features by toggling them on.
 - **General preferences** — theme and UI toggles, including **Show shared tokens**, which exposes the legacy per-UDF shared tokens (`fsh_***`) UI used in [Tokens & endpoints](/guide/data-input-outputs/export-api/tokens-endpoints).


### PR DESCRIPTION
## Summary

- Removes `[Experimental]` from the Slack page title, sidebar label, and tip callout in `slack.mdx`
- Removes `[Experimental]` from the Slack link in `integrations-secrets.mdx`
- Removes the Slack example from the Experimental features bullet in `preferences.mdx`

Fixes ITEM-11542.

## Test plan
- [ ] Verify sidebar shows "Slack" (not "Slack [Experimental]")
- [ ] Verify `/workbench/integrations/slack` page title is "Slack"
- [ ] Verify the tip callout no longer says "experimental feature"
- [ ] Verify the integrations list link text is just "Slack"

🤖 Generated with [Claude Code](https://claude.com/claude-code)