### PR TITLE
fix: add missing functions to generate_reference_docs.py allowlists

### DIFF
--- a/utils/generate_reference_docs.py
+++ b/utils/generate_reference_docs.py
@@ -171,7 +171,12 @@ with open(ROOT / "docs" / "python-sdk" / "top-level-functions.mdx", "w") as f:
 ## `fused.api` page
 
 api_listing = [
+    # Auth
     "whoami",
+    "access_token",
+    "auth_scheme",
+    "logout",
+    # File operations
     "delete",
     "list",
     "get",
@@ -179,7 +184,11 @@ api_listing = [
     "upload",
     "sign_url",
     "sign_url_prefix",
+    "resolve",
+    # UDFs / apps
     "get_udfs",
+    "get_apps",
+    # Jobs
     "job_get_logs",
     "job_print_logs",
     "job_tail_logs",
@@ -187,6 +196,19 @@ api_listing = [
     "job_cancel",
     "job_get_exec_time",
     "job_wait_for_job",
+    "job_get_results",
+    "job_wait_for_results",
+    # Scheduling
+    "schedule_udf",
+    "schedule_list",
+    # Utilities
+    "session_token",
+    "team_info",
+    "enable_gcs",
+    "log",
+    # Snowflake
+    "snowflake_connect",
+    "snowflake_query",
     # Note: Functions that no longer exist will be automatically skipped with a warning
 ]
 
@@ -276,6 +298,41 @@ for meth in methods:
 **Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.{meth}()`
 """
     result += docstring + "\n" + usage_note + "\n---\n\n"
+
+# fused.api.FusedSnowflakeConnection class
+
+snowflake_methods = [
+    "connect",
+    "query",
+    "execute",
+    "list_databases",
+    "list_schemas",
+    "list_tables",
+    "list_stages",
+    "list_stage_files",
+    "read_stage",
+    "write",
+]
+
+if "FusedSnowflakeConnection" in mod_api.members:
+    snowflake_note = """\
+## Snowflake
+
+## FusedSnowflakeConnection
+
+"""
+    config_sf = dict(default_config)
+    config_sf["filters"] = ["__init__"]
+    config_sf["summary"] = False
+    result += snowflake_note + render_object_docs(mod_api["FusedSnowflakeConnection"], config_sf) + "\n---\n\n"
+
+    config_sf["heading_level"] = default_config["heading_level"] + 1
+    config_sf["show_root_full_path"] = False
+    for meth in snowflake_methods:
+        if meth not in mod_api["FusedSnowflakeConnection"].members:
+            print(f"Warning: {meth} not found in FusedSnowflakeConnection class, skipping")
+            continue
+        result += render_object_docs(mod_api["FusedSnowflakeConnection"][meth], config_sf) + "\n---\n\n"
 
 with open(ROOT / "docs" / "python-sdk" / "api-reference" / "api.mdx", "w") as f:
     f.write(result)
@@ -411,6 +468,10 @@ with open(ROOT / "docs" / "python-sdk" / "api-reference" / "udf.mdx", "w") as f:
 
 api_listing = [
     "run_ingest_raster_to_h3",
+    "persist_hex_table_metadata",
+    "read_hex_table",
+    "read_hex_table_slow",
+    "read_hex_table_with_persisted_metadata",
 ]
 
 result = """\


### PR DESCRIPTION
## Summary

- Expands `api_listing` in `utils/generate_reference_docs.py` to include all exported `fused.api` functions that were missing from auto-generated docs: `access_token`, `auth_scheme`, `logout`, `get_apps`, `resolve`, `job_get_results`, `job_wait_for_results`, `log`, `schedule_udf`, `schedule_list`, `session_token`, `team_info`, `enable_gcs`, `snowflake_connect`, `snowflake_query`
- Adds `FusedSnowflakeConnection` class rendering with all its methods (`connect`, `query`, `execute`, `list_databases`, `list_schemas`, `list_tables`, `list_stages`, `list_stage_files`, `read_stage`, `write`)
- Expands `fused.h3` listing to include `persist_hex_table_metadata`, `read_hex_table`, `read_hex_table_slow`, `read_hex_table_with_persisted_metadata`

All added functions were confirmed to exist in fused-py and be exported — they were simply missing from the script's explicit allowlists.

## Related

Part of automated API docs sync: fusedlabs/application#7572

Notion: https://www.notion.so/fusedio/Find-better-way-to-sync-application-repo-docstrings-to-API-Reference-in-docs-350899d3b76380c2b569e9334bad250f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates the doc-generation allowlist and a new Snowflake section in a utility script; runtime SDK behavior is unchanged.
> 
> **Overview**
> Expands the **allowlists** in `utils/generate_reference_docs.py` so regenerated Python SDK reference pages include APIs that already exist in `fused` but were omitted from the doc script.
> 
> For **`fused.api`**, the module-level listing now covers auth, apps, job results/wait helpers, scheduling, session/team utilities, GCS, logging, and top-level Snowflake helpers, with comments grouping those entries. A new block also emits **`FusedSnowflakeConnection`** (class doc plus methods like `query`, `execute`, stage listing, `read_stage`, and `write`), skipping any symbol not present at generation time.
> 
> For **`fused.h3`**, the listing adds hex-table metadata and read helpers (`persist_hex_table_metadata`, `read_hex_table`, and related variants) alongside the existing ingest entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61b28c78caa73e5ba35501399a84291c01c00cf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->