### PR TITLE
docs: move service accounts from Preferences to Integrations & Secrets

### DIFF
--- a/docs/guide/data-input-outputs/export-api/securing-shared-tokens.mdx
+++ b/docs/guide/data-input-outputs/export-api/securing-shared-tokens.mdx
@@ -55,12 +55,11 @@ This diagram shows the authentication flow for a team-only shared token with a s
 
 ## Creating a Fused Service Account {#fused-service-accounts}
 
-A Fused Service Account can be used to generate a session token. You can generate a service account in the Fused Workbench under Preferences.
+A Fused Service Account can be used to generate a session token. You can create one from the [Integrations & Secrets](/workbench/integrations-secrets#service-accounts) page in the Fused Workbench.
 
-1. Open the Preferences page in the Fused Workbench.
-2. Enable Service Accounts under Experimental Features.
-3. In the Service Accounts section, click the "Create Service Account" button.
-4. Give the service account a name and click "Create".
+1. Open **Integrations & Secrets** from the Workbench sidebar. If you're already inside a canvas, use **Quick Actions** (`Ctrl+K`) and search for "Integrations & secrets".
+2. Under **Service accounts**, click **+ Create service account**.
+3. Give the service account a name and click **Create**.
 
 :::important
 Your service account token will be shown only once, so make sure to copy it to a secure location. Never share your service account token publicly or commit it to version control.

--- a/docs/guide/data-input-outputs/export-api/securing-shared-tokens.mdx
+++ b/docs/guide/data-input-outputs/export-api/securing-shared-tokens.mdx
@@ -55,7 +55,7 @@ This diagram shows the authentication flow for a team-only shared token with a s
 
 ## Creating a Fused Service Account {#fused-service-accounts}
 
-A Fused Service Account can be used to generate a session token. You can create one from the [Integrations & Secrets](/workbench/integrations-secrets#service-accounts) page in the Fused Workbench.
+A Fused Service Account can be used to generate a session token. You can create one from the [Integrations & Secrets](/workbench/integrations-secrets) page in the Fused Workbench.
 
 1. Open **Integrations & Secrets** from the Workbench sidebar. If you're already inside a canvas, use **Quick Actions** (`Ctrl+K`) and search for "Integrations & secrets".
 2. Under **Service accounts**, click **+ Create service account**.

--- a/docs/workbench/integrations-secrets.mdx
+++ b/docs/workbench/integrations-secrets.mdx
@@ -24,24 +24,12 @@ Connect external services to Fused so canvases and UDFs can interact with them. 
 - [Baseten](/workbench/integrations/baseten)
 - [ComfyOrg](/workbench/integrations/comfy)
 
-## Service Accounts {#service-accounts}
-
-Service accounts authenticate programmatic access to team-scoped shared endpoints. Use them to mint short-lived session tokens from your backend instead of exposing your personal credentials.
-
-To create a service account:
-
-1. Open **Integrations & Secrets** from the Workbench sidebar. If you're already inside a canvas, use **Quick Actions** (`Ctrl+K`) and search for "Integrations & secrets".
-2. Under **Service accounts**, click **+ Create service account**.
-3. Give the service account a name and click **Create**.
-
-:::important
-The token is shown only once — copy it to a secure location immediately. Never share it publicly or commit it to version control.
-:::
-
-For details on using service accounts to mint session tokens, see [Securing Shared Tokens](/guide/data-input-outputs/export-api/securing-shared-tokens#fused-service-accounts).
-
 ## Secrets
 
 Store any keys or credentials you want to use in Workbench here. They're encrypted in the Fused backend and attached to your selected kernel. For details on managing secrets, see the [Secrets management](/guide/advanced-setup/secrets-management) guide.
 
 To use a stored secret from a UDF, see [`fused.secrets`](/python-sdk/api-reference/fused-secrets).
+
+## See also
+
+- [Service accounts](/guide/data-input-outputs/export-api/securing-shared-tokens#fused-service-accounts) — create service account tokens to authenticate programmatic access to team-scoped shared endpoints

--- a/docs/workbench/integrations-secrets.mdx
+++ b/docs/workbench/integrations-secrets.mdx
@@ -24,6 +24,22 @@ Connect external services to Fused so canvases and UDFs can interact with them. 
 - [Baseten](/workbench/integrations/baseten)
 - [ComfyOrg](/workbench/integrations/comfy)
 
+## Service Accounts {#service-accounts}
+
+Service accounts authenticate programmatic access to team-scoped shared endpoints. Use them to mint short-lived session tokens from your backend instead of exposing your personal credentials.
+
+To create a service account:
+
+1. Open **Integrations & Secrets** from the Workbench sidebar. If you're already inside a canvas, use **Quick Actions** (`Ctrl+K`) and search for "Integrations & secrets".
+2. Under **Service accounts**, click **+ Create service account**.
+3. Give the service account a name and click **Create**.
+
+:::important
+The token is shown only once — copy it to a secure location immediately. Never share it publicly or commit it to version control.
+:::
+
+For details on using service accounts to mint session tokens, see [Securing Shared Tokens](/guide/data-input-outputs/export-api/securing-shared-tokens#fused-service-accounts).
+
 ## Secrets
 
 Store any keys or credentials you want to use in Workbench here. They're encrypted in the Fused backend and attached to your selected kernel. For details on managing secrets, see the [Secrets management](/guide/advanced-setup/secrets-management) guide.


### PR DESCRIPTION
## Summary

Fixes service account docs that pointed to the old Preferences page location.

### Changes
- ****: Updated "Creating a Fused Service Account" steps to direct users to Integrations & Secrets instead of Preferences, removed the outdated "Enable under Experimental Features" step, added Quick Actions tip for users inside a canvas.
- ****: Added a new Service Accounts section with creation steps and a link to the session token minting docs.

Closes ITEM-11584

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or security behavior changes.
> 
> **Overview**
> Documentation now matches the Workbench UI for **service accounts**: creation is documented under **Integrations & Secrets** instead of **Preferences**, including removal of the obsolete “Experimental Features” step and a **Quick Actions** (`Ctrl+K`) path when you’re already on a canvas.
> 
> The **Integrations & Secrets** workbench page adds a **See also** link to the securing shared tokens guide for programmatic team-scoped access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a61aafa2f36c10222a03d3cfffde978b1edd2bc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->