### PR TITLE
ci: add automated PR review (Fused UDF + Claude)

### DIFF
--- a/.claude/skills/review-docs-pr/SKILL.md
+++ b/.claude/skills/review-docs-pr/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: review-docs-pr
+description: >
+  Review a fused-docs pull request. Classifies the PR by what changed,
+  runs deterministic SDK introspection on the API-reference portion via the
+  deployed Fused UDF, and reasons about prose / examples / guides directly.
+  Always emits the same 4-bucket report (blocks_merge, app_repo_fix,
+  nice_to_have, unknown). Use when the user asks to review or check a
+  fused-docs PR (e.g. "/review-docs-pr 1124" or "check PR 1130").
+---
+
+# Review fused-docs PR
+
+This skill reviews a pull request against `fusedio/fused-docs`. The goal is
+to flag anything that would mislead a reader, not to gatekeep style.
+
+## Inputs
+
+A PR number (e.g. `1124`) or a full PR URL. Optional repo override; defaults
+to `fusedio/fused-docs`.
+
+## Output
+
+A single markdown report with **four buckets**:
+
+- 🔴 **blocks_merge** — fix in this PR before merging. SDK conflict, broken
+  link, example that can't possibly work.
+- 🟡 **app_repo_fix** — upstream docstring / code fix needed in
+  `fusedlabs/application` before regenerating docs.
+- 🔵 **nice_to_have** — quality regression that won't break users (lost
+  example, dropped parameter note).
+- 🟣 **unknown** — change touches something that needs the live product to
+  verify (Workbench UI flow, screenshot freshness, whether a workflow still
+  matches reality). **Say "I don't know" explicitly — don't guess.**
+
+Each finding is one line: `<file>:<lineish> — <what's wrong> — <why it matters>`.
+
+## Steps
+
+### 1. Fetch PR metadata
+
+```bash
+gh pr view <N> --repo fusedio/fused-docs --json title,body,headRefName,baseRefName,files
+gh api repos/fusedio/fused-docs/pulls/<N>/files --paginate --jq '.[].filename'
+```
+
+### 2. Classify the PR by changed files
+
+Bucket files into one of these groups (a PR can span multiple — handle each
+subset with the matching checks):
+
+| File pattern | Group | Checks |
+|---|---|---|
+| Branch `api-docs/**` AND only `docs/python-sdk/**.mdx` | `api_ref` | L1 mechanical UDF (step 3) |
+| `blog/**` | `blog` | L3 prose (step 5) + L2 link/image existence |
+| New `.mdx` under `docs/use-cases/`, `docs/examples/`, canvas dirs | `example` | L2 code-blocks + L3 prose |
+| Edits to existing prose `docs/**.mdx` (not python-sdk, not blog) | `guide_revision` | L3 prose, lean on `unknown` for workflow changes |
+| `sidebars.js`, `docusaurus.config.ts`, `package.json` | `nav` | Check internal references resolve |
+| `scripts/**`, `.github/**`, `tools/**`, `_*.fused` | `plumbing` | Skip — emit one line: "no docs review needed" |
+| Everything else | `other` | Flag into `unknown` |
+
+If `headRefName` matches `api-docs/**`, treat the whole PR as `api_ref` even
+if other files snuck in.
+
+### 3. L1 — Run the SDK introspection UDF (only for `api_ref` files)
+
+Call the deployed mechanical reviewer. **Always pass `engine="realtime"`** so
+the introspection runs against the live cloud SDK, never against whatever
+`fused` happens to be installed locally:
+
+```bash
+uv run --with fused --with pandas --with requests python <<'PY'
+import fused, json
+udf = fused.load("aman@fused.io/review_pr", collection_name="docs_pr_reviewer")
+df = fused.run(
+    udf,
+    pr_number="<N>",
+    repo="fusedio/fused-docs",
+    output="table",
+    engine="realtime",   # required: ensures cloud-side SDK is used
+)
+print(df.to_json(orient="records"))
+PY
+```
+
+The local `fused` install is only a thin RPC client here — the UDF executes
+on Fused's realtime infrastructure and introspects whatever SDK version is
+deployed there. That's the version users actually run.
+
+Parse the JSON. Each row already has a `bucket`, `file`, `finding`, `detail`
+— pass them through to the report as-is.
+
+If the UDF errors (e.g. installed `fused` version doesn't match the release),
+note that as a single `unknown` row and continue.
+
+### 4. L2 — Code-block static check (only for `example`, `blog` with code)
+
+For each changed `.mdx`, extract \`\`\`python code blocks. For each block:
+
+- Parse with `ast.parse`. Syntax error → `blocks_merge`.
+- Find every `fused.X.Y(...)` call. For each: `uv run --with fused python -c
+  "import fused; getattr(<resolve>, ...)"` — if missing → `blocks_merge`.
+- Look for `fd://`, `s3://`, `https://` URLs that are clearly placeholders
+  (`fd://my-bucket/...`, `s3://fused-users/...`) and flag those as
+  `nice_to_have` so writers replace with realistic examples.
+
+### 5. L3 — Prose review (everything that isn't `api_ref` or `plumbing`)
+
+Read the changed file at `head`. For prose changes:
+
+- **Internal links** — for each `[text](/path)` or `[text](path.mdx)`, check
+  the target exists in the worktree (or in the PR head). Broken → `blocks_merge`.
+- **External links** — flag `http(s)://` links that look stale (e.g.
+  `localhost`, `staging.`, `127.0.0.1`) → `blocks_merge`.
+- **Image references** — `![](./img/foo.png)`: file must exist in PR head.
+- **Workflow claims** — when prose describes a Workbench flow ("click X,
+  then Y appears"), you almost never know if that's still true. **Default
+  to `unknown`** and quote the specific sentence.
+- **Screenshot freshness** — referenced PNG/JPG in `static/img/**`: if
+  introduced more than 6 months before the PR's base commit, flag as
+  `unknown` ("screenshot may be stale, verify in current Workbench").
+
+### 6. Emit the report
+
+Use this exact structure so the output is consistent across PR types:
+
+```markdown
+# PR #<N> review — <title>
+
+**Type:** <api_ref | blog | example | guide_revision | nav | mixed>
+**Files changed:** <count>
+**fused SDK version (UDF run):** <version or "n/a">
+
+## 🔴 Blocks merge (<count>)
+- `<file>` — <finding> — *<detail>*
+
+## 🟡 Needs application repo fix (<count>)
+- ...
+
+## 🔵 Nice to have (<count>)
+- ...
+
+## 🟣 Needs human review (<count>)
+- `<file>` — <what you couldn't verify> — *<what to check in Workbench / live site>*
+
+## Summary
+<one-paragraph synthesis: merge with fixes? merge as-is? block?>
+```
+
+If a bucket is empty, write `_None_` under the heading — don't drop the heading.
+
+## Behavioural rules
+
+- **Never guess workflow correctness.** If a doc says "the canvas now opens
+  in side panel mode", you don't know that. Put it in `unknown`.
+- **Don't repeat the same finding** across L1/L2/L3 — pick the bucket that
+  best describes the fix, not all of them.
+- **No emojis in the report** other than the bucket headers above.
+- **Quote file paths verbatim** so the user can click through.
+- **Don't suggest stylistic edits** — only flag things that mislead readers.
+
+## Examples of judgment calls
+
+- Docstring example says `fused.api.upload("file.json", "s3://...")` but the
+  current convention is `fd://`. → `nice_to_have` ("update example to fd://").
+  Not `blocks_merge` because the call still works.
+- Page describes a 3-step workflow with screenshots from Workbench. → All
+  three steps go to `unknown` with a note "verify in current Workbench".
+- New blog post claims "Fused is 10× faster than X". → `unknown` ("benchmark
+  claim, verify with author").
+- Sidebar entry points at a renamed file. → `blocks_merge`.
+
+## When NOT to use this skill
+
+- Reviewing a PR in any repo other than `fusedio/fused-docs` (or a fork).
+- Reviewing application-repo PRs — those have their own review tooling.
+- General code review of `.py` UDF files outside `docs/`.

--- a/.github/workflows/review-docs-pr.README.md
+++ b/.github/workflows/review-docs-pr.README.md
@@ -1,0 +1,66 @@
+# Auto-review on PR open
+
+Posts two comments on every PR opened against `main`:
+
+1. **📄 Mechanical SDK review** — link to a live Fused UDF that introspects the
+   cloud SDK against documented signatures. Refreshes on every click.
+2. **🤖 Claude review** — qualitative review of prose, examples, internal links,
+   and workflow claims. Posted as a 4-bucket markdown report
+   (`blocks_merge` / `app_repo_fix` / `nice_to_have` / `unknown`).
+
+Both comments use hidden markers (`<!-- review-docs-pr:mechanical -->` and
+`<!-- review-docs-pr:claude -->`) so re-pushing the PR updates them in place
+instead of stacking new comments.
+
+## One-time setup
+
+### 1. GitHub secrets
+
+Two repository secrets must exist on `fusedio/fused-docs`:
+
+| Secret | Value | How to get it |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | Anthropic API key | https://console.anthropic.com/settings/keys |
+| `GITHUB_TOKEN` | (built-in) | Provided automatically by Actions, no setup needed |
+
+Set via `gh secret set ANTHROPIC_API_KEY --repo fusedio/fused-docs` or in the
+repo Settings → Secrets and variables → Actions.
+
+### 2. The mechanical UDF must stay public
+
+The workflow points at this public Fused share token:
+
+- Widget URL: `https://www.fused.io/share/fc_z8RQeHReLxcEWyB2nmGJz/widget_dashboard`
+- Raw UDF: `https://udf.ai/fc_z8RQeHReLxcEWyB2nmGJz/review_pr.html`
+
+Both are public read by design — no auth, anyone with the link can re-run.
+If the share token is rotated, update the URLs in `review-docs-pr.yml`.
+
+The UDF source lives at `tools/docs_pr_reviewer/review_pr.py`. To redeploy
+after edits, `cd tools/docs_pr_reviewer && fused canvas push .`
+
+### 3. The Claude skill must be committed
+
+The workflow expects the skill at `.claude/skills/review-docs-pr/SKILL.md`.
+The Claude Code action looks there automatically.
+
+## What gets reviewed
+
+| File pattern | Reviewed by | Bucket priority |
+|---|---|---|
+| `docs/python-sdk/**.mdx` | UDF (mechanical) + Claude | `blocks_merge`, `app_repo_fix` |
+| `blog/**` | Claude only | `unknown` for claim verification |
+| `docs/**` prose | Claude only | `unknown` for Workbench UI claims |
+| `scripts/**`, `.github/**` | Skipped — "no docs review needed" | — |
+
+## Disabling for a PR
+
+Add the label `skip-review` (or just ignore the comments — they're advisory,
+not gating). The workflow does not block merges; it only posts comments.
+
+## Cost
+
+- UDF: billed per call, ~$0.001 per click
+- Claude: ~$0.05–0.20 per PR for typical docs PRs (a few changed files)
+
+Negligible for the volume on `fusedio/fused-docs`.

--- a/.github/workflows/review-docs-pr.yml
+++ b/.github/workflows/review-docs-pr.yml
@@ -1,0 +1,104 @@
+name: Review docs PR
+
+# Triggered automatically when a PR is opened or updated against main.
+# Posts two PR comments:
+#  1. A link to the mechanical SDK review (Fused UDF, public share URL)
+#  2. A Claude-generated qualitative review (4-bucket report)
+# Both comments use hidden markers so re-pushes update in place instead of stacking.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: review-docs-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # ---------------------------------------------------------------- #
+  # Job A — Mechanical UDF review
+  # Posts a single comment with a link to the live HTML report.
+  # The link runs the UDF against Fused cloud on each click, so it
+  # always reflects the latest cloud SDK.
+  # ---------------------------------------------------------------- #
+  mechanical-review:
+    name: Mechanical SDK review (UDF)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build report URLs
+        id: urls
+        env:
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # URL-encode the repo (e.g. fusedio/fused-docs -> fusedio%2Ffused-docs)
+          REPO_ENC=$(echo -n "$REPO" | sed 's|/|%2F|g')
+          echo "widget=https://www.fused.io/share/fc_z8RQeHReLxcEWyB2nmGJz/widget_dashboard?pr_number=${PR}&repo=${REPO_ENC}" >> $GITHUB_OUTPUT
+          echo "raw=https://udf.ai/fc_z8RQeHReLxcEWyB2nmGJz/review_pr.html?pr_number=${PR}&output=html" >> $GITHUB_OUTPUT
+
+      - name: Upsert PR comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            <!-- review-docs-pr:mechanical -->
+            ## 📄 Mechanical SDK review
+
+            Runs against the **live Fused cloud SDK** — signature comparison, stub detection, missing-export checks. Refreshes on every click.
+
+            🔗 **[Open full report ↗](${{ steps.urls.outputs.widget }})**
+
+            <details><summary>Raw HTML (no widget chrome)</summary>
+
+            ${{ steps.urls.outputs.raw }}
+            </details>
+
+            _Mechanical only — prose, examples, and Workbench UI claims are reviewed in the Claude comment below._
+          edit-mode: replace
+          # find-and-replace by matching the marker in the first line
+          body-includes: "<!-- review-docs-pr:mechanical -->"
+
+  # ---------------------------------------------------------------- #
+  # Job B — Claude qualitative review
+  # Runs the /review-docs-pr skill (committed at .claude/skills/) and
+  # posts the resulting 4-bucket markdown report as a PR comment.
+  # ---------------------------------------------------------------- #
+  claude-review:
+    name: Claude review (L2/L3)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run /review-docs-pr skill
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Skill content is committed at .claude/skills/review-docs-pr/SKILL.md
+          # The action picks it up automatically from the project skills directory.
+          prompt: |
+            Run the `review-docs-pr` skill on PR #${{ github.event.pull_request.number }}
+            in repo `${{ github.repository }}`.
+
+            After producing the markdown report, post it as a single PR comment
+            using `gh pr comment ${{ github.event.pull_request.number }} --body-file <file>`.
+
+            Start the comment body with this exact hidden marker on its own line
+            so re-pushes can update the same comment:
+
+                <!-- review-docs-pr:claude -->
+
+            If a comment with that marker already exists, edit it instead of
+            posting a new one. Use:
+
+                gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments
+                # find the comment id whose body starts with the marker
+                gh api -X PATCH repos/${{ github.repository }}/issues/comments/<id> -f body=@<file>
+
+            Do not post any other comments. Do not modify any repo files.


### PR DESCRIPTION
## Summary

Adds a GitHub workflow that posts two comments on every PR opened against `main`:

1. **📄 Mechanical SDK review** — link to a public Fused UDF that introspects the live cloud SDK against documented signatures (stub detection, missing exports, signature mismatch). Refreshes on every click.
2. **🤖 Claude review** — qualitative 4-bucket report (`blocks_merge` / `app_repo_fix` / `nice_to_have` / `unknown`) covering prose, examples, internal links, and Workbench UI claims.

Both comments use hidden markers (`<!-- review-docs-pr:mechanical -->` and `<!-- review-docs-pr:claude -->`) so re-pushes update them in place instead of stacking.

The workflow is **advisory** — it does not block merges, only posts comments.

## What's included

- `.github/workflows/review-docs-pr.yml` — the workflow (two jobs)
- `.github/workflows/review-docs-pr.README.md` — setup + behavior docs
- `.claude/skills/review-docs-pr/SKILL.md` — the skill the Claude job invokes

## Before this works

One repo secret needs to be added:

- `ANTHROPIC_API_KEY` — for the Claude review job. Get one at https://console.anthropic.com/settings/keys

The mechanical UDF job works without any secret (public Fused share URL).

## Test plan

- [ ] Add `ANTHROPIC_API_KEY` to repo secrets
- [ ] Merge this PR
- [ ] Open a trivial follow-up PR (e.g. a typo fix) and confirm both comments appear within ~2 minutes
- [ ] Push another commit to that PR and confirm both comments update in place (no duplicates)
- [ ] Verify the mechanical report URL renders correctly
- [ ] Verify the Claude report follows the 4-bucket format

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New CI depends on Anthropic API secrets, third-party Actions, and a fixed public Fused share URL; failures are non-blocking but affect reviewer trust and per-PR cost.
> 
> **Overview**
> Adds an **advisory** GitHub Actions workflow on PRs to `main` that posts **two updatable PR comments** (hidden HTML markers + replace/edit) instead of stacking new threads on every push.
> 
> The **mechanical** job builds public Fused widget/raw URLs for the existing `review_pr` UDF (PR number + repo encoded) and upserts a comment linking to live cloud SDK checks. The **Claude** job checks out the repo, runs the new `review-docs-pr` skill via `anthropics/claude-code-action`, and instructs the agent to publish a fixed **four-bucket** markdown report (`blocks_merge`, `app_repo_fix`, `nice_to_have`, `unknown`) with the same marker-based upsert pattern.
> 
> Also adds **`.claude/skills/review-docs-pr/SKILL.md`** (file-type routing, optional L1 UDF via `engine="realtime"`, L2 Python AST/SDK checks, L3 link/image/prose rules) and **`.github/workflows/review-docs-pr.README.md`** (secrets, public share token maintenance, scope/cost). Reviews are **comment-only**—no merge blocking; **`ANTHROPIC_API_KEY`** is required for the Claude job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 194f08dd1356731696dd22a430a7035cef8c4f66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->