### PR TITLE
docs: sync API reference with fused-py v2.8.0

### DIFF
--- a/docs/python-sdk/api-reference/api.mdx
+++ b/docs/python-sdk/api-reference/api.mdx
@@ -17,7 +17,17 @@ fused.api.function_name()
 
 ---
 
-## access_token
+## fused.api.whoami
+
+```python
+whoami()
+```
+
+Returns information on the currently logged in user
+
+---
+
+## fused.api.access_token
 
 ```python
 access_token() -> str
@@ -25,29 +35,29 @@ access_token() -> str
 
 Get an access token for the Fused service.
 
-Returns the Bearer token for the authenticated user. Use this for authenticating API requests outside of the Fused SDK.
-
-**Returns:**
-
-- `str` – The access token string.
-
 ---
 
-## auth_scheme
+## fused.api.auth_scheme
 
 ```python
 auth_scheme() -> str
 ```
 
-Return the auth scheme used for API requests (e.g. `"Bearer"`).
+---
 
-**Returns:**
+## fused.api.logout
 
-- `str` – The auth scheme string.
+```python
+logout()
+```
+
+Log out the current user.
+
+This deletes the credentials saved to disk and resets the global Fused API.
 
 ---
 
-## delete
+## fused.api.delete
 
 ```python
 delete(path: str, max_deletion_depth: int | Literal['unlimited'] = 3) -> bool
@@ -57,47 +67,45 @@ Delete the files at the path.
 
 **Parameters:**
 
-- **path** (`str`) – Directory or file to delete, like `s3://fused-users/fused/aman/my-old-table/`
-- **max_deletion_depth** (`int | Literal['unlimited']`) – If set (defaults to 3), the maximum depth the operation will recurse to.
+- **path** (<code>str</code>) – Directory or file to delete, like `fd://my-old-table/`
+- **max_deletion_depth** (<code>int | Literal['unlimited']</code>) – If set (defaults to 3), the maximum depth the operation will recurse to.
   This option is to help avoid accidentally deleting more data that intended.
   Pass `"unlimited"` for unlimited.
 
 **Examples:**
 
 ```python
-fused.api.delete("s3://fused-users/fused/aman/deprecated_table/")  # change to your own path
+fused.api.delete("fd://bucket-name/deprecated_table/")
 ```
 
 ---
 
-## download
+## fused.api.list
 
 ```python
-download(path: str, local_path: str | Path) -> None
+list(path: str, *, details: bool = False) -> list[str] | list[ListDetails]
 ```
 
-Download the contents at the path to disk.
+List the files at the path.
 
 **Parameters:**
 
-- **path** (`str`) – URL to a file, like `s3://fused-users/fused/aman/file.parquet`
-- **local_path** (`str | Path`) – Path to a local file.
+- **path** (<code>str</code>) – Parent directory URL, like `fd://bucket-name/`
+- **details** (<code>bool</code>) – If True, return additional metadata about each record.
 
----
+**Returns:**
 
-## enable_gcs
+- <code>[list](#fused.api._public_api.list)\[[str](#str)\] | [list](#fused.api._public_api.list)\[[ListDetails](#fused.models.api.ListDetails)\]</code> – A list of paths as URLs, or as metadata objects.
+
+**Examples:**
 
 ```python
-enable_gcs()
+fused.api.list("fd://bucket-name/")
 ```
-
-Save GCS credentials from AWS secret manager into a temporary local file and set its path to the environment variable.
-
-Use this to enable Google Cloud Storage access in your UDFs.
 
 ---
 
-## get
+## fused.api.get
 
 ```python
 get(path: str) -> bytes
@@ -107,85 +115,135 @@ Download the contents at the path to memory.
 
 **Parameters:**
 
-- **path** (`str`) – URL to a file, like `s3://fused-users/fused/aman/file.parquet`
+- **path** (<code>str</code>) – URL to a file, like `fd://bucket-name/file.parquet`
 
 **Returns:**
 
-- `bytes` – bytes of the file
+- <code>[bytes](#bytes)</code> – bytes of the file
 
 **Examples:**
 
 ```python
-fused.api.get("s3://fused-users/fused/aman/file.parquet")  # change to your own path
+fused.api.get("fd://bucket-name/file.parquet")
 ```
 
 ---
 
-## get_apps
+## fused.api.download
 
 ```python
-get_apps(
-    n: int | None = None,
-    *,
-    skip: int = 0,
-    by: Literal['name', 'id', 'slug'] = 'name',
-    whose: Literal['self', 'public'] = 'self'
-) -> dict
+download(path: str, local_path: str | Path) -> None
 ```
 
-Get apps for the current user or public apps.
+Download the contents at the path to disk.
 
 **Parameters:**
 
-- **n** (`int | None`) – Maximum number of apps to return. None for all.
-- **skip** (`int`) – Number of apps to skip.
-- **by** (`Literal['name', 'id', 'slug']`) – Sort order.
-- **whose** (`Literal['self', 'public']`) – Whose apps to get.
-
-**Returns:**
-
-- `dict` – Dictionary of apps.
+- **path** (<code>str</code>) – URL to a file, like `fd://bucket-name/file.parquet`
+- **local_path** (<code>str | Path</code>) – Path to a local file.
 
 ---
 
-## get_jobs
+## fused.api.upload
 
 ```python
-get_jobs(
-    n: int = 5,
-    *,
-    skip: int = 0,
-    per_request: int = 25,
-    max_requests: int | None = None
-) -> Jobs
+upload(
+    local_path: str | Path | bytes | BinaryIO | pd.DataFrame | gpd.GeoDataFrame,
+    remote_path: str,
+    timeout: float | None = None,
+) -> None
 ```
 
-Get the job history.
+Upload local file to S3.
 
 **Parameters:**
 
-- **n** (`int`) – The number of jobs to fetch. Defaults to 5.
-- **skip** (`int`) – Where in the job history to begin. Defaults to 0, which retrieves the most recent job.
-- **per_request** (`int`) – Number of jobs per request to fetch. Defaults to 25.
-- **max_requests** (`int | None`) – Maximum number of requests to make. May be None to fetch all jobs.
+- **local_path** (<code>str | Path | bytes | BinaryIO | pd.DataFrame | gpd.GeoDataFrame</code>) – Either a path to a local file (`str`, `Path`), a (Geo)DataFrame
+  (which will get uploaded as Parquet file), or the contents to upload.
+  Any string will be treated as a Path, if you wish to upload the contents of
+  the string, first encode it: `s.encode("utf-8")`
+- **remote_path** (<code>str</code>) – URL to upload to, like `fd://new-file.txt`
+- **timeout** (<code>float | None</code>) – Optional timeout in seconds for the upload (will default to `OPTIONS.request_timeout` if not specified).
+
+**Examples:**
+
+To upload a local json file to your Fused-managed S3 bucket:
+
+```py
+fused.api.upload("my_file.json", "fd://my_bucket/my_file.json")
+```
+
+---
+
+## fused.api.sign_url
+
+```python
+sign_url(path: str) -> str
+```
+
+Create a signed URL to access the path.
+
+This function may not check that the file represented by the path exists.
+
+**Parameters:**
+
+- **path** (<code>str</code>) – URL to a file, like `fd://bucket-name/file.parquet`
 
 **Returns:**
 
-- `Jobs` – The job history.
+- <code>[str](#str)</code> – HTTPS URL to access the file using signed access.
 
 **Examples:**
 
 ```python
-# Get the 5 most recent jobs
-jobs = fused.api.get_jobs()
-
-# Get more jobs
-jobs = fused.api.get_jobs(n=20)
+fused.api.sign_url("fd://bucket-name/table_directory/file.parquet")
 ```
 
 ---
 
-## get_udfs
+## fused.api.sign_url_prefix
+
+```python
+sign_url_prefix(path: str) -> dict[str, str]
+```
+
+Create signed URLs to access all blobs under the path.
+
+**Parameters:**
+
+- **path** (<code>str</code>) – URL to a prefix, like `fd://bucket-name/some_directory/`
+
+**Returns:**
+
+- <code>[dict](#dict)\[[str](#str), [str](#str)\]</code> – Dictionary mapping from blob store key to signed HTTPS URL.
+
+**Examples:**
+
+```python
+fused.api.sign_url_prefix("fd://bucket-name/table_directory/")
+```
+
+---
+
+## fused.api.resolve
+
+```python
+resolve(path: str) -> str
+```
+
+Resolve a path from fd:// to the full S3 URI.
+
+**Parameters:**
+
+- **path** (<code>str</code>) – The path to resolve.
+
+**Returns:**
+
+- <code>[str](#str)</code> – S3 resolved path
+
+---
+
+## fused.api.get_udfs
 
 ```python
 get_udfs(
@@ -202,16 +260,16 @@ Fetches a list of UDFs.
 
 **Parameters:**
 
-- **n** (`int | None`) – The total number of UDFs to fetch. Defaults to All.
-- **skip** (`int`) – The number of UDFs to skip before starting to collect the result set. Defaults to 0.
-- **by** (`Literal['name', 'id', 'slug']`) – The attribute by which to sort the UDFs. Can be "name", "id", or "slug". Defaults to "name".
-- **whose** (`Literal['self', 'public', 'community', 'team']`) – Specifies whose UDFs to fetch. Can be "self" for the user's own UDFs or "public" for
+- **n** (<code>int | None</code>) – The total number of UDFs to fetch. Defaults to All.
+- **skip** (<code>int</code>) – The number of UDFs to skip before starting to collect the result set. Defaults to 0.
+- **by** (<code>Literal['name', 'id', 'slug']</code>) – The attribute by which to sort the UDFs. Can be "name", "id", or "slug". Defaults to "name".
+- **whose** (<code>Literal['self', 'public', 'community', 'team']</code>) – Specifies whose UDFs to fetch. Can be "self" for the user's own UDFs or "public" for
   UDFs available publicly or "community" for all community UDFs. Defaults to "self".
-- **collection_name** (`str | None`) – Filter UDFs by collection name. If not provided, returns UDFs from all collections.
+- **collection_name** (<code>str | None</code>) – Filter UDFs by collection name. If not provided, defaults to "default".
 
 **Returns:**
 
-- `dict` – A list of UDFs.
+- <code>[dict](#dict)</code> – A list of UDFs.
 
 **Examples:**
 
@@ -223,39 +281,43 @@ fused.api.get_udfs()
 
 ---
 
-## job_cancel
+## fused.api.get_apps
 
 ```python
-job_cancel(job: CoerceableToJobId) -> RunResponse
+get_apps(
+    n: int | None = None,
+    *,
+    skip: int = 0,
+    by: Literal["name", "id", "slug"] = "name",
+    whose: Literal["self", "public"] = "self"
+) -> dict
 ```
 
-Cancel an existing job
+Fetches a list of apps.
 
 **Parameters:**
 
-- **job** (`CoerceableToJobId`) – the identifier of a job or a `RunResponse` object.
+- **n** (<code>int | None</code>) – The total number of UDFs to fetch. Defaults to All.
+- **skip** (<code>int</code>) – The number of UDFs to skip before starting to collect the result set. Defaults to 0.
+- **by** (<code>Literal['name', 'id', 'slug']</code>) – The attribute by which to sort the apps. Can be "name", "id", or "slug". Defaults to "name".
+- **whose** (<code>Literal['self', 'public']</code>) – Specifies whose apps to fetch. Can be "self" for the user's own apps or "public" for
+  UDFs available publicly. Defaults to "self".
 
 **Returns:**
 
-- `RunResponse` – A new job object.
+- <code>[dict](#dict)</code> – A list of apps.
 
----
+**Examples:**
 
-## job_get_exec_time
+Fetch apps under the user account:
 
-```python
-job_get_exec_time(job: CoerceableToJobId) -> timedelta
+```py
+fused.api.get_apps()
 ```
 
-Determine the execution time of this job, using the logs.
-
-**Returns:**
-
-- `timedelta` – Time the job took. If the job is in progress, time from first to last log message is returned.
-
 ---
 
-## job_get_logs
+## fused.api.job_get_logs
 
 ```python
 job_get_logs(job: CoerceableToJobId, since_ms: int | None = None) -> list[Any]
@@ -265,52 +327,16 @@ Fetch logs for a job
 
 **Parameters:**
 
-- **job** (`CoerceableToJobId`) – the identifier of a job or a `RunResponse` object.
-- **since_ms** (`int | None`) – Timestamp, in milliseconds since epoch, to get logs for. Defaults to None for all logs.
+- **job** (<code>CoerceableToJobId</code>) – the identifier of a job or a `RunResponse` object.
+- **since_ms** (<code>int | None</code>) – Timestamp, in milliseconds since epoch, to get logs for. Defaults to None for all logs.
 
 **Returns:**
 
-- `list[Any]` – Log messages for the given job.
+- <code>[list](#fused.api._public_api.list)\[[Any](#typing.Any)\]</code> – Log messages for the given job.
 
 ---
 
-## job_get_results
-
-```python
-job_get_results(job: CoerceableToJobId) -> list[Any]
-```
-
-Get the results of a completed job.
-
-**Parameters:**
-
-- **job** (`CoerceableToJobId`) – The identifier of a job or a `RunResponse` object.
-
-**Returns:**
-
-- `list[Any]` – List of results from the job.
-
----
-
-## job_get_status
-
-```python
-job_get_status(job: CoerceableToJobId) -> RunResponse
-```
-
-Fetch the status of a running job
-
-**Parameters:**
-
-- **job** (`CoerceableToJobId`) – the identifier of a job or a `RunResponse` object.
-
-**Returns:**
-
-- `RunResponse` – The status of the given job.
-
----
-
-## job_print_logs
+## fused.api.job_print_logs
 
 ```python
 job_print_logs(
@@ -322,17 +348,17 @@ Fetch and print logs for a job
 
 **Parameters:**
 
-- **job** (`CoerceableToJobId`) – the identifier of a job or a `RunResponse` object.
-- **since_ms** (`int | None`) – Timestamp, in milliseconds since epoch, to get logs for. Defaults to None for all logs.
-- **file** (`IO | None`) – Where to print logs to. Defaults to sys.stdout.
+- **job** (<code>CoerceableToJobId</code>) – the identifier of a job or a `RunResponse` object.
+- **since_ms** (<code>int | None</code>) – Timestamp, in milliseconds since epoch, to get logs for. Defaults to None for all logs.
+- **file** (<code>IO | None</code>) – Where to print logs to. Defaults to sys.stdout.
 
 **Returns:**
 
-- `None` – None
+- <code>None</code> – None
 
 ---
 
-## job_tail_logs
+## fused.api.job_tail_logs
 
 ```python
 job_tail_logs(
@@ -347,14 +373,64 @@ Continuously print logs for a job
 
 **Parameters:**
 
-- **job** (`CoerceableToJobId`) – the identifier of a job or a `RunResponse` object.
-- **refresh_seconds** (`float`) – how frequently, in seconds, to check for new logs. Defaults to 1.
-- **sample_logs** (`bool`) – if true, print out only a sample of logs. Defaults to True.
-- **timeout** (`float | None`) – if not None, how long to continue tailing logs for. Defaults to None for indefinite.
+- **job** (<code>CoerceableToJobId</code>) – the identifier of a job or a `RunResponse` object.
+- **refresh_seconds** (<code>float</code>) – how frequently, in seconds, to check for new logs. Defaults to 1.
+- **sample_logs** (<code>bool</code>) – if true, print out only a sample of logs. Defaults to True.
+- **timeout** (<code>float | None</code>) – if not None, how long to continue tailing logs for. Defaults to None for indefinite.
 
 ---
 
-## job_wait_for_job
+## fused.api.job_get_status
+
+```python
+job_get_status(job: CoerceableToJobId) -> RunResponse
+```
+
+Fetch the status of a running job
+
+**Parameters:**
+
+- **job** (<code>CoerceableToJobId</code>) – the identifier of a job or a `RunResponse` object.
+
+**Returns:**
+
+- <code>[RunResponse](#fused.models.internal.job.RunResponse)</code> – The status of the given job.
+
+---
+
+## fused.api.job_cancel
+
+```python
+job_cancel(job: CoerceableToJobId) -> RunResponse
+```
+
+Cancel an existing job
+
+**Parameters:**
+
+- **job** (<code>CoerceableToJobId</code>) – the identifier of a job or a `RunResponse` object.
+
+**Returns:**
+
+- <code>[RunResponse](#fused.models.internal.job.RunResponse)</code> – A new job object.
+
+---
+
+## fused.api.job_get_exec_time
+
+```python
+job_get_exec_time(job: CoerceableToJobId) -> timedelta
+```
+
+Determine the execution time of this job, using the logs.
+
+**Returns:**
+
+- <code>[timedelta](#datetime.timedelta)</code> – Time the job took. If the job is in progress, time from first to last log message is returned.
+
+---
+
+## fused.api.job_wait_for_job
 
 ```python
 job_wait_for_job(
@@ -368,71 +444,130 @@ Block the Python kernel until this job has finished
 
 **Parameters:**
 
-- **poll_interval_seconds** (`float`) – How often (in seconds) to poll for status updates. Defaults to 5.
-- **timeout** (`float | None`) – The length of time in seconds to wait for the job. Defaults to None.
+- **poll_interval_seconds** (<code>float</code>) – How often (in seconds) to poll for status updates. Defaults to 5.
+- **timeout** (<code>float | None</code>) – The length of time in seconds to wait for the job. Defaults to None.
 
 **Raises:**
 
-- `TimeoutError` – if waiting for the job timed out.
+- <code>[TimeoutError](#TimeoutError)</code> – if waiting for the job timed out.
 
 **Returns:**
 
-- `RunResponse` – The status of the given job.
+- <code>[RunResponse](#fused.models.internal.job.RunResponse)</code> – The status of the given job.
 
 ---
 
-## job_wait_for_results
+## fused.api.job_get_results
+
+```python
+job_get_results(job: CoerceableToJobId) -> list[Any]
+```
+
+---
+
+## fused.api.job_wait_for_results
 
 ```python
 job_wait_for_results(
     job: CoerceableToJobId,
     poll_interval_seconds: float = 5,
-    timeout: float | None = None
+    timeout: float | None = None,
 ) -> list[UdfEvaluationResult]
 ```
 
-Block until a job completes and return its results.
+---
 
-Combines `job_wait_for_job` and `job_get_results` into a single call.
+## fused.api.schedule_udf
+
+```python
+schedule_udf(
+    udf: BaseUdf | str,
+    minute: list[int] | int,
+    hour: list[int] | int,
+    day_of_month: list[int] | int | None = None,
+    month: list[int] | int | None = None,
+    day_of_week: list[int] | int | None = None,
+    udf_args: dict[str, Any] | None = None,
+    enabled: bool = True,
+    _create_udf: bool = True,
+    **kwargs: bool
+) -> CronJob
+```
+
+Schedule a UDF to run on a cron schedule.
 
 **Parameters:**
 
-- **job** (`CoerceableToJobId`) – The identifier of a job or a `RunResponse` object.
-- **poll_interval_seconds** (`float`) – How often to poll for status. Defaults to 5.
-- **timeout** (`float | None`) – Maximum time to wait in seconds. None for no timeout.
-
-**Returns:**
-
-- `list[UdfEvaluationResult]` – List of UDF evaluation results.
+- **udf** (<code>BaseUdf | str</code>) – The UDF to schedule.
+- **minute** (<code>list[int] | int</code>) – The minute to run the UDF on.
+- **hour** (<code>list[int] | int</code>) – The hour to run the UDF on.
+- **day_of_month** (<code>list[int] | int | None</code>) – The day of the month to run the UDF on. (Default every day)
+- **month** (<code>list[int] | int | None</code>) – The month to run the UDF on. (Default every month)
+- **day_of_week** (<code>list[int] | int | None</code>) – The day of the week to run the UDF on. (Default every day)
+- **udf_args** (<code>dict[str, Any] | None</code>) – The arguments to pass to the UDF. (Default None)
+- **enabled** (<code>bool</code>) – Whether the cron job is enabled. (Default True)
+- **\_create_udf** (<code>bool</code>) – Save the UDF to Fused before creating the CronJob. (Default True)
 
 ---
 
-## list
+## fused.api.schedule_list
 
 ```python
-list(path: str, *, details: bool = False) -> list[str] | list[ListDetails]
+schedule_list()
 ```
 
-List the files at the path.
+List all cron jobs
+
+---
+
+## fused.api.session_token
+
+```python
+session_token(session_max_age: str | int = '1h') -> SessionToken
+```
+
+Create a session token for the current workbench canvas.
+
+Automatically resolves the canvas share token from the currently
+running UDF context. Must be called from within the Fused workbench.
 
 **Parameters:**
 
-- **path** (`str`) – Parent directory URL, like `s3://fused-users/fused/aman/`
-- **details** (`bool`) – If True, return additional metadata about each record.
+- **session_max_age** (<code>str | int</code>) – Lifetime of the session token. Accepts an integer
+  (seconds) or a duration string such as `"30m"`, `"1h"`,
+  `"1d"`. Defaults to `"1h"`.
 
 **Returns:**
 
-- `list[str] | list[ListDetails]` – A list of paths as URLs, or as metadata objects.
-
-**Examples:**
-
-```python
-fused.api.list("s3://fused-users/fused/aman/")  # change to your own path
-```
+- **A** (<code>[SessionToken](#fused.models.api.SessionToken)</code>) – class:`SessionToken` with `session_token` and `expires_at` fields.
 
 ---
 
-## log
+## fused.api.team_info
+
+```python
+team_info() -> dict
+```
+
+Fetch the team execution environment details.
+
+**Returns:**
+
+- <code>[dict](#dict)</code> – A dictionary with information about the execution environment.
+
+---
+
+## fused.api.enable_gcs
+
+```python
+enable_gcs()
+```
+
+Save gcs credentials from AWS secret manager into a temporary local file and set its path to the env variable.
+
+---
+
+## fused.api.log
 
 ```python
 log(
@@ -449,7 +584,7 @@ log(
     limit: int = 100,
     scan_forward: bool = True,
     page_token: str | None = None,
-    max_records_to_scan: int = 1000,
+    max_records_to_scan: int = 1000
 ) -> dict[str, Any]
 ```
 
@@ -459,23 +594,23 @@ Routes to the appropriate audit log method based on the provided arguments.
 
 **Parameters:**
 
-- **id** (`str | None`) – Get audit log by record ID. If provided, other filters are ignored.
-- **udf_id** (`str | None`) – Filter logs by UDF ID.
-- **udf_name** (`str | None`) – Filter logs by UDF name.
-- **shared_token** (`str | None`) – Filter logs by shared token.
-- **exec_env** (`bool`) – If True, filter by execution environment. Defaults to False.
-- **distinct** (`bool`) – If True, return distinct values instead of full logs. Defaults to False.
-- **distinct_type** (`Literal["names", "ids"] | None`) – When distinct=True, specify "names" or "ids" to get distinct UDF names or IDs.
-- **start_timestamp** (`str | None`) – Start timestamp (ISO format, inclusive). Defaults to None.
-- **end_timestamp** (`str | None`) – End timestamp (ISO format, inclusive). Defaults to None.
-- **limit** (`int`) – Maximum number of items to return (max 300). Defaults to 100.
-- **scan_forward** (`bool`) – If True, scan forward in time; if False, scan backward. Defaults to True.
-- **page_token** (`str | None`) – Pagination token from previous response. Defaults to None.
-- **max_records_to_scan** (`int`) – Maximum number of records to scan (max 5000). Used for distinct queries. Defaults to 1000.
+- **id** (<code>str | None</code>) – Get audit log by record ID. If provided, other filters are ignored.
+- **udf_id** (<code>str | None</code>) – Filter logs by UDF ID.
+- **udf_name** (<code>str | None</code>) – Filter logs by UDF name.
+- **shared_token** (<code>str | None</code>) – Filter logs by shared token.
+- **exec_env** (<code>bool</code>) – If True, filter by execution environment. Defaults to False.
+- **distinct** (<code>bool</code>) – If True, return distinct values instead of full logs. Defaults to False.
+- **distinct_type** (<code>Literal['names', 'ids'] | None</code>) – When distinct=True, specify "names" or "ids" to get distinct UDF names or IDs.
+- **start_timestamp** (<code>str | None</code>) – Start timestamp (ISO format, inclusive). Defaults to None.
+- **end_timestamp** (<code>str | None</code>) – End timestamp (ISO format, inclusive). Defaults to None.
+- **limit** (<code>int</code>) – Maximum number of items to return (max 300). Used for regular log queries. Defaults to 100.
+- **scan_forward** (<code>bool</code>) – If True, scan forward in time; if False, scan backward. Defaults to True.
+- **page_token** (<code>str | None</code>) – Pagination token from previous response. Defaults to None.
+- **max_records_to_scan** (<code>int</code>) – Maximum number of records to scan (max 5000). Used for distinct queries. Defaults to 1000.
 
 **Returns:**
 
-- `dict[str, Any]` – Dictionary containing items, limit, and next_page_token.
+- <code>[dict](#dict)\[[str](#str), [Any](#typing.Any)\]</code> – Dictionary containing items, limit, and next_page_token.
 
 **Examples:**
 
@@ -492,6 +627,9 @@ logs = fused.api.log(udf_id="udf-id")
 # Get logs by UDF name
 logs = fused.api.log(udf_name="my_udf")
 
+# Get logs by shared token
+logs = fused.api.log(shared_token="shared-token")
+
 # Get a specific log by ID
 log_entry = fused.api.log(id="audit-log-id")
 
@@ -504,182 +642,7 @@ distinct_ids = fused.api.log(distinct=True, distinct_type="ids", exec_env=True)
 
 ---
 
-## logout
-
-```python
-logout()
-```
-
-Log out the current user.
-
-Deletes the credentials saved to disk and resets the global Fused API.
-
----
-
-## resolve
-
-```python
-resolve(path: str) -> str
-```
-
-Resolve a path from `fd://` to the full S3 URI.
-
-**Parameters:**
-
-- **path** (`str`) – The path to resolve (e.g., `fd://my-data/output.parquet`).
-
-**Returns:**
-
-- `str` – The resolved S3 path.
-
-**Example:**
-
-```python
-s3_path = fused.api.resolve("fd://my-data/output.parquet")
-# Returns: "s3://fused-users/fused/my-team/my-data/output.parquet"
-```
-
----
-
-## schedule_list
-
-```python
-schedule_list()
-```
-
-List all cron jobs scheduled for the current user.
-
-**Returns:**
-
-- List of `CronJob` objects.
-
----
-
-## schedule_udf
-
-```python
-schedule_udf(
-    udf: BaseUdf | str,
-    minute: list[int] | int,
-    hour: list[int] | int,
-    day_of_month: list[int] | int | None = None,
-    month: list[int] | int | None = None,
-    day_of_week: list[int] | int | None = None,
-    udf_args: dict[str, Any] | None = None,
-    enabled: bool = True,
-    **kwargs
-) -> CronJob
-```
-
-Schedule a UDF to run on a cron schedule.
-
-**Parameters:**
-
-- **udf** (`BaseUdf | str`) – The UDF to schedule, either as a UDF object or name.
-- **minute** (`list[int] | int`) – Minute(s) to run (0-59).
-- **hour** (`list[int] | int`) – Hour(s) to run (0-23).
-- **day_of_month** (`list[int] | int | None`) – Day(s) of month to run (1-31).
-- **month** (`list[int] | int | None`) – Month(s) to run (1-12).
-- **day_of_week** (`list[int] | int | None`) – Day(s) of week to run (0-6, where 0 is Sunday).
-- **udf_args** (`dict[str, Any] | None`) – Arguments to pass to the UDF.
-- **enabled** (`bool`) – Whether the schedule is enabled. Defaults to True.
-
-**Returns:**
-
-- `CronJob` – The created cron job object.
-
-**Example:**
-
-```python
-# Run a UDF every day at 8:00 AM
-fused.api.schedule_udf(
-    udf="my_udf",
-    minute=0,
-    hour=8
-)
-
-# Run every Monday and Friday at noon
-fused.api.schedule_udf(
-    udf=my_udf,
-    minute=0,
-    hour=12,
-    day_of_week=[1, 5]
-)
-```
-
----
-
-## session_token
-
-```python
-session_token(session_max_age: str | int = "1h") -> SessionToken
-```
-
-Create a session token for the current workbench canvas.
-
-Automatically resolves the canvas share token from the currently running UDF context. Must be called from within the Fused workbench.
-
-**Parameters:**
-
-- **session_max_age** (`str | int`) – Lifetime of the session token. Accepts an integer (seconds) or a duration string such as `"30m"`, `"1h"`, `"1d"`. Defaults to `"1h"`.
-
-**Returns:**
-
-- `SessionToken` – Object with `session_token` and `expires_at` fields.
-
----
-
-## sign_url
-
-```python
-sign_url(path: str) -> str
-```
-
-Create a signed URL to access the path.
-
-This function may not check that the file represented by the path exists.
-
-**Parameters:**
-
-- **path** (`str`) – URL to a file, like `s3://fused-users/fused/aman/file.parquet`
-
-**Returns:**
-
-- `str` – HTTPS URL to access the file using signed access.
-
-**Examples:**
-
-```python
-fused.api.sign_url("s3://fused-users/fused/aman/table_directory/file.parquet")  # change to your own path
-```
-
----
-
-## sign_url_prefix
-
-```python
-sign_url_prefix(path: str) -> dict[str, str]
-```
-
-Create signed URLs to access all blobs under the path.
-
-**Parameters:**
-
-- **path** (`str`) – URL to a prefix, like `s3://fused-users/fused/aman/some_directory/`
-
-**Returns:**
-
-- `dict[str, str]` – Dictionary mapping from blob store key to signed HTTPS URL.
-
-**Examples:**
-
-```python
-fused.api.sign_url_prefix("s3://fused-users/fused/aman/table_directory/")  # change to your own path
-```
-
----
-
-## snowflake_connect
+## fused.api.snowflake_connect
 
 ```python
 snowflake_connect(
@@ -687,39 +650,26 @@ snowflake_connect(
     role: str | None = None,
     warehouse: str | None = None,
     database: str | None = None,
-    schema: str | None = None,
+    schema: str | None = None
 ) -> FusedSnowflakeConnection
 ```
 
-Create a `SnowflakeConnection` using Fused-managed OAuth.
+Create a Snowflake connection using Fused-managed OAuth.
 
 **Parameters:**
 
-- **role** (`str | None`) – Snowflake role to `USE` after connecting.
-- **warehouse** (`str | None`) – Snowflake warehouse to `USE`.
-- **database** (`str | None`) – Default database context.
-- **schema** (`str | None`) – Default schema context.
+- **role** (<code>str | None</code>) – Snowflake role to USE after connecting.
+- **warehouse** (<code>str | None</code>) – Snowflake warehouse to USE after connecting.
+- **database** (<code>str | None</code>) – Default database context.
+- **schema** (<code>str | None</code>) – Default schema context.
 
 **Returns:**
 
-- `FusedSnowflakeConnection` – A connection wrapper instance.
-
-**Examples:**
-
-```python
-conn = fused.api.snowflake_connect(
-    role="ANALYST",
-    warehouse="COMPUTE_WH",
-    database="ANALYTICS",
-    schema="PUBLIC",
-)
-
-df = conn.query("SELECT CURRENT_USER() AS user")
-```
+- **A** (<code>[FusedSnowflakeConnection](#fused.api._snowflake.FusedSnowflakeConnection)</code>) – class:`FusedSnowflakeConnection` instance.
 
 ---
 
-## snowflake_query
+## fused.api.snowflake_query
 
 ```python
 snowflake_query(
@@ -728,88 +678,135 @@ snowflake_query(
     role: str | None = None,
     warehouse: str | None = None,
     database: str | None = None,
-    schema: str | None = None,
+    schema: str | None = None
 ) -> pd.DataFrame
 ```
 
-Execute a SQL query against Snowflake and return a DataFrame. Shorthand for `FusedSnowflakeConnection(**kwargs).query(sql)`.
+Execute a SQL query against Snowflake and return a DataFrame.
+
+This is a convenience wrapper around
+:meth:`FusedSnowflakeConnection.query`.
 
 **Parameters:**
 
-- **sql** (`str`) – The SQL query to execute.
-- **role** (`str | None`) – Snowflake role to `USE` after connecting.
-- **warehouse** (`str | None`) – Snowflake warehouse to `USE`.
-- **database** (`str | None`) – Default database context.
-- **schema** (`str | None`) – Default schema context.
+- **sql** (<code>str</code>) – The SQL statement to execute.
+- **role** (<code>str | None</code>) – Snowflake role to USE after connecting.
+- **warehouse** (<code>str | None</code>) – Snowflake warehouse to USE after connecting.
+- **database** (<code>str | None</code>) – Default database context.
+- **schema** (<code>str | None</code>) – Default schema context.
 
 **Returns:**
 
-- `pd.DataFrame` – The query results.
-
-**Examples:**
-
-```python
-df = fused.api.snowflake_query(
-    "SELECT date, revenue FROM sales WHERE year = 2025",
-    warehouse="COMPUTE_WH",
-    database="ANALYTICS",
-)
-```
+- **A** (<code>[DataFrame](#pandas.DataFrame)</code>) – class:`~pandas.DataFrame` with the query results.
 
 ---
 
-## team_info
+## fused.api.anthropic_connect
 
 ```python
-team_info() -> dict
+anthropic_connect() -> anthropic.Anthropic
 ```
 
-Get information about the current user's team.
+Return an authenticated Anthropic client for Claude model inference.
 
-**Returns:**
-
-- `dict` – Team information including name, members, and settings.
+The API key is read from `fused.secrets["ANTHROPIC_API_KEY"]`.
 
 ---
 
-## upload
+## fused.api.huggingface_connect
 
 ```python
-upload(
-    local_path: str | Path | bytes | BinaryIO | pd.DataFrame | gpd.GeoDataFrame,
-    remote_path: str,
-    timeout: float | None = None,
-) -> None
+huggingface_connect() -> HfApi
 ```
 
-Upload local file to S3.
+Return an authenticated HfApi client for repos, models, and datasets.
+
+The token is read from `fused.secrets["HUGGINGFACE_API_KEY"]`.
+
+---
+
+## fused.api.huggingface_inference
+
+```python
+huggingface_inference() -> InferenceClient
+```
+
+Return an authenticated InferenceClient for model inference.
+
+The token is read from `fused.secrets["HUGGINGFACE_API_KEY"]`.
+
+---
+
+## fused.api.airtable_connect
+
+```python
+airtable_connect(*, base_id: str | None = None) -> FusedAirtableConnection
+```
+
+Create an Airtable connection using Fused-managed OAuth.
 
 **Parameters:**
 
-- **local_path** (`str | Path | bytes | BinaryIO | pd.DataFrame | gpd.GeoDataFrame`) – Either a path to a local file (`str`, `Path`), a (Geo)DataFrame
-  (which will get uploaded as Parquet file), or the contents to upload.
-  Any string will be treated as a Path, if you wish to upload the contents of
-  the string, first encode it: `s.encode("utf-8")`
-- **remote_path** (`str`) – URL to upload to, like `s3://fused-users/fused/aman/new-file.txt`
-- **timeout** (`float | None`) – Optional timeout in seconds for the upload (will default to `OPTIONS.request_timeout` if not specified).
+- **base_id** (<code>str | None</code>) – Default Airtable base ID (e.g. `"appXXXXXXXXXXXXXX"`).
+  When provided, methods that accept a `base_id` parameter will
+  fall back to this value.
 
-**Examples:**
+**Returns:**
 
-To upload a local json file to your Fused home directory in S3:
-
-```py
-fused.api.upload("my_file.json", "s3://fused-users/fused/aman/my_bucket/my_file.json")  # change to your own path
-```
+- **A** (<code>[FusedAirtableConnection](#fused.api._airtable.FusedAirtableConnection)</code>) – class:`FusedAirtableConnection` instance.
 
 ---
 
-## whoami
+## fused.api.airtable_list_records
 
 ```python
-whoami()
+airtable_list_records(table: str, *, base_id: str, **params: Any) -> list[dict]
 ```
 
-Returns information on the currently logged in user
+List records from an Airtable table.
+
+This is a convenience wrapper around
+:meth:`FusedAirtableConnection.list_records`.
+
+**Parameters:**
+
+- **table** (<code>str</code>) – Table name or ID.
+- **base_id** (<code>str</code>) – Airtable base ID.
+- \*\***params** (<code>Any</code>) – Extra query parameters forwarded to the Airtable
+  List Records endpoint (e.g. `maxRecords`, `view`,
+  `filterByFormula`).
+
+**Returns:**
+
+- <code>[list](#fused.api._public_api.list)\[[dict](#dict)\]</code> – A list of record dicts.
+
+---
+
+## fused.api.hubspot_connect
+
+```python
+hubspot_connect()
+```
+
+Create a HubSpot client using Fused-managed OAuth.
+
+Returns an official `hubspot.HubSpot` client instance initialized
+with a short-lived access token. See the hubspot-api-client docs for
+the full API surface.
+
+---
+
+## fused.api.notion_connect
+
+```python
+notion_connect() -> FusedNotionConnection
+```
+
+Create a Notion connection using Fused-managed OAuth.
+
+**Returns:**
+
+- **A** (<code>[FusedNotionConnection](#fused.api._notion.FusedNotionConnection)</code>) – class:`FusedNotionConnection` instance.
 
 ---
 
@@ -823,7 +820,7 @@ api = FusedAPI()
 api.method_name()
 ```
 
-## FusedAPI
+## fused.api.FusedAPI
 
 ```python
 FusedAPI(
@@ -841,44 +838,10 @@ Create a FusedAPI instance.
 
 **Other Parameters:**
 
-- **base_url** (`str | None`) – The Fused instance to send requests to. Defaults to `https://www.fused.io/server/v1`.
-- **shared_udf_base_url** (`str | None`) – The shared UDF instance to send requests to. Defaults to `https://www.udf.ai`.
-- **set_global_api** (`bool`) – Set this as the global API object. Defaults to True.
-- **credentials_needed** (`bool`) – If True, automatically attempt to log in. Defaults to True.
-
----
-
-### auth_token
-
-```python
-auth_token() -> str
-```
-
-Returns the current user's Fused environment (team) auth token
-
-
-**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.auth_token()`
-
----
-
-### cancel_job
-
-```python
-cancel_job(job: CoerceableToJobId) -> RunResponse
-```
-
-Cancel an existing job
-
-**Parameters:**
-
-- **job** (`CoerceableToJobId`) – the identifier of a job or a `RunResponse` object.
-
-**Returns:**
-
-- `RunResponse` – A new job object.
-
-
-**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.cancel_job()`
+- **base_url** (<code>[str](#str) | None</code>) – The Fused instance to send requests to. Defaults to `https://www.fused.io/server/v1`.
+- **shared_udf_base_url** (<code>[str](#str) | None</code>) – The shared UDF instance to send requests to. Defaults to `https://www.udf.ai`.
+- **set_global_api** (<code>[bool](#bool)</code>) – Set this as the global API object. Defaults to True.
+- **credentials_needed** (<code>[bool](#bool)</code>) – If True, automatically attempt to log in. Defaults to True.
 
 ---
 
@@ -908,96 +871,38 @@ The token does not allow running any other UDF on your account.
 
 **Parameters:**
 
-- **udf_email_or_name_or_id** (`str | None`) – A UDF ID, email address (for use with udf_name), or UDF name.
-- **udf_name** (`str | None`) – The name of the UDF to create the token for.
+- **udf_email_or_name_or_id** (<code>str | None</code>) – A UDF ID, email address (for use with udf_name), or UDF name.
+- **udf_name** (<code>str | None</code>) – The name of the UDF to create the token for.
 
 **Other Parameters:**
 
-- **udf_email** (`str | None`) – The email of the user owning the UDF, or, if udf_name is None, the name of the UDF.
-- **udf_id** (`str | None`) – The backend ID of the UDF to create the token for.
-- **client_id** (`str | Ellipsis | None`) – If specified, overrides which realtime environment to run the UDF under.
-- **cache** (`bool`) – If True, UDF tiles will be cached.
-- **metadata_json** (`dict[str, Any] | None`) – Additional metadata to serve as part of the tiles metadata.json.
-- **enabled** (`bool`) – If True, the token can be used.
+- **udf_email** (<code>[str](#str) | None</code>) – The email of the user owning the UDF, or, if udf_name is None, the name of the UDF.
+- **udf_id** (<code>[str](#str) | None</code>) – The backend ID of the UDF to create the token for.
+- **client_id** (<code>[str](#str) | [Ellipsis](#Ellipsis) | None</code>) – If specified, overrides which realtime environment to run the UDF under.
+- **cache** (<code>[bool](#bool)</code>) – If True, UDF tiles will be cached.
+- **metadata_json** (<code>[dict](#dict)\[[str](#str), [Any](#typing.Any)\] | None</code>) – Additional metadata to serve as part of the tiles metadata.json.
+- **enabled** (<code>[bool](#bool)</code>) – If True, the token can be used.
 
 
 **Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.create_udf_access_token()`
 
 ---
 
-### get_jobs
+### upload
 
 ```python
-get_jobs(
-    n: int = 5,
-    *,
-    skip: int = 0,
-    per_request: int = 25,
-    max_requests: int | None = 1
-) -> Jobs
+upload(
+    path: str,
+    data: bytes | BinaryIO,
+    client_id: str | None = None,
+    timeout: float | None = None,
+) -> None
 ```
 
-Get the job history.
-
-**Parameters:**
-
-- **n** (`int`) – The number of jobs to fetch. Defaults to 5.
-
-**Other Parameters:**
-
-- **skip** (`int`) – Where in the job history to begin. Defaults to 0, which retrieves the most recent job.
-- **per_request** (`int`) – Number of jobs per request to fetch. Defaults to 25.
-- **max_requests** (`int | None`) – Maximum number of requests to make. May be None to fetch all jobs. Defaults to 1.
-
-**Returns:**
-
-- `Jobs` – The job history.
+Upload a binary blob to a cloud location
 
 
-**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.get_jobs()`
-
----
-
-### get_logs
-
-```python
-get_logs(job: CoerceableToJobId, since_ms: int | None = None) -> list[Any]
-```
-
-Fetch logs for a job
-
-**Parameters:**
-
-- **job** (`CoerceableToJobId`) – the identifier of a job or a `RunResponse` object.
-- **since_ms** (`int | None`) – Timestamp, in milliseconds since epoch, to get logs for. Defaults to None for all logs.
-
-**Returns:**
-
-- `list[Any]` – Log messages for the given job.
-
-
-**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.get_logs()`
-
----
-
-### get_status
-
-```python
-get_status(job: CoerceableToJobId) -> RunResponse
-```
-
-Fetch the status of a running job
-
-**Parameters:**
-
-- **job** (`CoerceableToJobId`) – the identifier of a job or a `RunResponse` object.
-
-**Returns:**
-
-- `RunResponse` – The status of the given job.
-
-
-**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.get_status()`
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.upload()`
 
 ---
 
@@ -1021,19 +926,95 @@ Execute an operation
 
 **Parameters:**
 
-- **config** (`JobConfig | JobStepConfig`) – the configuration object to run in the job.
+- **config** (<code>JobConfig | JobStepConfig</code>) – the configuration object to run in the job.
 
 **Other Parameters:**
 
-- **instance_type** (`WHITELISTED_INSTANCE_TYPES | None`) – The AWS EC2 instance type to use for the job. Acceptable strings are "m5.large", "m5.xlarge", "m5.2xlarge", "m5.4xlarge", "r5.large", "r5.xlarge", "r5.2xlarge", "r5.4xlarge". Defaults to None.
-- **region** (`str | None`) – The AWS region in which to run. Defaults to None.
-- **disk_size_gb** (`int | None`) – The disk size to specify for the job. Defaults to None.
-- **additional_env** (`Sequence[str] | None`) – Any additional environment variables to be passed into the job, each in the form KEY=value. Defaults to None.
-- **image_name** (`str | None`) – Custom image name to run. Defaults to None for default image.
-- **send_status_email** (`bool | None`) – Whether to send a status email to the user when the job is complete.
+- **instance_type** (<code>[WHITELISTED_INSTANCE_TYPES](#fused.models.request.WHITELISTED_INSTANCE_TYPES) | None</code>) – The AWS EC2 instance type to use for the job. Acceptable strings are "m5.large", "m5.xlarge", "m5.2xlarge", "m5.4xlarge", "r5.large", "r5.xlarge", "r5.2xlarge", "r5.4xlarge". Defaults to None.
+- **region** (<code>[str](#str) | None</code>) – The AWS region in which to run. Defaults to None.
+- **disk_size_gb** (<code>[int](#int) | None</code>) – The disk size to specify for the job. Defaults to None.
+- **additional_env** (<code>[Sequence](#typing.Sequence)\[[str](#str)\] | None</code>) – Any additional environment variables to be passed into the job, each in the form KEY=value. Defaults to None.
+- **image_name** (<code>[str](#str) | None</code>) – Custom image name to run. Defaults to None for default image.
+- **send_status_email** (<code>[bool](#bool) | None</code>) – Whether to send a status email to the user when the job is complete.
 
 
 **Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.start_job()`
+
+---
+
+### get_jobs
+
+```python
+get_jobs(
+    n: int = 5,
+    *,
+    skip: int = 0,
+    per_request: int = 25,
+    max_requests: int | None = 1
+) -> Jobs
+```
+
+Get the job history.
+
+**Parameters:**
+
+- **n** (<code>int</code>) – The number of jobs to fetch. Defaults to 5.
+
+**Other Parameters:**
+
+- **skip** (<code>[int](#int)</code>) – Where in the job history to begin. Defaults to 0, which retrieves the most recent job.
+- **per_request** (<code>[int](#int)</code>) – Number of jobs per request to fetch. Defaults to 25.
+- **max_requests** (<code>[int](#int) | None</code>) – Maximum number of requests to make. May be None to fetch all jobs. Defaults to 1.
+
+**Returns:**
+
+- <code>[Jobs](#fused.models.internal.Jobs)</code> – The job history.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.get_jobs()`
+
+---
+
+### get_status
+
+```python
+get_status(job: CoerceableToJobId) -> RunResponse
+```
+
+Fetch the status of a running job
+
+**Parameters:**
+
+- **job** (<code>CoerceableToJobId</code>) – the identifier of a job or a `RunResponse` object.
+
+**Returns:**
+
+- <code>[RunResponse](#fused.models.internal.RunResponse)</code> – The status of the given job.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.get_status()`
+
+---
+
+### get_logs
+
+```python
+get_logs(job: CoerceableToJobId, since_ms: int | None = None) -> list[Any]
+```
+
+Fetch logs for a job
+
+**Parameters:**
+
+- **job** (<code>CoerceableToJobId</code>) – the identifier of a job or a `RunResponse` object.
+- **since_ms** (<code>int | None</code>) – Timestamp, in milliseconds since epoch, to get logs for. Defaults to None for all logs.
+
+**Returns:**
+
+- <code>[list](#fused.api.api.FusedAPI.list)\[[Any](#typing.Any)\]</code> – Log messages for the given job.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.get_logs()`
 
 ---
 
@@ -1052,31 +1033,13 @@ Continuously print logs for a job
 
 **Parameters:**
 
-- **job** (`CoerceableToJobId`) – the identifier of a job or a `RunResponse` object.
-- **refresh_seconds** (`float`) – how frequently, in seconds, to check for new logs. Defaults to 1.
-- **sample_logs** (`bool`) – if true, print out only a sample of logs. Defaults to False.
-- **timeout** (`float | None`) – if not None, how long to continue tailing logs for. Defaults to None for indefinite.
+- **job** (<code>CoerceableToJobId</code>) – the identifier of a job or a `RunResponse` object.
+- **refresh_seconds** (<code>float</code>) – how frequently, in seconds, to check for new logs. Defaults to 1.
+- **sample_logs** (<code>bool</code>) – if true, print out only a sample of logs. Defaults to False.
+- **timeout** (<code>float | None</code>) – if not None, how long to continue tailing logs for. Defaults to None for indefinite.
 
 
 **Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.tail_logs()`
-
----
-
-### upload
-
-```python
-upload(
-    path: str,
-    data: bytes | BinaryIO,
-    client_id: str | None = None,
-    timeout: float | None = None,
-) -> None
-```
-
-Upload a binary blob to a cloud location
-
-
-**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.upload()`
 
 ---
 
@@ -1094,20 +1057,367 @@ Block the Python kernel until the given job has finished
 
 **Parameters:**
 
-- **job** (`CoerceableToJobId`) – the identifier of a job or a `RunResponse` object.
-- **poll_interval_seconds** (`float`) – How often (in seconds) to poll for status updates. Defaults to 5.
-- **timeout** (`float | None`) – The length of time in seconds to wait for the job. Defaults to None.
+- **job** (<code>CoerceableToJobId</code>) – the identifier of a job or a `RunResponse` object.
+- **poll_interval_seconds** (<code>float</code>) – How often (in seconds) to poll for status updates. Defaults to 5.
+- **timeout** (<code>float | None</code>) – The length of time in seconds to wait for the job. Defaults to None.
 
 **Raises:**
 
-- `TimeoutError` – if waiting for the job timed out.
+- <code>[TimeoutError](#TimeoutError)</code> – if waiting for the job timed out.
 
 **Returns:**
 
-- `RunResponse` – The status of the given job.
+- <code>[RunResponse](#fused.models.internal.RunResponse)</code> – The status of the given job.
 
 
 **Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.wait_for_job()`
+
+---
+
+### cancel_job
+
+```python
+cancel_job(job: CoerceableToJobId) -> RunResponse
+```
+
+Cancel an existing job
+
+**Parameters:**
+
+- **job** (<code>CoerceableToJobId</code>) – the identifier of a job or a `RunResponse` object.
+
+**Returns:**
+
+- <code>[RunResponse](#fused.models.internal.RunResponse)</code> – A new job object.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.cancel_job()`
+
+---
+
+### auth_token
+
+```python
+auth_token() -> str
+```
+
+Returns the current user's Fused environment (team) auth token
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.auth_token()`
+
+---
+
+### get_secret_value
+
+```python
+get_secret_value(key: str, client_id: str | None = None) -> str
+```
+
+Retrieve a secret value from the Fused service.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.get_secret_value()`
+
+---
+
+### set_secret_value
+
+```python
+set_secret_value(key: str, value: str, client_id: str | None = None) -> str
+```
+
+Set a secret value on the Fused service.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.set_secret_value()`
+
+---
+
+### delete_secret_value
+
+```python
+delete_secret_value(key: str, client_id: str | None = None) -> str
+```
+
+Delete a secret value on the Fused service.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.delete_secret_value()`
+
+---
+
+### list_secrets
+
+```python
+list_secrets(client_id: str | None = None) -> Iterable[str]
+```
+
+List available secret values on the Fused service.
+
+This may also be used to retrieve all secrets.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.list_secrets()`
+
+---
+
+### get_user_custom_secret
+
+```python
+get_user_custom_secret(key: str) -> str
+```
+
+Retrieve a user-owned custom secret value.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.get_user_custom_secret()`
+
+---
+
+### list_user_custom_secrets
+
+```python
+list_user_custom_secrets() -> list[str]
+```
+
+List all user-owned custom secret keys.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.list_user_custom_secrets()`
+
+---
+
+### list_cronjobs
+
+```python
+list_cronjobs() -> list[CronJob]
+```
+
+List all cronjobs
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.list_cronjobs()`
+
+---
+
+### create_cronjob
+
+```python
+create_cronjob(cronjob: CronJob) -> CronJob
+```
+
+Create a cronjob
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.create_cronjob()`
+
+---
+
+### update_cronjob
+
+```python
+update_cronjob(cronjob: CronJob) -> CronJob
+```
+
+Update a cronjob
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.update_cronjob()`
+
+---
+
+### delete_cronjob
+
+```python
+delete_cronjob(cronjob_id: str) -> CronJob
+```
+
+Delete a cronjob
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.delete_cronjob()`
+
+---
+
+### get_cronjob
+
+```python
+get_cronjob(cronjob_id: str) -> CronJob
+```
+
+Get a cronjob
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.get_cronjob()`
+
+---
+
+### get_cronjobs_for_udf
+
+```python
+get_cronjobs_for_udf(udf_id: str) -> CronJobSequence
+```
+
+Get cronjob(s) for this given UDF ID
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.get_cronjobs_for_udf()`
+
+---
+
+### run_cronjob
+
+```python
+run_cronjob(cronjob_id: str)
+```
+
+Run a cronjob
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.run_cronjob()`
+
+---
+
+### list_collections
+
+```python
+list_collections(
+    *,
+    whose: Literal["self", "team"] = "self",
+    n: int | None = None,
+    skip: int = 0,
+    per_request: int = 100,
+    lite: bool = True
+) -> list[dict[str, Any]]
+```
+
+List collections in lite form with pagination support.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.list_collections()`
+
+---
+
+### get_collection_by_name
+
+```python
+get_collection_by_name(collection_name: str) -> dict[str, Any]
+```
+
+Get a collection by name for the authenticated user.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.get_collection_by_name()`
+
+---
+
+### get_team_collection_by_name
+
+```python
+get_team_collection_by_name(collection_name: str) -> dict[str, Any]
+```
+
+Get a team collection by name.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.get_team_collection_by_name()`
+
+---
+
+### get_collection_by_id
+
+```python
+get_collection_by_id(collection_id: str) -> Collection
+```
+
+Get a collection by ID for the authenticated user.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.get_collection_by_id()`
+
+---
+
+### create_collection
+
+```python
+create_collection(
+    name: str,
+    *,
+    access_scope: str = "team",
+    allow_public_read: bool | None = None,
+    dashboard_body: str | None = None,
+    passcode: str | None = None
+) -> Collection
+```
+
+Create a collection for the authenticated user.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.create_collection()`
+
+---
+
+### update_collection
+
+```python
+update_collection(
+    collection_id: str,
+    *,
+    name: str,
+    access_scope: str | AccessScope,
+    udfs: list[dict[str, Any]] | None = None,
+    dashboard_body: str | None = None,
+    passcode: str | None = None,
+    preview_image_url: str | None = None
+) -> Collection
+```
+
+Update an existing collection for the authenticated user.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.update_collection()`
+
+---
+
+### delete_collection
+
+```python
+delete_collection(collection_id: str) -> None
+```
+
+Delete an existing collection for the authenticated user.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.delete_collection()`
+
+---
+
+### share_collection
+
+```python
+share_collection(
+    collection_id: str, *, client_id: str | None = None, new_token: bool = False
+) -> Collection
+```
+
+Share a collection and return the updated collection.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.share_collection()`
+
+---
+
+### unshare_collection
+
+```python
+unshare_collection(collection_id: str) -> Collection
+```
+
+Unshare a collection and return the updated collection.
+
+
+**Usage:** `from fused.api import FusedAPI; api = FusedAPI(); api.unshare_collection()`
 
 ---
 
@@ -1115,9 +1425,10 @@ Block the Python kernel until the given job has finished
 
 ## FusedSnowflakeConnection
 
+## fused.api.FusedSnowflakeConnection
+
 ```python
 FusedSnowflakeConnection(
-    *,
     role: str | None = None,
     warehouse: str | None = None,
     database: str | None = None,
@@ -1125,90 +1436,48 @@ FusedSnowflakeConnection(
 )
 ```
 
-Snowflake integration using Fused-managed OAuth tokens. A thin wrapper around `snowflake-connector-python` that exposes high-level helper methods for querying, browsing metadata, reading stages, and writing DataFrames.
+Snowflake integration using Fused-managed OAuth tokens.
 
-Each method call fetches a fresh short-lived token from the Fused server (cached for up to 10 minutes), opens a connection, executes the operation, and closes the connection.
+The connection lazily fetches a short-lived OAuth access token from the Fused
+server and uses `snowflake-connector-python` with `authenticator='oauth'`
+to talk directly to Snowflake.
 
 **Parameters:**
 
-- **role** (`str | None`) – Snowflake role to `USE` after connecting.
-- **warehouse** (`str | None`) – Snowflake warehouse to `USE` after connecting.
-- **database** (`str | None`) – Default database context.
-- **schema** (`str | None`) – Default schema context.
-
-**Examples:**
-
-```python
-from fused.api import FusedSnowflakeConnection
-
-conn = FusedSnowflakeConnection(
-    role="ANALYST",
-    warehouse="COMPUTE_WH",
-    database="MY_DB",
-    schema="PUBLIC",
-)
-```
-
-For setup instructions, see the [Snowflake Integration guide](/workbench/integrations/snowflake).
+- **role** (<code>str | None</code>) – Snowflake role to USE after connecting.
+- **warehouse** (<code>str | None</code>) – Snowflake warehouse to USE after connecting.
+- **database** (<code>str | None</code>) – Default database context.
+- **schema** (<code>str | None</code>) – Default schema context.
 
 ---
 
 ### connect
 
 ```python
-connect(**kwargs) -> snowflake.connector.SnowflakeConnection
+connect(**kwargs: Any) -> snowflake.connector.SnowflakeConnection
 ```
 
-Open a raw `snowflake.connector.SnowflakeConnection` using Fused-managed OAuth tokens. Use this when you need direct cursor access or want to pass the connection to another library.
-
-**Returns:**
-
-- `snowflake.connector.SnowflakeConnection` – A native Snowflake connection object.
+Create a Snowflake connection using OAuth token.
 
 ---
 
 ### query
 
 ```python
-query(sql: str, *args, **kwargs) -> pd.DataFrame
+query(sql: str, *args: str, **kwargs: str) -> pd.DataFrame
 ```
 
-Execute a SQL statement and return the results as a pandas DataFrame.
-
-**Parameters:**
-
-- **sql** (`str`) – The SQL query to execute.
-
-**Returns:**
-
-- `pd.DataFrame` – The query results.
-
-**Examples:**
-
-```python
-df = conn.query("SELECT * FROM customers WHERE active = TRUE")
-```
+Execute SQL and return results as a DataFrame.
 
 ---
 
 ### execute
 
 ```python
-execute(sql: str, *args, **kwargs)
+execute(sql: str, *args: str, **kwargs: str)
 ```
 
-Execute a SQL statement without returning results. Use for DDL or DML.
-
-**Parameters:**
-
-- **sql** (`str`) – The SQL statement to execute.
-
-**Examples:**
-
-```python
-conn.execute("CREATE TABLE IF NOT EXISTS staging.events (id INT, ts TIMESTAMP)")
-conn.execute("INSERT INTO staging.events VALUES (1, CURRENT_TIMESTAMP())")
-```
+Execute SQL without returning results (DDL, DML).
 
 ---
 
@@ -1218,18 +1487,7 @@ conn.execute("INSERT INTO staging.events VALUES (1, CURRENT_TIMESTAMP())")
 list_databases() -> list[str]
 ```
 
-Return all database names visible to the current role (`SHOW DATABASES`).
-
-**Returns:**
-
-- `list[str]` – Database names.
-
-**Examples:**
-
-```python
-databases = conn.list_databases()
-# ['ANALYTICS', 'RAW_DATA', 'STAGING']
-```
+Return a list of database names (`SHOW DATABASES`).
 
 ---
 
@@ -1239,74 +1497,37 @@ databases = conn.list_databases()
 list_schemas(database: str | None = None) -> list[str]
 ```
 
-Return schema names. Optionally scoped to a specific database.
+Return schema names. Optionally scoped to *database*.
 
-**Parameters:**
-
-- **database** (`str | None`) – Database to scope the query to.
-
-**Returns:**
-
-- `list[str]` – Schema names.
-
-**Examples:**
-
-```python
-schemas = conn.list_schemas("ANALYTICS")
-# ['PUBLIC', 'REPORTING', 'TRANSFORMS']
-```
+Note: database is not escaped.
 
 ---
 
 ### list_tables
 
 ```python
-list_tables(database: str | None = None, schema: str | None = None) -> list[str]
+list_tables(
+    database: str | None = None, schema: str | None = None
+) -> list[str]
 ```
 
-Return table names. Optionally scoped to a database and/or schema.
+Return table names. Optionally scoped to *database*/*schema*.
 
-**Parameters:**
-
-- **database** (`str | None`) – Database to scope the query to.
-- **schema** (`str | None`) – Schema to scope the query to.
-
-**Returns:**
-
-- `list[str]` – Table names.
-
-**Examples:**
-
-```python
-tables = conn.list_tables(database="ANALYTICS", schema="PUBLIC")
-# ['CUSTOMERS', 'ORDERS', 'PRODUCTS']
-```
+Note: database and schema are not escaped.
 
 ---
 
 ### list_stages
 
 ```python
-list_stages(database: str | None = None, schema: str | None = None) -> list[str]
+list_stages(
+    database: str | None = None, schema: str | None = None
+) -> list[str]
 ```
 
-Return stage names. Optionally scoped to a database and/or schema.
+Return stage names. Optionally scoped to *database*/*schema*.
 
-**Parameters:**
-
-- **database** (`str | None`) – Database to scope the query to.
-- **schema** (`str | None`) – Schema to scope the query to.
-
-**Returns:**
-
-- `list[str]` – Stage names.
-
-**Examples:**
-
-```python
-stages = conn.list_stages(database="RAW_DATA", schema="INGEST")
-# ['CSV_STAGE', 'PARQUET_STAGE']
-```
+Note: database and schema are not escaped.
 
 ---
 
@@ -1316,25 +1537,14 @@ stages = conn.list_stages(database="RAW_DATA", schema="INGEST")
 list_stage_files(stage: str, pattern: str | None = None) -> list[str]
 ```
 
-List files in a stage (`LIST @stage`). The `@` prefix is added automatically if omitted.
+List files in a stage (`LIST @stage`).
 
 **Parameters:**
 
-- **stage** (`str`) – Stage name or path (e.g. `@RAW_DATA.INGEST.CSV_STAGE`).
-- **pattern** (`str | None`) – Regex pattern to filter results.
+- **stage** (<code>str</code>) – Stage reference, e.g. `"@my_stage"` or `"@db.schema.stage"`.
+- **pattern** (<code>str | None</code>) – Optional SQL LIKE pattern to filter files.
 
-**Returns:**
-
-- `list[str]` – File paths within the stage.
-
-**Examples:**
-
-```python
-files = conn.list_stage_files("@RAW_DATA.INGEST.CSV_STAGE")
-# ['csv_stage/data_2025_01.csv', 'csv_stage/data_2025_02.csv']
-
-parquet_files = conn.list_stage_files("@my_stage", pattern=".*[.]parquet")
-```
+Note: stage and pattern are not escaped.
 
 ---
 
@@ -1344,53 +1554,351 @@ parquet_files = conn.list_stage_files("@my_stage", pattern=".*[.]parquet")
 read_stage(stage_path: str) -> pd.DataFrame
 ```
 
-Read a file from a stage into a DataFrame (`SELECT * FROM @stage/path`). Works for CSV and semi-structured data that Snowflake can auto-detect.
+Read a file from a stage into a DataFrame.
+
+Uses `SELECT $1, $2, ... FROM @stage/path` which works for
+CSV / semi-structured data that Snowflake can auto-detect.
 
 **Parameters:**
 
-- **stage_path** (`str`) – Full stage file path (e.g. `@RAW_DATA.INGEST.CSV_STAGE/data.csv`).
+- **stage_path** (<code>str</code>) – Full stage path, e.g. `"@my_stage/data.csv"`.
 
-**Returns:**
-
-- `pd.DataFrame` – The file contents as a DataFrame.
-
-**Examples:**
-
-```python
-df = conn.read_stage("@RAW_DATA.INGEST.CSV_STAGE/data_2025_01.csv")
-```
+Note: stage_path is not escaped.
 
 ---
 
 ### write
 
 ```python
-write(
-    df: pd.DataFrame,
-    table: str,
-    mode: str = "append",
-    **kwargs,
-) -> None
+write(df: pd.DataFrame, table: str, mode: str = 'append', **kwargs: Any)
 ```
 
-Write a pandas DataFrame to a Snowflake table using `snowflake.connector.pandas_tools.write_pandas`.
+Write a DataFrame to a Snowflake table using `write_pandas`.
 
 **Parameters:**
 
-- **df** (`pd.DataFrame`) – The DataFrame to write.
-- **table** (`str`) – Table name. Can be fully-qualified (`db.schema.tbl`).
-- **mode** (`str`) – `"append"` or `"overwrite"`. Defaults to `"append"`.
-- **\*\*kwargs** – Extra arguments forwarded to `write_pandas`.
-
-**Examples:**
-
-```python
-import pandas as pd
-
-df = pd.DataFrame({"id": [1, 2, 3], "value": [10.5, 20.3, 30.1]})
-
-conn.write(df, "ANALYTICS.PUBLIC.METRICS")
-conn.write(df, "ANALYTICS.PUBLIC.METRICS", mode="overwrite")
-```
+- **df** (<code>pd.DataFrame</code>) – DataFrame to write.
+- **table** (<code>str</code>) – Fully-qualified or simple table name.
+- **mode** (<code>str</code>) – `"append"` (default) or `"overwrite"`.
+- \*\***kwargs** (<code>Any</code>) – Extra keyword arguments forwarded to
+  `snowflake.connector.pandas_tools.write_pandas`.
 
 ---
+
+## Airtable
+
+## FusedAirtableConnection
+
+## fused.api.FusedAirtableConnection
+
+```python
+FusedAirtableConnection(base_id: str | None = None)
+```
+
+Airtable integration using Fused-managed OAuth tokens.
+
+The connection lazily fetches a short-lived OAuth access token from the
+Fused server and uses the Airtable REST API directly.
+
+**Parameters:**
+
+- **base_id** (<code>str | None</code>) – Default Airtable base ID (e.g. `"appXXXXXXXXXXXXXX"`).
+  When provided, methods that accept a `base_id` parameter will
+  fall back to this value.
+
+---
+
+### list_bases
+
+```python
+list_bases() -> list[dict[str, Any]]
+```
+
+Return the list of bases the token has access to.
+
+---
+
+### list_tables
+
+```python
+list_tables(base_id: str | None = None) -> list[dict[str, Any]]
+```
+
+Return the tables in a base.
+
+**Parameters:**
+
+- **base_id** (<code>str | None</code>) – Airtable base ID. Falls back to the default.
+
+---
+
+### list_records
+
+```python
+list_records(
+    table: str, *, base_id: str | None = None, **params: Any
+) -> list[dict[str, Any]]
+```
+
+List records from a table (auto-paginates).
+
+**Parameters:**
+
+- **table** (<code>str</code>) – Table name or ID.
+- **base_id** (<code>str | None</code>) – Airtable base ID. Falls back to the default.
+- \*\***params** (<code>Any</code>) – Extra query parameters forwarded to the Airtable
+  List Records endpoint (e.g. `maxRecords`, `view`,
+  `filterByFormula`).
+
+---
+
+### get_record
+
+```python
+get_record(
+    table: str, record_id: str, *, base_id: str | None = None
+) -> dict[str, Any]
+```
+
+Fetch a single record by ID.
+
+**Parameters:**
+
+- **table** (<code>str</code>) – Table name or ID.
+- **record_id** (<code>str</code>) – Airtable record ID (e.g. `"recXXXXXXXXXXXXXX"`).
+- **base_id** (<code>str | None</code>) – Airtable base ID. Falls back to the default.
+
+---
+
+### create_records
+
+```python
+create_records(
+    table: str, records: list[dict[str, Any]], *, base_id: str | None = None
+) -> list[dict[str, Any]]
+```
+
+Create one or more records.
+
+**Parameters:**
+
+- **table** (<code>str</code>) – Table name or ID.
+- **records** (<code>list\[dict[str, Any]\]</code>) – List of `{"fields": {...}}` dicts.
+- **base_id** (<code>str | None</code>) – Airtable base ID. Falls back to the default.
+
+---
+
+### update_records
+
+```python
+update_records(
+    table: str, records: list[dict[str, Any]], *, base_id: str | None = None
+) -> list[dict[str, Any]]
+```
+
+Update one or more records (PATCH -- partial update).
+
+**Parameters:**
+
+- **table** (<code>str</code>) – Table name or ID.
+- **records** (<code>list\[dict[str, Any]\]</code>) – List of `{"id": "rec...", "fields": {...}}` dicts.
+- **base_id** (<code>str | None</code>) – Airtable base ID. Falls back to the default.
+
+---
+
+### delete_records
+
+```python
+delete_records(
+    table: str, record_ids: list[str], *, base_id: str | None = None
+) -> list[dict[str, Any]]
+```
+
+Delete one or more records by ID.
+
+**Parameters:**
+
+- **table** (<code>str</code>) – Table name or ID.
+- **record_ids** (<code>list[str]</code>) – List of record IDs to delete.
+- **base_id** (<code>str | None</code>) – Airtable base ID. Falls back to the default.
+
+---
+
+## Notion
+
+## FusedNotionConnection
+
+## fused.api.FusedNotionConnection
+
+Notion integration using Fused-managed OAuth tokens.
+
+The connection lazily fetches a short-lived OAuth access token from the
+Fused server and uses the Notion REST API directly.
+
+---
+
+### get_page
+
+```python
+get_page(page_id: str) -> dict[str, Any]
+```
+
+Retrieve a page by ID.
+
+**Parameters:**
+
+- **page_id** (<code>str</code>) – Notion page ID.
+
+---
+
+### create_page
+
+```python
+create_page(
+    parent: dict[str, Any],
+    properties: dict[str, Any],
+    *,
+    children: list[dict[str, Any]] | None = None
+) -> dict[str, Any]
+```
+
+Create a new page.
+
+**Parameters:**
+
+- **parent** (<code>dict[str, Any]</code>) – Parent object, e.g. `{"page_id": "..."}` or
+  `{"database_id": "..."}`.
+- **properties** (<code>dict[str, Any]</code>) – Page properties matching the parent schema.
+- **children** (<code>list\[dict[str, Any]\] | None</code>) – Optional list of block objects for the page body.
+
+---
+
+### update_page
+
+```python
+update_page(
+    page_id: str,
+    *,
+    properties: dict[str, Any] | None = None,
+    in_trash: bool | None = None
+) -> dict[str, Any]
+```
+
+Update a page's properties or trash/restore it.
+
+**Parameters:**
+
+- **page_id** (<code>str</code>) – Notion page ID.
+- **properties** (<code>dict[str, Any] | None</code>) – Property values to update.
+- **in_trash** (<code>bool | None</code>) – Set `True` to move to trash, `False` to restore.
+
+---
+
+### delete_page
+
+```python
+delete_page(page_id: str) -> dict[str, Any]
+```
+
+Move a page to the trash.
+
+Notion does not support permanent deletion via the API.
+
+**Parameters:**
+
+- **page_id** (<code>str</code>) – Notion page ID.
+
+---
+
+### list_comments
+
+```python
+list_comments(block_id: str, *, page_size: int = 100) -> list[dict[str, Any]]
+```
+
+List comments on a block or page (auto-paginates).
+
+**Parameters:**
+
+- **block_id** (<code>str</code>) – The block or page ID to list comments for.
+- **page_size** (<code>int</code>) – Number of results per request (max 100).
+
+---
+
+### create_comment
+
+```python
+create_comment(
+    rich_text: list[dict[str, Any]],
+    *,
+    parent_id: str | None = None,
+    discussion_id: str | None = None
+) -> dict[str, Any]
+```
+
+Create a comment on a page or as a reply in a discussion.
+
+Provide exactly one of `parent_id` (top-level comment on a page)
+or `discussion_id` (reply to an existing discussion thread).
+
+**Parameters:**
+
+- **rich_text** (<code>list\[dict[str, Any]\]</code>) – List of rich text objects for the comment body.
+- **parent_id** (<code>str | None</code>) – Page ID for a new top-level comment.
+- **discussion_id** (<code>str | None</code>) – Discussion ID to reply to.
+
+---
+
+### list_users
+
+```python
+list_users(*, _page_size: int = 100) -> list[dict[str, Any]]
+```
+
+List all users in the workspace (auto-paginates).
+
+**Parameters:**
+
+- **page_size** – Number of results per request (max 100).
+
+---
+
+### get_user
+
+```python
+get_user(user_id: str) -> dict[str, Any]
+```
+
+Retrieve a user by ID.
+
+**Parameters:**
+
+- **user_id** (<code>str</code>) – Notion user ID.
+
+---
+
+### search
+
+```python
+search(
+    query: str | None = None,
+    *,
+    filter: dict[str, Any] | None = None,
+    sort: dict[str, Any] | None = None,
+    _page_size: int = 100
+) -> list[dict[str, Any]]
+```
+
+Search pages and databases by title (auto-paginates).
+
+**Parameters:**
+
+- **query** (<code>str | None</code>) – Text to search for in page/database titles.
+- **filter** (<code>dict[str, Any] | None</code>) – Optional filter object, e.g.
+  `{"value": "page", "property": "object"}`.
+- **sort** (<code>dict[str, Any] | None</code>) – Optional sort object, e.g.
+  `{"direction": "descending", "timestamp": "last_edited_time"}`.
+- **\_page_size** (<code>int</code>) – Number of results per request (max 100).
+
+---
+

--- a/docs/python-sdk/api-reference/h3.mdx
+++ b/docs/python-sdk/api-reference/h3.mdx
@@ -5,237 +5,7 @@ toc_max_heading_level: 5
 sidebar_position: 3
 ---
 
-The `fused.h3` module provides functions for working with H3-indexed datasets, including ingestion, reading, and metadata management.
-
-```python
-import fused
-
-# Ingest raster data to H3
-fused.h3.run_ingest_raster_to_h3(input_path="s3://...", output_path="s3://...")
-
-# Read H3-indexed data
-table = fused.h3.read_hex_table(...)
-```
-
----
-
-## persist_hex_table_metadata
-
-```python
-persist_hex_table_metadata(
-    dataset_path: str,
-    output_path: str | None = None,
-    metadata_path: str | None = None,
-    verbose: bool = False,
-    row_group_size: int = 500,
-    indexed_columns: list[str] | None = None,
-    pool_size: int = 10,
-    metadata_compression_level: int | None = None,
-) -> str
-```
-
-Persist metadata for a hex table to enable serverless queries.
-
-Scans all parquet files in the dataset, extracts metadata needed for fast reconstruction, and writes one `.metadata.parquet` file per source file.
-
-Each metadata file contains:
-- Row group metadata (offsets, H3 ranges, etc.)
-- Full metadata_json stored as custom metadata in the parquet schema
-
-Requires a `hex` column (or variant like `h3`, `h3_index`) in all files.
-Raises ValueError if no hex column is found.
-
-**Parameters:**
-
-- **dataset_path** (`str`) – Path to the dataset directory (e.g., `"s3://bucket/dataset/"`)
-- **output_path** (`str | None`) – Deprecated; use `metadata_path` instead.
-- **metadata_path** (`str | None`) – Where to write metadata files. If None, writes to `{source_dir}/.fused/{source_filename}.metadata.parquet` per source file. If provided, writes to `{metadata_path}/{full_source_path}.metadata.parquet` (allows storing metadata elsewhere when you don't have write access to the dataset directory).
-- **verbose** (`bool`) – If True, print timing/progress information.
-- **row_group_size** (`int`) – Rows per row group in output. Default 500.
-- **indexed_columns** (`list[str] | None`) – Column names to index. If None, indexes only the first identified indexed column; if `[]`, indexes all detected indexed columns.
-- **pool_size** (`int`) – Parallel workers. Default 10; set to 1 for sequential.
-- **metadata_compression_level** (`int | None`) – Optional zstd compression level for metadata parquet files (e.g. 1–22).
-
-**Returns:**
-
-- `str` – Path to metadata directory (if `metadata_path` provided) or first metadata file path.
-
-**Raises:** 
-- `ImportError` (job2 required)
-- `ValueError` (no hex column)
-- `FileNotFoundError` (no parquet files).
-
-**Example:**
-
-```python
->>> fused.h3.persist_hex_table_metadata("s3://my-bucket/my-dataset/")
-'s3://my-bucket/my-dataset/.fused/file1.metadata.parquet'
->>> fused.h3.persist_hex_table_metadata("s3://my-bucket/my-dataset/", metadata_path="s3://my-bucket/metadata/")
-'s3://my-bucket/metadata/'
->>> fused.h3.persist_hex_table_metadata("s3://my-bucket/my-dataset/", pool_size=4)
-'s3://my-bucket/my-dataset/.fused/file1.metadata.parquet'
-```
-
----
-
-## read_hex_table
-
-```python
-read_hex_table(
-    dataset_path: str,
-    hex_ranges_list: list[list[int]],
-    columns: list[str] | None = None,
-    base_url: str | None = None,
-    verbose: bool = False,
-    return_timing_info: bool = False,
-    batch_size: int | None = None,
-    max_concurrent_downloads: int | None = None,
-) -> pa.Table | tuple[pa.Table, dict[str, Any]]
-```
-
-Read data from an H3-indexed dataset by querying hex ranges.
-
-This is an optimized version that assumes the server always provides full metadata (start_offset, end_offset, metadata, and row_group_bytes) for all row groups. If any row group is missing required metadata, this function will raise an error indicating that the dataset needs to be re-indexed.
-
-This function eliminates all metadata API calls by using prefetched metadata from the /datasets/items-with-metadata endpoint.
-
-**Parameters:**
-
-- **dataset_path** (`str`) – Path to the H3-indexed dataset (e.g., "s3://bucket/dataset/")
-- **hex_ranges_list** (`list[list[int]]`) – List of [min_hex, max_hex] pairs as integers. Example: [[622236719905341439, 622246719905341439]]
-- **columns** (`list[str] | None`) – Optional list of column names to read. If None, reads all columns.
-- **base_url** (`str | None`) – Base URL for API. If None, uses current environment.
-- **verbose** (`bool`) – If True, print progress information. Default is False.
-- **return_timing_info** (`bool`) – If True, return a tuple of (table, timing_info) instead of just the table. Default is False for backward compatibility.
-- **batch_size** (`int | None`) – Target size in bytes for combining row groups. If None, uses `fused.options.row_group_batch_size` (default: 32KB).
-- **max_concurrent_downloads** (`int | None`) – Maximum number of simultaneous download operations. If None, uses a default based on the number of files. Default is None.
-
-**Returns:**
-
-- PyArrow Table containing the concatenated data from all matching row groups. If return_timing_info is True, returns a tuple of (table, timing_info dict).
-
-**Raises:** ValueError: If any row group is missing required metadata (start_offset, end_offset, metadata, or row_group_bytes). This indicates the dataset needs to be re-indexed.
-
-**Example:**
-
-```python
-import fused
-
-# Read data for a specific H3 hex range
-table = fused.h3.read_hex_table(
-    dataset_path="s3://my-bucket/my-h3-dataset/",
-    hex_ranges_list=[[622236719905341439, 622246719905341439]]
-)
-df = table.to_pandas()
-```
-
----
-
-## read_hex_table_slow
-
-```python
-read_hex_table_slow(
-    dataset_path: str,
-    hex_ranges_list: list[list[int]],
-    columns: list[str] | None = None,
-    base_url: str | None = None,
-    verbose: bool = False,
-    return_timing_info: bool = False,
-    metadata_batch_size: int = 50,
-) -> pa.Table | tuple[pa.Table, dict[str, Any]]
-```
-
-Read data from an H3-indexed dataset by querying hex ranges.
-
-This function queries the dataset index for row groups that match the given H3 hex ranges, downloads them in parallel with optimized batching, and returns a concatenated table.
-
-Adjacent row groups from the same file are combined into single downloads for better S3 performance. The batch size is controlled by `fused.options.row_group_batch_size` (default: 32KB).
-
-**Parameters:**
-
-- **dataset_path** (`str`) – Path to the H3-indexed dataset (e.g., "s3://bucket/dataset/")
-- **hex_ranges_list** (`list[list[int]]`) – List of [min_hex, max_hex] pairs as integers. Example: [[622236719905341439, 622246719905341439]]
-- **columns** (`list[str] | None`) – Optional list of column names to read. If None, reads all columns.
-- **base_url** (`str | None`) – Base URL for API. If None, uses current environment.
-- **verbose** (`bool`) – If True, print progress information. Default is False.
-- **return_timing_info** (`bool`) – If True, return a tuple of (table, timing_info) instead of just the table. Default is False for backward compatibility.
-- **metadata_batch_size** (`int`) – Maximum number of row group metadata requests to batch together in a single API call. Larger batches reduce API overhead. Default is 50. Consider MongoDB's 16KB document limit when adjusting this value.
-
-**Returns:**
-
-- PyArrow Table containing the concatenated data from all matching row groups. If return_timing_info is True, returns a tuple of (table, timing_info dict).
-
-**Example:**
-
-```python
-import fused
-
-# Read data for a specific H3 hex range
-table = fused.h3.read_hex_table_slow(
-    dataset_path="s3://my-bucket/my-h3-dataset/",
-    hex_ranges_list=[[622236719905341439, 622246719905341439]]
-)
-df = table.to_pandas()
-```
-
----
-
-## read_hex_table_with_persisted_metadata
-
-```python
-read_hex_table_with_persisted_metadata(
-    dataset_path: str,
-    hex_ranges_list: list[list[int]],
-    columns: list[str] | None = None,
-    metadata_path: str | None = None,
-    verbose: bool = False,
-    return_timing_info: bool = False,
-    batch_size: int | None = None,
-    max_concurrent_downloads: int | None = None,
-    max_concurrent_metadata_reads: int | None = None,
-) -> pa.Table | tuple[pa.Table, dict[str, Any]]
-```
-
-Read data from an H3-indexed dataset using persisted metadata parquet files (no server).
-
-Reads from per-file `.metadata.parquet` files instead of querying a server. Metadata location: `{source_dir}/.fused/{source_filename}.metadata.parquet`, or when `metadata_path` is provided, `{metadata_path}/{full_source_path}.metadata.parquet`. Supports subdirectory queries: if `dataset_path` is a subdirectory, metadata is looked up for files in that subdirectory.
-
-**Parameters:**
-
-- **dataset_path** (`str`) – Path to the H3-indexed dataset (e.g., `"s3://bucket/dataset/"`) or a subdirectory for filtering.
-- **hex_ranges_list** (`list[list[int]]`) – List of [min_hex, max_hex] pairs as integers.
-- **columns** (`list[str] | None`) – Columns to read. If None, reads all.
-- **metadata_path** (`str | None`) – Where metadata files are stored. If None, uses `{source_dir}/.fused/` per source file; if provided, reads from this location using full source paths (e.g. when you don't have access to the dataset directory).
-- **verbose** (`bool`) – If True, print progress. Default False.
-- **return_timing_info** (`bool`) – If True, return (table, timing_info) instead of just the table.
-- **batch_size** (`int | None`) – Target size in bytes for combining row groups. If None, uses `fused.options.row_group_batch_size`.
-- **max_concurrent_downloads** (`int | None`) – Max simultaneous downloads. If None, default based on number of files.
-- **max_concurrent_metadata_reads** (`int | None`) – Max simultaneous metadata file reads. If None, defaults to `min(10, len(source_files))`.
-
-**Returns:**
-
-- `pa.Table` – PyArrow Table (or (table, timing_info) if `return_timing_info`).
-
-**Raises:** `FileNotFoundError` (metadata file not found), `ValueError` (row group missing required metadata).
-
-**Example:**
-
-```python
-import fused
-
-# First, persist metadata
-fused.h3.persist_hex_table_metadata("s3://my-bucket/my-dataset/")
-
-# Then read using persisted metadata (no server needed)
-table = fused.h3.read_hex_table_with_persisted_metadata(
-    dataset_path="s3://my-bucket/my-dataset/",
-    hex_ranges_list=[[622236719905341439, 622246719905341439]]
-)
-```
-
----
-
-## run_ingest_raster_to_h3
+## fused.h3.run_ingest_raster_to_h3
 
 ```python
 run_ingest_raster_to_h3(
@@ -258,77 +28,438 @@ run_ingest_raster_to_h3(
     tmp_path: str | None = None,
     overwrite: bool = False,
     steps: list[str] | None = None,
-    extract_instance_type: str | None = None,
+    extract_engine: str | None = None,
     extract_max_workers: int = 256,
-    partition_instance_type: str | None = None,
+    partition_engine: str | None = None,
     partition_max_workers: int = 256,
-    overview_instance_type: str | None = None,
+    overview_engine: str | None = None,
     overview_max_workers: int = 256,
-    **kwargs,
+    **kwargs: int
 )
 ```
 
 Run the raster to H3 ingestion process.
 
 This process involves multiple steps:
+
 - extract pixels values and assign to H3 cells in chunks (extract step)
 - combine the chunks per partition (file) and prepare metadata (partition step)
 - create the metadata `_sample` file and overviews files
 
 **Parameters:**
 
-- **input_path** (`str | list[str]`) – Path(s) to the input raster data. When a single path, the file is chunked for processing based on `target_chunk_size`. When a list of paths, each file is processed as one chunk.
-- **output_path** (`str`) – Path for the resulting Parquet dataset.
-- **metrics** (`str | list[str]`) – The metrics to compute per H3 cell. Supported: `"cnt"` or a list containing any of `"avg"`, `"min"`, `"max"`, `"stddev"`, `"mode"` (most common value), and `"sum"`.
-- **res** (`int | None`) – The resolution of the H3 cells in the output data. Pixel values are assigned to H3 cells at resolution `res + res_offset` and then aggregated to `res`. By default, inferred from the input data so H3 cell size is close to pixel size (e.g. 30×30m raster → resolution 11).
-- **k_ring** (`int`) – The k-ring distance at resolution `res + res_offset` to which the pixel value is assigned (in addition to the center cell). Defaults to 1.
-- **res_offset** (`int`) – Offset to child resolution (relative to `res`) at which to assign the raw pixel values to H3 cells.
-- **file_res** (`int | None`) – The H3 resolution to chunk the resulting files of the Parquet dataset. By default inferred from `res`. Use `file_res=-1` for a single output file.
-- **chunk_res** (`int | None`) – The H3 resolution to chunk the row groups within each file (ignored when `max_rows_per_chunk` is specified). By default inferred from `res`.
-- **overview_res** (`list[int] | None`) – The H3 resolutions for which to create overview files. By default, resolutions 3 to 7 (or capped at a lower value if output `res` is lower).
-- **overview_chunk_res** (`int | list[int] | None`) – The H3 resolution(s) to chunk the row groups within each overview file. By default, each overview file is chunked at overview resolution minus 5 (clamped between 0 and output `res`).
-- **max_rows_per_chunk** (`int`) – Maximum number of rows per chunk in the resulting data and overview files. If 0 (default), `chunk_res` and `overview_chunk_res` are used.
-- **include_source_url** (`bool`) – If True, include a `"source_url"` column in the output with the list of source URLs that contributed data to each H3 cell. Defaults to True.
-- **target_chunk_size** (`int | None`) – Approximate number of pixel values to process per chunk in the extract step. Defaults to 10,000,000 for a single file or a few files. If ingesting more than 20 files, each file is processed as a single chunk by default; override with a specific value or `target_chunk_size=0` to always process each file as one chunk.
-- **nodata** (`int | float | None`) – By default, the "nodata" value from the raster metadata is used to ignore pixels when ingesting. If missing or wrong in the raster metadata, override with this keyword.
-- **debug_mode** (`bool`) – If True, run only the first two chunks for debugging. Defaults to False.
-- **remove_tmp_files** (`bool`) – If True, remove temporary files after ingestion. Defaults to True.
-- **tmp_path** (`str | None`) – Optional path for temporary files. If specified, the extract step is skipped and temporary files are assumed to already exist at this path.
-- **overwrite** (`bool`) – If True, overwrite the output path if it already exists (by first removing existing content). Defaults to False.
-- **steps** (`list[str] | None`) – The processing steps to run. Can include `"extract"`, `"partition"`, `"metadata"`, and `"overview"`. By default, all steps run.
-- **extract_instance_type** (`str | None`) – Instance type for the extract step. By default, tries "realtime" then falls back to "large".
-- **extract_max_workers** (`int`) – Maximum number of workers for the extract step. Defaults to 256.
-- **partition_instance_type** (`str | None`) – Instance type for the partition step. By default, tries "realtime" then falls back to "large".
-- **partition_max_workers** (`int`) – Maximum number of workers for the partition step. Defaults to 256.
-- **overview_instance_type** (`str | None`) – Instance type for the overview step. By default, tries "realtime" then falls back to "large".
-- **overview_max_workers** (`int`) – Maximum number of workers for the overview step. Defaults to 256.
-- **\*\*kwargs** – Additional keyword arguments for `fused.submit` for the extract, partition, and overview steps (e.g. `engine`, `instance_type`, `max_workers`, `n_processes_per_worker`, `max_retry`). To run locally: `run_ingest_raster_to_h3(..., engine="local")`.
+- **input_path** (<code>str, list</code>) – Path(s) to the input raster data.
+  When this is a single path, the file is chunked up for processing
+  based on `target_chunk_size`. When this is a list of paths, each
+  file is processed as one chunk.
+- **output_path** (<code>str</code>) – Path for the resulting Parquet dataset.
+- **metrics** (<code>str or list of str</code>) – The metrics to compute per H3 cell.
+  Supported metrics are either "cnt" or a list containing any of
+  "avg", "min", "max", "stddev", "mode" (i.e. most common value),
+  and "sum".
+- **res** (<code>int</code>) – The resolution of the H3 cells in the output data.
+  The pixel values are assigned to H3 cells at resolution
+  `res + res_offset` and then aggregated to `res`.
+  By default, this is inferred based on the resolution of the
+  input data ensuring the H3 cell size is close to the pixel size
+  (e.g. for a raster with pixel size of 30x30m, a resolution of 11
+  is inferred).
+- **k_ring** (<code>int</code>) – The k-ring distance at resolution `res + res_offset`
+  to which the pixel value is assigned (in addition to the center
+  cell). Defaults to 1.
+- **res_offset** (<code>int</code>) – Offset to child resolution (relative to `res`) at
+  which to assign the raw pixel values to H3 cells.
+- **file_res** (<code>int</code>) – The H3 resolution to chunk the resulting files of the
+  Parquet dataset. By default will be inferred based on the target
+  resolution `res`. You can specify `file_res=-1` to have a single
+  output file.
+- **chunk_res** (<code>int</code>) – The H3 resolution to chunk the row groups within
+  each file of the Parquet dataset (ignored when `max_rows_per_chunk`
+  is specified). By default will be inferred based on the target
+  resolution `res`.
+- **overview_res** (<code>list of int</code>) – The H3 resolutions for which to create
+  overview files. By default, overviews are created for resolutions 3
+  to 7 (or capped at a lower value if the `res` of the output dataset
+  is lower).
+- **overview_chunk_res** (<code>int or list of int</code>) – The H3 resolution(s) to chunk
+  the row groups within each overview file of the Parquet dataset. By
+  default, each overview file is chunked at the overview resolution
+  minus 5 (clamped between 0 and the `res` of the output dataset).
+- **max_rows_per_chunk** (<code>int</code>) – The maximum number of rows per chunk in the
+  resulting data and overview files. If 0 (the default), `chunk_res`
+  and `overview_chunk_res` are used to determine the chunking.
+- **include_source_url** (<code>bool</code>) – If True, include a `"source_url"` column in
+  the output dataset that contains a list of source URLs that
+  contributed data to each H3 cell. Defaults to True, set to False
+  to omit this column.
+- **target_chunk_size** (<code>int</code>) – The approximate number of pixel values to
+  process per chunk in the first "extract" step. Defaults to
+  10,000,000 for ingesting a single file or a few files. If ingesting
+  more than 20 files, each file is processed as a single chunk by
+  default, but you can override this by specifying a specific
+  `target_chunk_size` value, or by specifying `target_chunk_size=0` to
+  always process each file as a single chunk.
+- **nodata** (<code>int or float</code>) – By default, the "nodata" value indicated in the
+  raster metadata will be used to ignore pixels with this value when
+  ingesting the data. If this information is missing or wrong in the
+  raster metadata, you can override the value by specifying this
+  keyword.
+- **debug_mode** (<code>bool</code>) – If True, run only the first two chunks for
+  debugging purposes. Defaults to False.
+- **remove_tmp_files** (<code>bool</code>) – If True, remove the temporary files after
+  ingestion is complete. Defaults to True.
+- **tmp_path** (<code>str</code>) – Optional path to use for the temporary files.
+  If specified, the extract step is skipped and it is assumed that
+  the temporary files are already present at this path.
+- **overwrite** (<code>bool</code>) – If True, overwrite the output path if it already
+  exists, by first removing the existing content before writing the
+  new files. Defaults to False, in which case an error is raised if
+  the `output_path` is not empty.
+- **steps** (<code>list of str</code>) – The processing steps to run. Can include
+  "extract", "partition", "metadata", and "overview". By default, all
+  steps are run.
+- **extract_engine** (<code>str</code>) – The engine to use for the extract step.
+  By default, tries first with "realtime" and then falls back to "large".
+- **extract_max_workers** (<code>int</code>) – The maximum number of workers to use for the extract step.
+  Defaults to 256.
+- **partition_engine** (<code>str</code>) – The engine to use for the partition step.
+  By default, tries first with "realtime" and then falls back to "large".
+- **partition_max_workers** (<code>int</code>) – The maximum number of workers to use for the partition step.
+  Defaults to 256.
+- **overview_engine** (<code>str</code>) – The engine to use for the overview step.
+  By default, tries first with "realtime" and then falls back to "large".
+- **overview_max_workers** (<code>int</code>) – The maximum number of workers to use for the overview step.
+  Defaults to 256.
 
 The extract, partition and overview steps are run in parallel using
-`fused.submit()`. By default, the function will first attempt to run this using
+[`fused.submit()`](/python-sdk/top-level-functions/#fusedsubmit). By default, the function will first attempt to run this using
 "realtime" instances, and retry any failed runs using "large" instances.
 
-You can override this behavior by specifying the `engine`, `instance_type`,
-`max_workers`, `n_processes_per_worker`, etc parameters as additional
+You can override this behavior by specifying the `engine`, `max_workers`,
+`worker_concurrency`, etc parameters as additional
 keyword arguments to this function (`**kwargs`). If you want to specify
-those per step, use `extract_instance_type`, `partition_instance_type`, etc.
+those per step, use `extract_engine`, `partition_engine`, etc.
 For example, to run everything locally on the same machine where this
 function runs, use:
 
-    run_ingest_raster_to_h3(..., engine="local")
+```
+run_ingest_raster_to_h3(..., engine="local")
+```
 
 ---
 
-## run_partition_to_h3
+## fused.h3.persist_hex_table_metadata
+
+```python
+persist_hex_table_metadata(
+    dataset_path: str,
+    output_path: str | None = None,
+    metadata_path: str | None = None,
+    verbose: bool = False,
+    row_group_size: int = 500,
+    indexed_columns: list[str] | None = None,
+    pool_size: int = 10,
+    metadata_compression_level: int | None = None,
+) -> str
+```
+
+Persist metadata for a hex table to enable serverless queries.
+
+Scans all parquet files in the dataset, extracts metadata needed for
+fast reconstruction, and writes one .metadata.parquet file per source file.
+
+Each metadata file contains:
+
+- Row group metadata (offsets, H3 ranges, etc.)
+- Full metadata_json stored as custom metadata in the parquet schema
+
+Requires a 'hex' column (or variant like h3, h3_index) in all files.
+Raises ValueError if no hex column is found.
+
+**Parameters:**
+
+- **dataset_path** (<code>str</code>) – Path to the dataset directory (e.g., "s3://bucket/dataset/")
+- **output_path** (<code>str | None</code>) – Deprecated - use metadata_path instead
+- **metadata_path** (<code>str | None</code>) – Directory path where metadata files should be written.
+  If None, writes to {source_dir}/.fused/{source_filename}.metadata.parquet
+  for each source file. If provided, writes to
+  {metadata_path}/{full_source_path}.metadata.parquet using the full
+  source path as the filename. This allows storing metadata in a
+  different location when you don't have write access to the dataset directory.
+- **verbose** (<code>bool</code>) – If True, print timing/progress information.
+- **row_group_size** (<code>int</code>) – Number of rows per row group in output parquet file.
+  Default is 500. Larger values reduce file size but may
+  increase memory usage during writes.
+- **indexed_columns** (<code>list[str] | None</code>) – List of column names to index. If None (default),
+  indexes only the first identified indexed column
+  (typically the hex column). If an empty list, indexes
+  all detected indexed columns.
+- **pool_size** (<code>int</code>) – Number of parallel workers to use for processing files.
+  Default is 10 (parallel processing enabled by default).
+  Set to 1 for sequential processing. This can significantly speed up
+  metadata extraction for large datasets with many files.
+- **metadata_compression_level** (<code>int | None</code>) – Optional zstd compression level for metadata
+  parquet files. If None, uses PyArrow's default for zstd. Valid
+  levels are typically in the range [1, 22].
+
+**Returns:**
+
+- <code>[str](#str)</code> – Path to metadata directory (if metadata_path provided) or first metadata file path
+
+**Raises:**
+
+- <code>[ImportError](#ImportError)</code> – If job2 package is not available
+- <code>[ValueError](#ValueError)</code> – If no hex column is found in any file
+- <code>[FileNotFoundError](#FileNotFoundError)</code> – If no parquet files are found in the dataset
+
+<details class="example" open>
+<summary>Example</summary>
+>>> fused.h3.persist_hex_table_metadata("s3://my-bucket/my-dataset/")
+'s3://my-bucket/my-dataset/.fused/file1.metadata.parquet'
+>>> fused.h3.persist_hex_table_metadata("s3://my-bucket/my-dataset/", metadata_path="s3://my-bucket/metadata/")
+'s3://my-bucket/metadata/'
+>>> fused.h3.persist_hex_table_metadata("s3://my-bucket/my-dataset/", pool_size=4)
+'s3://my-bucket/my-dataset/.fused/file1.metadata.parquet'
+</details>
+
+---
+
+## fused.h3.read_hex_table
+
+```python
+read_hex_table(
+    dataset_path: str,
+    hex_ranges_list: List[List[int]],
+    columns: Optional[List[str]] = None,
+    base_url: Optional[str] = None,
+    verbose: bool = False,
+    return_timing_info: bool = False,
+    batch_size: Optional[int] = None,
+    max_concurrent_downloads: Optional[int] = None,
+) -> "pa.Table" | tuple["pa.Table", Dict[str, Any]]
+```
+
+Read data from an H3-indexed dataset by querying hex ranges.
+
+This is an optimized version that assumes the server always provides full metadata
+(start_offset, end_offset, metadata, and row_group_bytes) for all row groups.
+If any row group is missing required metadata, this function will raise an error
+indicating that the dataset needs to be re-indexed.
+
+This function eliminates all metadata API calls by using prefetched metadata from
+the /datasets/items-with-metadata endpoint.
+
+This function imports the implementation from job2 at runtime,
+similar to how read_parquet_row_group works.
+
+**Parameters:**
+
+- **dataset_path** (<code>str</code>) – Path to the H3-indexed dataset (e.g., "s3://bucket/dataset/")
+- **hex_ranges_list** (<code>List\[List[int]\]</code>) – List of [min_hex, max_hex] pairs as integers.
+  Example: \[[622236719905341439, 622246719905341439]\]
+- **columns** (<code>Optional\[List[str]\]</code>) – Optional list of column names to read. If None, reads all columns.
+- **base_url** (<code>Optional[str]</code>) – Base URL for API. If None, uses current environment.
+- **verbose** (<code>bool</code>) – If True, print progress information. Default is False.
+- **return_timing_info** (<code>bool</code>) – If True, return a tuple of (table, timing_info) instead of just the table.
+  Default is False for backward compatibility.
+- **batch_size** (<code>Optional[int]</code>) – Target size in bytes for combining row groups. If None, uses
+  `fused.options.row_group_batch_size` (default: 32KB).
+- **max_concurrent_downloads** (<code>Optional[int]</code>) – Maximum number of simultaneous download operations. If None,
+  uses a default based on the number of files. Default is None.
+
+**Returns:**
+
+- <code>'pa.Table' | [tuple](#tuple)\['pa.Table', [Dict](#typing.Dict)\[[str](#str), [Any](#typing.Any)\]\]</code> – PyArrow Table containing the concatenated data from all matching row groups.
+- <code>'pa.Table' | [tuple](#tuple)\['pa.Table', [Dict](#typing.Dict)\[[str](#str), [Any](#typing.Any)\]\]</code> – If return_timing_info is True, returns a tuple of (table, timing_info dict).
+
+**Raises:**
+
+- <code>[ValueError](#ValueError)</code> – If any row group is missing required metadata (start_offset, end_offset,
+  metadata, or row_group_bytes). This indicates the dataset needs to be re-indexed.
+
+<details class="example" open>
+<summary>Example</summary>
+import fused
+
+# Read data for a specific H3 hex range
+
+table = fused.h3.read_hex_table(
+dataset_path="s3://my-bucket/my-h3-dataset/",
+hex_ranges_list=\[[622236719905341439, 622246719905341439]\]
+)
+df = table.to_pandas()
+
+</details>
+
+---
+
+## fused.h3.read_hex_table_slow
+
+```python
+read_hex_table_slow(
+    dataset_path: str,
+    hex_ranges_list: List[List[int]],
+    columns: Optional[List[str]] = None,
+    base_url: Optional[str] = None,
+    verbose: bool = False,
+    return_timing_info: bool = False,
+    metadata_batch_size: int = 50,
+) -> "pa.Table" | tuple["pa.Table", Dict[str, Any]]
+```
+
+Read data from an H3-indexed dataset by querying hex ranges.
+
+This function queries the dataset index for row groups that match the given
+H3 hex ranges, downloads them in parallel with optimized batching, and returns
+a concatenated table.
+
+Adjacent row groups from the same file are combined into single downloads
+for better S3 performance. The batch size is controlled by
+`fused.options.row_group_batch_size` (default: 32KB).
+
+**Parameters:**
+
+- **dataset_path** (<code>str</code>) – Path to the H3-indexed dataset (e.g., "s3://bucket/dataset/")
+- **hex_ranges_list** (<code>List\[List[int]\]</code>) – List of [min_hex, max_hex] pairs as integers.
+  Example: \[[622236719905341439, 622246719905341439]\]
+- **columns** (<code>Optional\[List[str]\]</code>) – Optional list of column names to read. If None, reads all columns.
+- **base_url** (<code>Optional[str]</code>) – Base URL for API. If None, uses current environment.
+- **verbose** (<code>bool</code>) – If True, print progress information. Default is False.
+- **return_timing_info** (<code>bool</code>) – If True, return a tuple of (table, timing_info) instead of just the table.
+  Default is False for backward compatibility.
+- **metadata_batch_size** (<code>int</code>) – Maximum number of row group metadata requests to batch together
+  in a single API call. Larger batches reduce API overhead. Default is 50.
+  Consider MongoDB's 16KB document limit when adjusting this value.
+
+**Returns:**
+
+- <code>'pa.Table' | [tuple](#tuple)\['pa.Table', [Dict](#typing.Dict)\[[str](#str), [Any](#typing.Any)\]\]</code> – PyArrow Table containing the concatenated data from all matching row groups.
+- <code>'pa.Table' | [tuple](#tuple)\['pa.Table', [Dict](#typing.Dict)\[[str](#str), [Any](#typing.Any)\]\]</code> – If return_timing_info is True, returns a tuple of (table, timing_info dict).
+
+<details class="example" open>
+<summary>Example</summary>
+import fused
+
+# Read data for a specific H3 hex range
+
+table = fused.h3.read_hex_table_slow(
+dataset_path="s3://my-bucket/my-h3-dataset/",
+hex_ranges_list=\[[622236719905341439, 622246719905341439]\]
+)
+df = table.to_pandas()
+
+</details>
+
+---
+
+## fused.h3.read_hex_table_with_persisted_metadata
+
+```python
+read_hex_table_with_persisted_metadata(
+    dataset_path: str,
+    hex_ranges_list: List[List[int]],
+    columns: Optional[List[str]] = None,
+    metadata_path: Optional[str] = None,
+    verbose: bool = False,
+    return_timing_info: bool = False,
+    batch_size: Optional[int] = None,
+    max_concurrent_downloads: Optional[int] = None,
+    max_concurrent_metadata_reads: Optional[int] = None,
+) -> "pa.Table" | tuple["pa.Table", Dict[str, Any]]
+```
+
+Read data from an H3-indexed dataset using persisted metadata parquet.
+
+This function reads from per-file metadata parquet files instead of
+querying a server. Each source parquet file has a corresponding
+.metadata.parquet file stored at:
+{source_dir}/.fused/{source_filename}.metadata.parquet
+
+Or at the specified metadata_path if provided:
+{metadata_path}/{full_source_path}.metadata.parquet
+
+Supports subdirectory queries - if dataset_path points to a subdirectory,
+the function will look for metadata files for files in that subdirectory.
+
+**Parameters:**
+
+- **dataset_path** (<code>str</code>) – Path to the H3-indexed dataset (e.g., "s3://bucket/dataset/")
+  Can also be a subdirectory path for filtering (e.g., "s3://bucket/dataset/year=2024/")
+- **hex_ranges_list** (<code>List\[List[int]\]</code>) – List of [min_hex, max_hex] pairs as integers.
+  Example: \[[622236719905341439, 622246719905341439]\]
+- **columns** (<code>Optional\[List[str]\]</code>) – Optional list of column names to read. If None, reads all columns.
+- **metadata_path** (<code>Optional[str]</code>) – Directory path where metadata files are stored.
+  If None, looks for metadata at {source_dir}/.fused/ for each source file.
+  If provided, reads metadata files from this location using full source paths.
+  This allows reading metadata from a different location when
+  you don't have access to the original dataset directory.
+- **verbose** (<code>bool</code>) – If True, print progress information. Default is False.
+- **return_timing_info** (<code>bool</code>) – If True, return a tuple of (table, timing_info) instead of just the table.
+  Default is False for backward compatibility.
+- **batch_size** (<code>Optional[int]</code>) – Target size in bytes for combining row groups. If None, uses
+  `fused.options.row_group_batch_size` (default: 32KB).
+- **max_concurrent_downloads** (<code>Optional[int]</code>) – Maximum number of simultaneous download operations. If None,
+  uses a default based on the number of files. Default is None.
+- **max_concurrent_metadata_reads** (<code>Optional[int]</code>) – Maximum number of simultaneous metadata file reads. If None,
+  defaults to min(10, len(source_files)).
+
+**Returns:**
+
+- <code>'pa.Table' | [tuple](#tuple)\['pa.Table', [Dict](#typing.Dict)\[[str](#str), [Any](#typing.Any)\]\]</code> – PyArrow Table containing the concatenated data from all matching row groups.
+- <code>'pa.Table' | [tuple](#tuple)\['pa.Table', [Dict](#typing.Dict)\[[str](#str), [Any](#typing.Any)\]\]</code> – If return_timing_info is True, returns a tuple of (table, timing_info dict).
+
+**Raises:**
+
+- <code>[FileNotFoundError](#FileNotFoundError)</code> – If the metadata parquet file is not found.
+- <code>[ValueError](#ValueError)</code> – If any row group is missing required metadata.
+
+<details class="example" open>
+<summary>Example</summary>
+import fused
+
+# First, persist metadata (one-time operation)
+
+fused.h3.persist_hex_table_metadata("s3://my-bucket/my-dataset/")
+
+# Then read using persisted metadata (no server required)
+
+table = fused.h3.read_hex_table_with_persisted_metadata(
+dataset_path="s3://my-bucket/my-dataset/",
+hex_ranges_list=\[[622236719905341439, 622246719905341439]\]
+)
+df = table.to_pandas()
+
+# Read from subdirectory (filters by path prefix)
+
+table = fused.h3.read_hex_table_with_persisted_metadata(
+dataset_path="s3://my-bucket/my-dataset/year=2024/",
+hex_ranges_list=\[[622236719905341439, 622246719905341439]\]
+)
+
+# Read with metadata in alternate location
+
+table = fused.h3.read_hex_table_with_persisted_metadata(
+dataset_path="s3://my-bucket/my-dataset/",
+metadata_path="s3://my-bucket/metadata/",
+hex_ranges_list=\[[622236719905341439, 622246719905341439]\]
+)
+
+</details>
+
+---
+
+## fused.h3.run_partition_to_h3
 
 ```python
 run_partition_to_h3(
     input_path: str | list[str],
     output_path: str,
     metrics: str | list[str] = "cnt",
-    groupby_cols: list[str] = ["hex", "data"],
+    groupby_cols: list[str] = ["hex"],
+    data_cols: list[str] = ["data"],
     window_cols: list[str] = ["hex"],
     additional_cols: list[str] = [],
+    input_rows_are_counts: bool = True,
     res: int | None = None,
     chunk_res: int | None = None,
     file_res: int | None = None,
@@ -337,38 +468,98 @@ run_partition_to_h3(
     max_rows_per_chunk: int = 0,
     remove_tmp_files: bool = True,
     overwrite: bool = False,
-    extract_kwargs: dict = {},
-    partition_kwargs: dict = {},
-    overview_kwargs: dict = {},
-    **kwargs
+    extract_kwargs: bool = {},
+    partition_kwargs: bool = {},
+    overview_kwargs: bool = {},
+    **kwargs: bool
 )
 ```
 
 Run the H3 partitioning process.
 
-This pipeline assumes that the input data already has a `"hex"` column with H3 cell IDs at the target resolution. It will then repartition the data spatially and add overview files. See `run_ingest_raster_to_h3` for more on the processing steps and execution options.
+This pipeline assumes that the input data already has a `"hex"` column
+with H3 cell IDs at the target resolution. It will then repartition
+the data spatially and add overview files.
+
+By default, it is assumed that each row in the input data has a `cnt` column
+with counts of the raster pixel values (in the "data" column).
+
+If your data already has actual statistics per H3 cell, you can set
+`input_rows_are_counts=False`. If you then specify, for example, a metric
+like "avg", it will take just take the average of the "data" column for each H3 cell.
+At the target resolution, this will typically be a single row, not actually
+further aggregating. For overview files, it will then create aggregated data.
 
 **Parameters:**
 
-- **input_path** (`str | list[str]`) – Path(s) to the input data (file, directory, or list of file paths). The first step is parallelized per input file.
-- **output_path** (`str`) – Path for the resulting Parquet dataset.
-- **metrics** (`str | list[str]`) – Per H3 cell: `"cnt"` or a list of `"avg"`, `"min"`, `"max"`, `"stddev"`, `"sum"`.
-- **groupby_cols** (`list[str]`) – Columns defining groups for aggregated metrics. Default `["hex", "data"]`; must include `"hex"`. Only for `"cnt"` metric.
-- **window_cols** (`list[str]`) – Columns for window total counts (adds one output column per column). Default `["hex"]`. Only for `"cnt"` metric.
-- **additional_cols** (`list[str]`) – Extra columns to include; assumed unique per `groupby_cols` group. Default `[]`. Only for `"cnt"` metric.
-- **res** (`int | None`) – H3 resolution; must be specified.
-- **file_res** (`int | None`) – H3 resolution to chunk output files. Default inferred from `res`. Use `file_res=-1` for a single file.
-- **chunk_res** (`int | None`) – H3 resolution to chunk row groups within each file (ignored when `max_rows_per_chunk` is set). Default inferred from `res`.
-- **overview_res** (`list[int] | None`) – Resolutions for overview files. Default 3–7 (capped by `res`).
-- **overview_chunk_res** (`int | list[int] | None`) – Row-group chunk resolution(s) for overview files. Default: overview resolution minus 5 (clamped to 0–`res`).
-- **max_rows_per_chunk** (`int`) – Max rows per chunk; 0 (default) uses `chunk_res` and `overview_chunk_res`.
-- **remove_tmp_files** (`bool`) – Remove temporary files after run. Default True.
-- **overwrite** (`bool`) – Overwrite output path if it exists. Default False.
-- **extract_kwargs** (`dict`) – Extra arguments for [`fused.submit`](/python-sdk/api-reference/fused-submit) for the extract step.
-- **partition_kwargs** (`dict`) – Extra arguments for `fused.submit` for the partition step.
-- **overview_kwargs** (`dict`) – Extra arguments for `fused.submit` for the overview step.
-- **\*\*kwargs** – Extra arguments for all steps; overridden by `extract_kwargs`, `partition_kwargs`, `overview_kwargs`.
+- **input_path** (<code>str, list</code>) – Path(s) to the input data.
+  Can be a path to file or directory, or list of file paths). The
+  first step of the processing is parallelized per input file.
+- **output_path** (<code>str</code>) – Path for the resulting Parquet dataset.
+- **metrics** (<code>str or list of str</code>) – The metrics to compute per H3 cell.
+  Supported metrics are either "cnt" or a list containing any of
+  "avg", "min", "max", "stddev", and "sum".
+- **groupby_cols** (<code>list</code>) – The columns indicating the groups for which
+  the aggregated metrics are calculated. By default, for the "cnt"
+  metric, this is the "hex" column, which is further combined with
+  the `data_cols` (by default "data"). For the default "cnt" metric,
+  this means counts are calculated (summed) per unique combination
+  of "hex" and "data".
+  For the other metrics, this should typically always be the "hex" column.
+- **data_cols** (<code>list[str]</code>) – Value column names (default `["data"]`). For
+  "cnt", this column contains the categories that are counted and is
+  appended to the `GROUP BY` clause.
+  For non-"cnt" metrics, the list of columns that will be aggregated
+  according to the metrics (the result contains the cartesian product
+  of data columns and metrics, i.e. all `{data_col}_{metric}` combinations).
+- **window_cols** (<code>list</code>) – The columns for which to calculate total counts
+  over using a window function. This will add an additional column to
+  the output (one for each of the columns in this list) with the total
+  counts per unique value of the specified column.
+  By default, this is only done for the "hex" column.
+  This only applies when the "cnt" metric is specified.
+- **additional_cols** (<code>list</code>) – Additional columns from the input data to
+  include in the output dataset. These columns are assumed to have a
+  unique value per group defined by the `groupby_cols`. If this is not
+  the case, the output will contain arbitrary values from one of the
+  rows in each group.
+  By default, this is empty.
+  This only applies when the "cnt" metric is specified.
+- **res** (<code>int</code>) – The resolution at which to assign the pixel values to H3 cells.
+- **file_res** (<code>int</code>) – The H3 resolution to chunk the resulting files of the
+  Parquet dataset. By default will be inferred based on the target
+  resolution `res`. You can specify `file_res=-1` to have a single
+  output file.
+- **chunk_res** (<code>int</code>) – The H3 resolution to chunk the row groups within
+  each file of the Parquet dataset (ignored when `max_rows_per_chunk`
+  is specified). By default will be inferred based on the target
+  resolution `res`.
+- **overview_res** (<code>list of int</code>) – The H3 resolutions for which to create
+  overview files. By default, overviews are created for resolutions 3
+  to 7 (or capped at a lower value if the `res` of the output dataset
+  is lower).
+- **overview_chunk_res** (<code>int or list of int</code>) – The H3 resolution(s) to chunk
+  the row groups within each overview file of the Parquet dataset. By
+  default, each overview file is chunked at the overview resolution
+  minus 5 (clamped between 0 and the `res` of the output dataset).
+- **max_rows_per_chunk** (<code>int</code>) – The maximum number of rows per chunk in the
+  resulting data and overview files. If 0 (the default), `chunk_res`
+  and `overview_chunk_res` are used to determine the chunking.
+- **remove_tmp_files** (<code>bool</code>) – If True, remove the temporary files after
+  ingestion is complete. Defaults to True.
+- **overwrite** (<code>bool</code>) – If True, overwrite the output path if it already
+  exists, by first removing the existing content before writing the
+  new files. Defaults to False, in which case an error is raised if
+  the `output_path` is not empty.
+- **extract_kwargs** (<code>dict</code>) – Additional keyword arguments to pass to
+  `fused.submit` for the extract step.
+- **partition_kwargs** (<code>dict</code>) – Additional keyword arguments to pass to
+  `fused.submit` for the partition step.
+- **overview_kwargs** (<code>dict</code>) – Additional keyword arguments to pass to
+  `fused.submit` for the overview step.
 
-See the docstring of `run_ingest_raster_to_h3` for more details on the processing steps and how to configure the execution.
+See the docstring of `run_ingest_raster_to_h3` for more details on
+the processing steps and how to configure the execution.
 
 ---
+

--- a/docs/python-sdk/api-reference/jobpool.mdx
+++ b/docs/python-sdk/api-reference/jobpool.mdx
@@ -1,515 +1,312 @@
 ---
-sidebar_label: JobPool (class)
-title: JobPool (class)
-toc_max_heading_level: 2
+sidebar_label: JobPool
+title: JobPool
+toc_max_heading_level: 5
 sidebar_position: 1
 ---
 
-```python
-class JobPool
-```
+## JobPool
 
-The `JobPool` class manages parallel job execution and result retrieval. It is returned by [`udf.map()`](/python-sdk/api-reference/udf#map).
+The `JobPool` class is used to manage, inspect and retrieve results from
+submitted jobs from [`fused.submit()`](/python-sdk/top-level-functions/#fusedsubmit).
 
-**Basic usage**
-
-```python
-@fused.udf
-def udf():
-    # Create a pool of jobs
-    pool = my_udf.map([1, 2, 3, 4, 5])
-
-    # Wait and collect results as DataFrame
-    df = pool.df()
-
-    return df
-
-@fused.udf
-def my_udf(x: int):
-    return x ** 2
-```
-
-:::note
-`my_udf` is defined in the same file above, so there is no need to load it.
-:::
-
-**Monitoring progress**
+### cancel
 
 ```python
-pool = my_udf.map(range(100))
-
-# Show live progress
-pool.tail()
-
-# Check status
-pool.status()        # Series of status counts
-pool.all_succeeded() # True if all jobs succeeded
-pool.any_failed()    # True if any job failed
+cancel(wait: bool = False)
 ```
 
-**Parallel processing within workers**
+Cancel any pending (not running) tasks.
 
-Use `worker_concurrency` to combine multiple items per UDF invocation, reducing total invocations for large job counts:
-
-```python
-@fused.udf
-def udf():
-    # Running 10 jobs in parallel but with 4 jobs per UDF instance
-    pool = my_udf.map(range(10), worker_concurrency=4)
-    df = pool.df()
-
-    return df
-
-@fused.udf
-def my_udf(x: int):
-    return x ** 2
-```
-
-**Local engine execution**
-
-When using `engine="local"`, the pool uses process-based execution. The pool automatically shuts down after `df()`:
-
-```python
-@fused.udf
-def udf():
-    # All jobs are executed locally
-    pool = my_udf.map(range(10), engine="local")
-    df = pool.df() # Pool automatically shuts down after collecting
-
-    return df
-
-@fused.udf
-def my_udf(x: int):
-    return x ** 2
-```
-
-**Async methods (AsyncJobPool)**
-
-When using [`udf.map_async()`](/python-sdk/api-reference/udf#map_async), the returned object is an `AsyncJobPool` (subclass of `JobPool`) with async variants of the key methods. Use them in `async` code so they don't block the event loop (e.g. in Workbench):
-
-```python
-@fused.udf
-async def udf():
-    pool = await my_udf.map_async([1, 2, 3])
-    await pool.wait_async()
-    results = await pool.results_async()
-    return results
-
-@fused.udf
-def my_udf(x: int):
-    return x ** 2
-```
-
-The async variants are documented below in alphabetical order with the sync methods.
+Note it will not be possible to retry on the same JobPool later.
 
 ---
 
-## all_succeeded
+### retry
 
 ```python
-pool.all_succeeded() -> bool
-```
-
-True if all tasks finished with success.
-
----
-
-## any_failed
-
-```python
-pool.any_failed() -> bool
-```
-
-True if any task finished with an error.
-
----
-
-## any_succeeded
-
-```python
-pool.any_succeeded() -> bool
-```
-
-True if any task finished with success.
-
----
-
-## arg_df
-
-```python
-pool.arg_df() -> pd.DataFrame
-```
-
-The arguments passed to runs as a DataFrame.
-
----
-
-## cancel
-
-```python
-pool.cancel(
-    wait=False,  # if True, wait for running tasks to complete
-)
-```
-
-Cancel any pending (not running) tasks. Note it will not be possible to retry on the same JobPool later.
-
----
-
-## cancel_async
-
-```python
-await pool.cancel_async(wait: bool = False)
-```
-
-Cancel any pending (not running) tasks. (AsyncJobPool only.)
-
----
-
-## cancelled
-
-```python
-pool.cancelled() -> dict[int, Any]
-```
-
-Retrieve the arguments that were cancelled and not run.
-
----
-
-## collect
-
-```python
-pool.collect(
-    ignore_exceptions=False,  # if True, skip failed jobs instead of raising
-    flatten=True,             # if True, flatten DataFrame results
-    drop_index=False,         # if True, use position index instead of args
-) -> pd.DataFrame
-```
-
-Alias for [`df()`](#df).
-
----
-
-## df
-
-```python
-pool.df(
-    ignore_exceptions=False,  # if True, skip failed jobs instead of raising
-    flatten=True,             # if True, flatten DataFrame results
-    drop_index=False,         # if True, use position index instead of args
-) -> pd.DataFrame
-```
-
-Collect all results into a DataFrame.
-
-:::note
-When using `engine="local"`, `df()` automatically shuts down the pool after collecting results.
-:::
-
----
-
-## done
-
-```python
-pool.done() -> bool
-```
-
-True if all tasks have finished, regardless of success or failure.
-
----
-
-## errors
-
-```python
-pool.errors() -> dict[int, Exception]
-```
-
-Retrieve the results that are currently done and are errors. Results are indexed by position in the args list.
-
----
-
-## errors_async
-
-```python
-await pool.errors_async() -> dict[int, Exception]
-```
-
-Async version of [`errors()`](#errors) that doesn't block the event loop. (AsyncJobPool only.)
-
----
-
-## first_error
-
-```python
-pool.first_error() -> Exception | None
-```
-
-Retrieve the first (by order of arguments) error result, or None.
-
----
-
-## first_error_async
-
-```python
-await pool.first_error_async() -> Exception | None
-```
-
-Async version of [`first_error()`](#first_error) that doesn't block the event loop. (AsyncJobPool only.)
-
----
-
-## first_log
-
-```python
-pool.first_log() -> str | None
-```
-
-Retrieve the first (by order of arguments) logs, or None.
-
----
-
-## first_log_async
-
-```python
-await pool.first_log_async() -> str | None
-```
-
-Async version of [`first_log()`](#first_log) that doesn't block the event loop. (AsyncJobPool only.)
-
----
-
-## logs
-
-```python
-pool.logs() -> list[str | None]
-```
-
-Logs for each task. Incomplete tasks will be reported as None.
-
----
-
-## logs_async
-
-```python
-await pool.logs_async() -> list[str | None]
-```
-
-Async version of [`logs()`](#logs) that doesn't block the event loop. (AsyncJobPool only.)
-
----
-
-## logs_df
-
-```python
-pool.logs_df(
-    status_column="status",    # column name for status (None to omit)
-    result_column="result",    # column name for result (None to omit)
-    time_column="time",        # column name for time (None to omit)
-    logs_column="logs",        # column name for logs (None to omit)
-    exception_column=None,     # column name for exceptions (None to omit)
-    include_exceptions=True,   # include exceptions in result column
-) -> pd.DataFrame
-```
-
-Get a DataFrame of results as they are currently. The DataFrame will have columns for each argument passed, and columns for: `status`, `result`, `time`, `logs` and optionally `exception`.
-
----
-
-## logs_df_async
-
-```python
-await pool.logs_df_async(
-    status_column="status",
-    result_column="result",
-    time_column="time",
-    logs_column="logs",
-    exception_column=None,
-    include_exceptions=True,
-) -> pd.DataFrame
-```
-
-Async version of [`logs_df()`](#logs_df) that doesn't block the event loop. (AsyncJobPool only.)
-
----
-
-## n_jobs
-
-The number of jobs in the pool.
-
----
-
-## pending
-
-```python
-pool.pending() -> dict[int, Any]
-```
-
-Retrieve the arguments that are currently pending and not yet submitted.
-
----
-
-## results
-
-```python
-pool.results(
-    return_exceptions=False,  # if True, return exceptions instead of raising
-) -> list[Any]
-```
-
-Retrieve all results of the job. Results are ordered by the order of the args list.
-
----
-
-## results_async
-
-```python
-await pool.results_async(return_exceptions: bool = False) -> list[Any]
-```
-
-Async version of [`results()`](#results); assumes waiting has already been done. (AsyncJobPool only.)
-
----
-
-## results_now
-
-```python
-pool.results_now(
-    return_exceptions=False,  # if True, return exceptions instead of raising
-) -> dict[int, Any]
-```
-
-Retrieve the results that are currently done. Results are indexed by position in the args list.
-
----
-
-## retry
-
-```python
-pool.retry()
+retry()
 ```
 
 Rerun any tasks in error or timeout states. Tasks are rerun in the same pool.
 
 ---
 
-## running
+### total_time
 
 ```python
-pool.running() -> dict[int, Any]
+total_time(since_retry: bool = False) -> timedelta
+```
+
+Returns how long the entire job took.
+
+If only partial results are available, returns based on the last task to have been completed.
+
+---
+
+### times
+
+```python
+times() -> list[timedelta | None]
+```
+
+Time taken for each task.
+
+Incomplete tasks will be reported as None.
+
+---
+
+### done
+
+```python
+done() -> bool
+```
+
+True if all tasks have finished, regardless of success or failure.
+
+---
+
+### all_succeeded
+
+```python
+all_succeeded() -> bool
+```
+
+True if all tasks finished with success
+
+---
+
+### any_failed
+
+```python
+any_failed() -> bool
+```
+
+True if any task finished with an error
+
+---
+
+### any_succeeded
+
+```python
+any_succeeded() -> bool
+```
+
+True if any task finished with success
+
+---
+
+### arg_df
+
+```python
+arg_df()
+```
+
+The arguments passed to runs as a DataFrame
+
+---
+
+### status
+
+```python
+status()
+```
+
+Return a Series indexed by status of task counts
+
+---
+
+### wait
+
+```python
+wait()
+```
+
+Wait until all jobs are finished
+
+Use fused.options.show.enable_tqdm to enable/disable tqdm.
+Use pool.\_wait_sleep to set if sleep should occur while waiting.
+
+---
+
+### tail
+
+```python
+tail(stop_on_exception = False, timeout: float | None = None)
+```
+
+Wait until all jobs are finished, printing statuses as they become available.
+
+This is useful for interactively watching for the state of the pool.
+
+Use pool.\_wait_sleep to set if sleep should occur while waiting.
+
+If `timeout` is None and this runs inside a realtime instance, it defaults
+to 90 seconds. Otherwise `None` means no time limit. On timeout, prints
+any errors for completed failures and a list of args for jobs that did not
+succeed (pending, running, or errored) for reuse in a new submit, then raises
+`TimeoutError`.
+
+---
+
+### results
+
+```python
+results(return_exceptions = False) -> list[Any]
+```
+
+Retrieve all results of the job.
+
+Results are ordered by the order of the args list.
+
+---
+
+### results_now
+
+```python
+results_now(return_exceptions = False) -> dict[int, Any]
+```
+
+Retrieve the results that are currently done.
+
+Results are indexed by position in the args list.
+
+---
+
+### logs_df
+
+```python
+logs_df(
+    status_column: str | None = "status",
+    result_column: str | None = "result",
+    time_column: str | None = "time",
+    logs_column: str | None = "logs",
+    exception_column: str | None = None,
+    include_exceptions: bool = True,
+) -> pd.DataFrame
+```
+
+Get a DataFrame of results as they are currently.
+The DataFrame will have columns for each argument passed, and columns for:
+`status`, `result`, `time`, `logs` and optionally `exception`.
+
+---
+
+### errors
+
+```python
+errors() -> dict[int, Exception]
+```
+
+Retrieve the results that are currently done and are errors.
+
+Results are indexed by position in the args list.
+
+---
+
+### first_error
+
+```python
+first_error() -> Exception | None
+```
+
+Retrieve the first (by order of arguments) error result, or None.
+
+---
+
+### logs
+
+```python
+logs() -> list[str | None]
+```
+
+Logs for each task.
+
+Incomplete tasks will be reported as None.
+
+---
+
+### first_log
+
+```python
+first_log() -> str | None
+```
+
+Retrieve the first (by order of arguments) logs, or None.
+
+---
+
+### success
+
+```python
+success() -> dict[int, Any]
+```
+
+Retrieve the results that are currently done and are successful.
+
+Results are indexed by position in the args list.
+
+---
+
+### pending
+
+```python
+pending() -> dict[int, Any]
+```
+
+Retrieve the arguments that are currently pending and not yet submitted.
+
+---
+
+### running
+
+```python
+running() -> dict[int, Any]
 ```
 
 Retrieve the results that are currently running.
 
 ---
 
-## shutdown
+### cancelled
 
 ```python
-pool.shutdown(
-    wait=True,  # if True, wait for all workers to complete
+cancelled() -> dict[int, Any]
+```
+
+Retrieve the arguments that were cancelled and not run.
+
+---
+
+### df
+
+```python
+df(
+    ignore_exceptions: bool = False,
+    flatten: bool = True,
+    drop_index: bool = False,
+    verbose: bool = True,
+    log_timeout: float | None = None,
+) -> pd.DataFrame
+```
+
+Collect all results into a DataFrame
+
+---
+
+### collect
+
+```python
+collect(
+    ignore_exceptions: bool = False,
+    flatten: bool = True,
+    drop_index: bool = False,
+    verbose: bool = True,
+    log_timeout: float | None = None,
 )
 ```
 
-Shutdown the process pool executor.
-
-This should be called when all jobs are complete to ensure worker processes are properly terminated and don't hang. Only applicable when using `engine="local"`. Called automatically by `collect()`.
+Collect all results into a DataFrame
 
 ---
 
-## status
-
-```python
-pool.status() -> pd.Series
-```
-
-Return a Series indexed by status of task counts.
-
----
-
-## success
-
-```python
-pool.success() -> dict[int, Any]
-```
-
-Retrieve the results that are currently done and are successful. Results are indexed by position in the args list.
-
----
-
-## success_async
-
-```python
-await pool.success_async() -> dict[int, Any]
-```
-
-Async version of [`success()`](#success) that doesn't block the event loop. (AsyncJobPool only.)
-
----
-
-## tail
-
-```python
-pool.tail(
-    stop_on_exception=False,  # if True, stop when first exception occurs
-)
-```
-
-Wait until all jobs are finished, printing statuses as they become available.
-
-This is useful for interactively watching for the state of the pool. Use pool._wait_sleep to set if sleep should occur while waiting.
-
----
-
-## tail_async
-
-```python
-await pool.tail_async(stop_on_exception: bool = False)
-```
-
-Async version of [`tail()`](#tail) that doesn't block the event loop. (AsyncJobPool only.)
-
----
-
-## times
-
-```python
-pool.times() -> list[timedelta | None]
-```
-
-Time taken for each task. Incomplete tasks will be reported as None.
-
----
-
-## total_time
-
-```python
-pool.total_time(
-    since_retry=False,  # if True, measure from last retry instead of start
-) -> timedelta
-```
-
-Returns how long the entire job took. If only partial results are available, returns based on the last task to have been completed.
-
----
-
-## wait
-
-```python
-pool.wait()
-```
-
-Wait until all jobs are finished.
-
-Use fused.options.show.enable_tqdm to enable/disable tqdm. Use pool._wait_sleep to set if sleep should occur while waiting.
-
----
-
-## wait_async
-
-```python
-await pool.wait_async()
-```
-
-Wait until all jobs are finished. Does not block the event loop. (AsyncJobPool only.)
-
----

--- a/docs/python-sdk/api-reference/options.mdx
+++ b/docs/python-sdk/api-reference/options.mdx
@@ -5,7 +5,7 @@ toc_max_heading_level: 5
 sidebar_position: 4
 ---
 
-## options
+## fused.options
 
 List global configuration options.
 
@@ -19,19 +19,14 @@ Change the `request_timeout` option from its default value to 60 seconds:
 fused.options.request_timeout = 60
 ```
 
----
 
 ## Options
 
-### auth
+### __dir__
 
 ```python
-auth: AuthOptions = Field(default_factory=AuthOptions)
+__dir__() -> List[str]
 ```
-
-Options for authentication.
-
----
 
 ### base_url
 
@@ -41,209 +36,29 @@ base_url: str = PROD_DEFAULT_BASE_URL
 
 Fused API endpoint
 
----
-
-### base_web_url
+### shared_udf_base_url
 
 ```python
-base_web_url
+shared_udf_base_url: str = PROD_SHARED_UDF_DEFAULT_BASE_URL
 ```
 
-Base URL for web interface.
+Shared UDF API endpoint
 
----
-
-### cache_decorator_max_age
+### auth
 
 ```python
-cache_decorator_max_age: int = 60 * 60 * 48  # 48 hours
+auth: AuthOptions = Field(default_factory=AuthOptions)
 ```
 
-Default max age for cache decorated functions. Accepts duration strings like "12h", "30m", "7d", or integer seconds.
+Options for authentication.
 
----
-
-### cache_directory
+### show
 
 ```python
-cache_directory: Path | None = None
+show: ShowOptions = Field(default_factory=ShowOptions)
 ```
 
-The base directory for storing cached results.
-
----
-
-### cache_storage
-
-```python
-cache_storage: StorageStr = 'auto'
-```
-
-Specify the default cache storage type
-
----
-
-### data_directory
-
-```python
-data_directory: Path = None
-```
-
-The base directory for storing data results. Note: if storage type is 'object', then this path is relative to `fd_prefix`.
-
----
-
-### default_dtype_out_raster
-
-```python
-default_dtype_out_raster: StrictStr = 'npy,tiff'
-```
-
-Default transfer type for raster data
-
----
-
-### default_dtype_out_simple
-
-```python
-default_dtype_out_simple: StrictStr = 'json'
-```
-
-Default transfer type for simple Python data (bool, int, float, str, list)
-
----
-
-### default_dtype_out_vector
-
-```python
-default_dtype_out_vector: StrictStr = 'parquet'
-```
-
-Default transfer type for vector (tabular) data
-
----
-
-### default_run_headers
-
-```python
-default_run_headers: Optional[Dict[str, str]] = {
-    "X-Fused-Cache-Disable": "true"
-}
-```
-
-(Advanced) Default headers to include with UDF run requests.
-
----
-
-### default_send_status_email
-
-```python
-default_send_status_email: StrictBool = True
-```
-
-Whether to send a status email to the user when a job is complete.
-
----
-
-### default_udf_run_engine
-
-```python
-default_udf_run_engine: Optional[StrictStr] = None
-```
-
-Default engine to run UDFs, one of: "local" or "remote".
-
----
-
-### default_validate_imports
-
-```python
-default_validate_imports: StrictBool = False
-```
-
-Default for whether to validate imports in UDFs before `run_local`, `run_batch`.
-
----
-
-### fd_prefix
-
-```python
-fd_prefix: Optional[str] = None
-```
-
-If set, where `fd://` scheme URLs will resolve to. By default will infer this from your user account.
-
----
-
-### gcp_project_name
-
-```python
-gcp_project_name: Optional[StrictStr] = None
-```
-
-Project name for GCS to use for GCS operations.
-
----
-
-### gcs_filename
-
-```python
-gcs_filename: str = '/tmp/.gcs.fused'
-```
-
-Filename for saving temporary GCS credentials to locally or in rt2 instance
-
----
-
-### gcs_secret
-
-```python
-gcs_secret: str = 'gcs_fused'
-```
-
-Secret name for GCS credentials.
-
----
-
-### job_id
-
-```python
-job_id: Optional[StrictStr] = None
-```
-
-ID of the job being executed (set by job2 when running in job context). This is automatically populated when running inside a Fused batch job.
-
----
-
-### local_engine_cache
-
-```python
-local_engine_cache: StrictBool = True
-```
-
-Enable UDF cache with local engine
-
----
-
-### logging
-
-```python
-logging: StrictBool = Field(default=False, validate_default=True)
-```
-
-Control logging for Fused
-
----
-
-### max_recursion_factor
-
-```python
-max_recursion_factor: int = 5
-```
-
-Maximum recursion factor for UDFs. This is used to limit the number of recursive calls to UDFs. If a UDF exceeds this limit, an error will be raised.
-
----
+Options for object reprs and how data are shown for debugging.
 
 ### max_workers
 
@@ -253,87 +68,13 @@ max_workers: int = 16
 
 Maximum number of threads, when multithreading requests
 
----
-
-### metadata_request_timeout
+### run_timeout
 
 ```python
-metadata_request_timeout: float = 60.0
+run_timeout: float = 130
 ```
 
-Request timeout for file metadata requests (e.g., /file-metadata endpoint). These requests may involve processing large parquet files and can take longer.
-
----
-
-### never_import
-
-```python
-never_import: StrictBool = False
-```
-
-Never import UDF code when loading UDFs.
-
----
-
-### no_login
-
-```python
-no_login: StrictBool = False
-```
-
-If set, Fused will not attempt to login automatically when needed.
-
----
-
-### prompt_to_login
-
-```python
-prompt_to_login: StrictBool = False
-```
-
-Automatically prompt the user to login when importing Fused.
-
----
-
-### pyodide_async_requests
-
-```python
-pyodide_async_requests: StrictBool = False
-```
-
-If set, Fused is being called inside Pyodide and should use pyodide for async HTTP requests.
-
----
-
-### realtime_client_id
-
-```python
-realtime_client_id: Optional[StrictStr] = None
-```
-
-Client ID for realtime service.
-
----
-
-### request_max_retries
-
-```python
-request_max_retries: int = 5
-```
-
-Maximum number of retries for API requests
-
----
-
-### request_retry_base_delay
-
-```python
-request_retry_base_delay: float = 1.0
-```
-
-Base delay before retrying a API request in seconds
-
----
+Request timeout for UDF run requests to the Fused service
 
 ### request_timeout
 
@@ -345,27 +86,55 @@ Request timeout for the Fused service
 
 May be set to a tuple of connection timeout and read timeout
 
----
-
-### row_group_batch_size
+### metadata_request_timeout
 
 ```python
-row_group_batch_size: int = 32768
+metadata_request_timeout: float = 60.0
 ```
 
-Target size in bytes for combining adjacent row group downloads. Adjacent row groups from the same file will be combined into single downloads until this threshold is reached. Default is 32KB (32768 bytes), which is optimized for S3 performance.
+Request timeout for file metadata requests (e.g., /file-metadata endpoint).
+These requests may involve processing large parquet files and can take longer.
 
----
-
-### run_timeout
+### request_max_retries
 
 ```python
-run_timeout: float = 130
+request_max_retries: int = 5
 ```
 
-Request timeout for UDF run requests to the Fused service
+Maximum number of retries for API requests
 
----
+### request_retry_base_delay
+
+```python
+request_retry_base_delay: float = 1.0
+```
+
+Base delay before retrying a API request in seconds
+
+### realtime_client_id
+
+```python
+realtime_client_id: Optional[StrictStr] = None
+```
+
+Client ID for realtime service.
+
+### job_id
+
+```python
+job_id: Optional[StrictStr] = None
+```
+
+ID of the job being executed (set by job2 when running in job context).
+
+### max_recursion_factor
+
+```python
+max_recursion_factor: int = 5
+```
+
+Maximum recursion factor for UDFs. This is used to limit the number of
+recursive calls to UDFs. If a UDF exceeds this limit, an error will be raised.
 
 ### save_user_settings
 
@@ -375,27 +144,55 @@ save_user_settings: StrictBool = True
 
 Save per-user settings such as credentials and environment IDs.
 
----
-
-### shared_udf_base_url
+### default_udf_run_engine
 
 ```python
-shared_udf_base_url: str = PROD_SHARED_UDF_DEFAULT_BASE_URL
+default_udf_run_engine: Optional[StrictStr] = None
 ```
 
-Shared UDF API endpoint
+Default engine to run UDFs, one of: "local" or "remote".
 
----
-
-### show
+### prompt_to_login
 
 ```python
-show: ShowOptions = Field(default_factory=ShowOptions)
+prompt_to_login: StrictBool = False
 ```
 
-Options for object reprs and how data are shown for debugging.
+Automatically prompt the user to login when importing Fused.
 
----
+### no_login
+
+```python
+no_login: StrictBool = False
+```
+
+If set, Fused will not attempt to login automatically when needed.
+
+### pyodide_async_requests
+
+```python
+pyodide_async_requests: StrictBool = False
+```
+
+If set, Fused is being called inside Pyodide and should use pyodide
+for async HTTP requests.
+
+### cache_directory
+
+```python
+cache_directory: Path | None = None
+```
+
+The base directory for storing cached results.
+
+### data_directory
+
+```python
+data_directory: Path = None
+```
+
+The base directory for storing data results. Note: if storage type is 'object', then this path is relative to
+fd_prefix.
 
 ### temp_directory
 
@@ -405,17 +202,105 @@ temp_directory: Path = Path(tempfile.gettempdir())
 
 The base directory for storing temporary files.
 
----
-
-### use_process_pool_for_local_submit
+### never_import
 
 ```python
-use_process_pool_for_local_submit: StrictBool = False
+never_import: StrictBool = False
 ```
 
-Use ProcessPoolExecutor instead of ThreadPoolExecutor for local engine submit. This avoids GDAL thread-safety issues and Python GIL limitations, but has higher memory overhead and slower startup time.
+Never import UDF code when loading UDFs.
 
----
+### gcs_secret
+
+```python
+gcs_secret: str = 'gcs_fused'
+```
+
+Secret name for GCS credentials.
+
+### gcs_filename
+
+```python
+gcs_filename: str = '/tmp/.gcs.fused'
+```
+
+Filename for saving temporary GCS credentials to locally or in rt2 instance
+
+### gcp_project_name
+
+```python
+gcp_project_name: Optional[StrictStr] = None
+```
+
+Project name for GCS to use for GCS operations.
+
+### logging
+
+```python
+logging: StrictBool = Field(default=False, validate_default=True)
+```
+
+Control logging for Fused
+
+### verbose_udf_runs
+
+```python
+verbose_udf_runs: StrictBool = False
+```
+
+Whether to print logs from UDF runs by default
+
+### default_run_headers
+
+```python
+default_run_headers: Optional[Dict[str, str]] = {
+    "X-Fused-Cache-Disable": "true"
+}
+
+```
+
+(Advanced) Default headers to include with UDF run requests.
+
+### fused_cache_disable_stream
+
+```python
+fused_cache_disable_stream: StrictBool = True
+```
+
+When true (default), realtime UDF requests include the
+fused_cache_disable_stream query parameter so the server does not stream from cache.
+
+### default_dtype_out_vector
+
+```python
+default_dtype_out_vector: StrictStr = 'parquet'
+```
+
+Default transfer type for vector (tabular) data
+
+### default_dtype_out_raster
+
+```python
+default_dtype_out_raster: StrictStr = 'npy,tiff'
+```
+
+Default transfer type for raster data
+
+### default_dtype_out_simple
+
+```python
+default_dtype_out_simple: StrictStr = 'json'
+```
+
+Default transfer type for simple Python data (bool, int, float, str, list)
+
+### fd_prefix
+
+```python
+fd_prefix: Optional[str] = None
+```
+
+If set, where fd:// scheme URLs will resolve to. By default will infer this from your user account.
 
 ### verbose_cached_functions
 
@@ -425,17 +310,73 @@ verbose_cached_functions: StrictBool = True
 
 Whether to print logs from cache decorated functions by default
 
----
-
-### verbose_udf_runs
+### local_engine_cache
 
 ```python
-verbose_udf_runs: StrictBool = True
+local_engine_cache: StrictBool = True
 ```
 
-Whether to print logs from UDF runs by default
+Enable UDF cache with local engine
 
----
+### default_send_status_email
+
+```python
+default_send_status_email: StrictBool = True
+```
+
+Whether to send a status email to the user when a job is complete.
+
+### cache_storage
+
+```python
+cache_storage: StorageStr = 'auto'
+```
+
+Specify the default cache storage type
+
+### use_process_pool_for_local_submit
+
+```python
+use_process_pool_for_local_submit: StrictBool = False
+```
+
+Use ProcessPoolExecutor instead of ThreadPoolExecutor for local engine submit.
+This avoids GDAL thread-safety issues and Python GIL limitations, but has higher
+memory overhead and slower startup time.
+
+### row_group_batch_size
+
+```python
+row_group_batch_size: int = 32768
+```
+
+Target size in bytes for combining adjacent row group downloads.
+Adjacent row groups from the same file will be combined into single downloads
+until this threshold is reached. Default is 32KB (32768 bytes), which is
+optimized for S3 performance.
+
+### cache_decorator_max_age
+
+```python
+cache_decorator_max_age: int = 60 * 60 * 48
+```
+
+Default max age for cache decorated functions. Accepts duration strings like
+"12h", "30m", "7d", or integer seconds.
+
+### default_conflict_overwrite_choice
+
+```python
+default_conflict_overwrite_choice: str = 'no'
+```
+
+Default choice for conflict overwrite when pulling a canvas. Accepts yes/no/diff/all/quit (case-insensitive).
+
+### base_web_url
+
+```python
+base_web_url
+```
 
 ### save
 
@@ -443,4 +384,5 @@ Whether to print logs from UDF runs by default
 save()
 ```
 
-Save Fused options to `~/.fused/settings.toml`. They will be automatically reloaded the next time fused-py is imported.
+Save Fused options to `~/.fused/settings.toml`. They will be automatically
+reloaded the next time fused-py is imported.

--- a/docs/python-sdk/api-reference/udf.mdx
+++ b/docs/python-sdk/api-reference/udf.mdx
@@ -1,442 +1,254 @@
 ---
-sidebar_label: Udf (class)
-title: Udf (class)
-toc_max_heading_level: 2
+sidebar_label: Udf
+title: Udf
+toc_max_heading_level: 5
 sidebar_position: 0
 ---
 
-```python
-class Udf
-```
+## Udf
 
-A user-defined function. The `Udf` class is the object returned when decorating a function with [`@fused.udf`](/python-sdk/api-reference/fused-udf), or when loading a saved UDF with [`fused.load()`](/python-sdk/api-reference/fused-load).
+The `Udf` class is the object you get when defining a UDF with the
+[`@fused.udf`](/python-sdk/top-level-functions/#fusedudf) decorator, or when loading
+a saved UDF with [`fused.load()`](/python-sdk/top-level-functions/#fusedload).
 
-**Calling a UDF**
-
-Call this UDF. UDFs are callable; pass arguments as for a regular function, plus optional `engine`, `cache_max_age`, and `cache`:
+### to_directory
 
 ```python
-udf(
-    *args,               # positional arguments to pass to the UDF
-    engine=None,         # "remote" (default), "local", or "small"/"medium"/"large"
-    cache_max_age=None,  # max cache age, e.g. "48h", "10s"; None uses @fused.udf() default
-    cache=True,          # set False to disable caching
-    **kwargs,            # keyword arguments to pass to the UDF
-)
+to_directory(where: str | Path | None = None, *, overwrite: bool = False)
 ```
 
-- **engine**: "remote" (default), "local", or batch instance type ("small", "medium", "large"). Other values are interpreted as batch instance type.
-- **cache_max_age**: Maximum age when returning a result from the cache (e.g. "48h", "10s"). Default `None` so the UDF follows `cache_max_age` from `@fused.udf()` unless overridden.
-- **cache**: Set to False as a shortcut for `cache_max_age='0s'` to disable caching. (Default True.)
-- **Returns**: The result of the UDF execution.
+Write the UDF to disk as a directory (folder).
 
-Learn more about [engine options](/guide/working-with-udfs/fused-run#engine) and [caching](/guide/working-with-udfs/udf-best-practices/caching).
+**Parameters:**
+
+- **where** (<code>str | Path | None</code>) – A path to a directory. If not provided, uses the UDF function name.
+
+**Other Parameters:**
+
+- **overwrite** (<code>[bool](#bool)</code>) – If true, overwriting is allowed.
+
+---
+
+### to_file
 
 ```python
-@fused.udf
-def udf():
-    # Call directly
-    result = my_udf(x=5, multiplier=3)  # Returns 15
-
-    # Run locally
-    result = my_udf(x=5, engine="local")
-
-    # Run on a dedicated instance
-    result = my_udf(x=5, engine="small")
-
-    # Cache results for 1 hour
-    result = my_udf(x=5, cache_max_age="1h")
-
-    # Disable caching
-    result = my_udf(x=5, cache=False)
-
-    return result
-
-@fused.udf
-def my_udf(x: int, multiplier: int = 2):
-    return x * multiplier
+to_file(where: str | Path | BinaryIO, *, overwrite: bool = False)
 ```
 
-**Parallel execution**
+Write the UDF to disk or the specified file-like object.
 
-Use [`.map()`](#map) to run a UDF in parallel across multiple inputs:
+The UDF will be written as a Zip file.
 
-```python 
-@fused.udf
-def udf():
-    # Create a pool of jobs
-    pool = my_udf.map([1, 2, 3])
-    df = pool.df()
-    return df
+**Parameters:**
 
-@fused.udf
-def my_udf(x: int):
-    return x ** 2
-```
+- **where** (<code>str | Path | BinaryIO</code>) – A path to a file or a file-like object.
+
+**Other Parameters:**
+
+- **overwrite** (<code>[bool](#bool)</code>) – If true, overwriting is allowed.
 
 ---
 
-## cache_max_age
-
-The maximum age when returning a result from the cache.
-
----
-
-## catalog_url
-
-Returns the link to open this UDF in the Workbench Catalog, or None if the UDF is not saved.
+### set_parameters
 
 ```python
-udf = fused.load("my_udf")
-print(udf.catalog_url)
-# https://www.fused.io/workbench/catalog/my_udf-abc123
-```
-
----
-
-## code
-
-The source code of the UDF as a string.
-
----
-
-## collection_id
-
-The ID of the collection this UDF belongs to.
-
----
-
-## collection_name
-
-The name of the collection this UDF belongs to.
-
----
-
-## create_access_token
-
-```python
-udf.create_access_token(
-    *,
-    client_id=None,      # override realtime environment
-    public_read=None,    # allow public read access
-    access_scope=None,   # access scope for the token
-    cache=True,          # enable caching on the token
-    metadata_json=None,  # additional metadata for tiles
-    enabled=True,        # whether the token is active
-) -> UdfAccessToken
-```
-
-Create an access token for sharing this UDF.
-
----
-
-## invalidate_cache
-
-Invalidate cached results for `my_udf`:
-
-```python
-udf = fused.load("my_udf")
-udf.invalidate_cache()
-```
-
----
-
-## delete_saved
-
-```python
-udf.delete_saved(
-    inplace=True,  # update this object to reflect deletion
-)
-```
-
-Delete this UDF from the Fused service.
-
----
-
-## disk_size_gb
-
-The size of the disk in GB to use for remote execution. Used in batch jobs.
-
----
-
-## entrypoint
-
-Name of the function within the code to invoke.
-
----
-
-## from_gist
-
-```python
-@classmethod
-Udf.from_gist(
-    gist_id,  # the GitHub gist ID
+set_parameters(
+    parameters: dict[str, Any],
+    replace_parameters: bool = False,
+    inplace: bool = False,
 ) -> Udf
 ```
 
-Create a UDF from a GitHub gist.
+Set the parameters on this UDF.
+
+**Parameters:**
+
+- **parameters** (<code>dict[str, Any]</code>) – The new parameters dictionary.
+- **replace_parameters** (<code>bool</code>) – If True, unset any parameters not in the parameters argument. Defaults to False.
+- **inplace** (<code>bool</code>) – If True, modify this object. If False, return a new object. Defaults to True.
+
+Deprecated: Set parameters when calling the UDF or using `UDF.map()` instead.
 
 ---
 
-## get_access_token
+### eval_schema
 
 ```python
-udf.get_access_token() -> UdfAccessToken | None
+eval_schema(inplace: bool = False) -> Udf
 ```
 
-Get the first access token, or `None` if none exists.
+Reload the schema saved in the code of the UDF.
+
+Note that this will evaluate the UDF function.
+
+**Parameters:**
+
+- **inplace** (<code>bool</code>) – If True, update this UDF object. Otherwise return a new UDF object (default).
+
+Deprecated: Do not call this.
 
 ---
 
-## get_access_tokens
+### run_local
 
 ```python
-udf.get_access_tokens() -> UdfAccessTokenList
+run_local(*, inplace: bool = False, **kwargs: bool) -> UdfEvaluationResult
 ```
 
-Get all access tokens for this UDF.
+Evaluate this UDF against a sample.
+
+**Parameters:**
+
+- **inplace** (<code>bool</code>) – If True, update this UDF object with schema information. (default)
+
+Deprecated: Call the UDF instead.
 
 ---
 
-## get_schedule
+### map
 
 ```python
-udf.get_schedule() -> CronJobSequence
-```
-
-Retrieve scheduled runs of this UDF.
-
----
-
-## engine
-
-The engine to run this UDF on by default, if not specified in `fused.run()`, e.g., "small"/"medium"/"large".
-
----
-
-## instance_type [Deprecated]
-
-**[Deprecated]** Use [`engine`](#engine) instead. This property is an alias for `engine`.
-
----
-
-## map
-
-```python
-udf.map(
-    arg_list,
+map(
+    arg_list: list[Any] | pd.DataFrame,
     *,
-    engine=None,
-    cache_max_age=None,
-    max_workers=None,
-    worker_concurrency=None,
-    cache=True,
-    max_retry=2,
-) -> JobPool
+    engine: Engine | None = None,
+    max_workers: int | None = None,
+    worker_concurrency: int | None = None,
+    max_retry: int = 2,
+    debug_mode: bool = False,
+    cache_max_age: str | None = None,
+    run_cache_max_age: str | int | None = None,
+    cache: bool = True,
+    _before_run: float | None = None,
+    _before_submit: float | None = 0.01,
+    _isolate_streams: bool = True,
+    **kwargs: bool
+) -> "JobPool"
 ```
 
 Submit a job for each element in arg_list.
 
-- **arg_list**: A list of arguments to pass to the UDF. Each element in arg_list will become a job and run.
-- **engine**: "remote" (default), "local", or "small"/"medium"/"large". Other values are interpreted as a batch instance type.
-- **max_workers**: For realtime: number of instances (default 32). For local: number of threads (default 1). For batch: number of worker machines (default 1).
-- **worker_concurrency**: For realtime: arguments per instance (default 1). For batch: processes per worker. Not settable for local.
-- **cache_max_age**: Max age when returning a result from the cache (e.g. "48h", "10s"). Default `None` to follow `@fused.udf()`.
-- **cache**: Set to False to disable caching. (Default True.)
-- **max_retry**: Max retries for failed jobs (default 2). Retries only if the pool is waited on (e.g. `pool.wait()`, `pool.tail()`, `pool.df()`).
+**Parameters:**
 
-**Returns:** A JobPool object. Call `.df()` to get the results.
+- **arg_list** (<code>list[Any] | pd.DataFrame</code>) – A list of arguments to pass to the UDF. Each element
+  in arg_list will become a job and run.
+- **engine** (<code>Engine | None</code>) – The engine to use for execution.
+  "remote": Run on a realtime instance. (Default)
+  "local": Run locally.
+  "small", "medium", "large": Run on a batch instance.
+  Other values will be interpreted as a batch instance type.
+- **max_workers** (<code>int | None</code>) – The maximum number of workers to use.
+  For running on realtime instances, this is the number of
+  instances to use. (Default 32)
+  For running locally, this is the number of threads to use.
+  (Default 1)
+  For running on batch instances, this is the number of worker
+  machines to use. (Default 1)
+- **worker_concurrency** (<code>int | None</code>) – The concurrency level for each worker.
+  For running on realtime instances, this is the number of
+  arguments to run in each instance at a time. (Default 1)
+  For running locally, this cannot be set.
+  For running on batch instances, this is the number of processes
+  to use in each worker machine. (Default based on the number of
+  cores in the machine.)
+- **max_retry** (<code>int</code>) – The maximum number of retries for failed jobs. (Default 2)
+  Note that retries will only be attempted if the object is waited on,
+  e.g. with `pool.wait()`, `pool.tail()`, or `pool.df()`.
+- **debug_mode** (<code>bool</code>) – If True, executes only the first item in arg_list directly using
+  `fused.run()`, useful for debugging UDF execution. Default is False.
+- **cache_max_age** (<code>str | None</code>) – The maximum age when returning a result from the cache.
+  Supported units are seconds (s), minutes (m), hours (h), and days (d) (e.g. “48h”, “10s”, etc.).
+  Default is `None` so a UDF will follow `cache_max_age` defined in `@fused.udf()` unless this value is changed.
+- **run_cache_max_age** (<code>str | int | None</code>) – When set, wraps each inner `fused.run` with `fused.cache` so
+  cache hits skip the HTTP round-trip (client-side disk cache). Uses the same
+  `cache_reset`, `cache_storage`, and `cache_verbose` as the submit-level cache.
+- **cache** (<code>bool</code>) – Set to False as a shortcut for `cache_max_age='0s'` to disable caching. (Default True)
+- \*\***kwargs** – Additional (constant) keyword arguments to pass to the UDF.
 
-**Example:**
+**Returns:**
 
-```python
-@fused.udf
-def my_udf(x: int):
-    return x * 2
+- <code>'JobPool'</code> – A JobPool object. Call `.df()` to get the results.
 
-pool = my_udf.map([1, 2, 3])
-df = pool.df()  # Returns [2, 4, 6]
-```
+<details class="note" open>
+<summary>Note</summary>
+For remote runs (default or ``engine="remote"``) without ``worker_concurrency``,
+an asyncio-based pool is used. Local runs and batch instance types still use a
+thread (or process) pool where appropriate.
+</details>
 
-```python
-@fused.udf
-def my_udf(a: int, b: int):
-    return a + b
-
-a_values = [1, 3, 5]
-b_values = [2, 4, 6]
-
-arg_list = [{"a": a, "b": b} for a, b in zip(a_values, b_values)]
-pool = my_udf.map(arg_list)
-df = pool.df()  # Runs jobs for (1,2), (3,4), (5,6)
-```
-
-```python
-import pandas as pd
-
-arg_list = pd.DataFrame({
-    "a": [1, 3, 5],
-    "b": [2, 4, 6],
-})
-
-pool = my_udf.map(arg_list)
-df = pool.df()  # DataFrame rows map to jobs
-```
+<details class="example" open>
+<summary>Example</summary>
+>>> @fused.udf()
+... def my_udf(x: int):
+...     return x + 1
+...
+>>> pool = my_udf.map([1, 2, 3])
+>>> results = pool.df()
+>>> print(results)
+[2, 3, 4]
+</details>
 
 ---
 
-## map_async
+### map_async
 
 ```python
-await udf.map_async(
+map_async(
     arg_list,
     *,
-    engine=None,
-    max_workers=None,
-    cache_max_age=None,
-    cache=True,
-    max_retry=2,
-) -> AsyncJobPool
+    engine: Engine | None = None,
+    max_workers: int | None = None,
+    cache_max_age: str | None = None,
+    cache: bool = True,
+    max_retry: int = 2
+) -> "JobPool"
 ```
 
-Submit a job for each element in arg_list. (Async; use in async contexts.)
+Submit a job for each element in arg_list.
 
-- **arg_list**: A list of arguments to pass to the UDF. Each element will become a job and run.
-- **engine**: "remote" (default) or "local". Note: batch instance types are not supported for async map.
-- **max_workers**: For realtime: number of instances (default 32). For local: number of threads (default 1).
-- **cache_max_age**: Max age when returning a result from the cache. Default `None` to follow `@fused.udf()`.
-- **cache**: Set to False to disable caching. (Default True.)
-- **max_retry**: Max retries for failed jobs (default 2). Retries only if the pool is waited on.
+.. deprecated::
+`map_async` is deprecated. Use :meth:`map` instead; for remote runs
+without `worker_concurrency`, :meth:`map` already uses the same
+asyncio-based execution path.
 
-Note: worker_concurrency is not supported for async map.
+**Parameters:**
 
-**Returns:** An AsyncJobPool object. Call `.df()` to get the results.
+- **arg_list** – A list of arguments to pass to the UDF. Each element
+  in arg_list will become a job and run.
+- **engine** (<code>Engine | None</code>) – The engine to use for execution.
+  "remote": Run on a realtime instance. (Default)
+  "local": Run locally.
+  Note: batch instance types are not supported for async map.
+- **max_workers** (<code>int | None</code>) – The maximum number of workers to use.
+  For running on realtime instances, this is the number of
+  instances to use. (Default 32)
+  For running locally, this is the number of threads to use.
+  (Default 1)
+- **cache_max_age** (<code>str | None</code>) – The maximum age when returning a result from the cache.
+  Supported units are seconds (s), minutes (m), hours (h), and days (d) (e.g. “48h”, “10s”, etc.).
+  Default is `None` so a UDF will follow `cache_max_age` defined in `@fused.udf()` unless this value is changed.
+- **cache** (<code>bool</code>) – Set to False as a shortcut for `cache_max_age='0s'` to disable caching. (Default True)
+- **max_retry** (<code>int</code>) – The maximum number of retries for failed jobs. (Default 2)
+  Note that retries will only be attempted if the object is waited on,
+  e.g. with `pool.wait()`, `pool.tail()`, or `pool.df()`.
 
-**Example:**
+Note worker_concurrency is not supported for async map.
 
-```python
-@fused.udf
-def my_udf(x: int):
-    return x ** 2
+**Returns:**
 
-# In an async context
-pool = await my_udf.map_async([1, 2, 3, 4, 5])
-await pool.wait_async()
-results = await pool.results_async()
-```
+- <code>'JobPool'</code> – An AsyncJobPool object. Call `.df()` to get the results.
 
----
-
-## metadata
-
-Optional dictionary of metadata associated with the UDF.
-
----
-
-## name
-
-The name of the UDF. Defaults to the function name.
-
----
-
-## parameters
-
-Parameters to pass into the entrypoint.
-
----
-
-## region
-
-The region to use for remote execution. Used in batch jobs.
+<details class="example" open>
+<summary>Example</summary>
+>>> @fused.udf()
+... def my_udf(x: int):
+...     return x + 1
+...
+>>> pool = my_udf.map([1, 2, 3])
+>>> results = pool.df()
+>>> print(results)
+[2, 3, 4]
+</details>
 
 ---
 
-## render
-
-```python
-udf.render()
-```
-
-Render the UDF code in a Jupyter notebook cell. Only works in Jupyter environments.
-
----
-
-## schedule
-
-```python
-udf.schedule(
-    minute,             # minute(s) to run (0-59)
-    hour,               # hour(s) to run (0-23)
-    day_of_month=None,  # day(s) of month (1-31)
-    month=None,         # month(s) (1-12)
-    day_of_week=None,   # day(s) of week (0-6, 0=Sunday)
-    udf_args=None,      # arguments to pass to the UDF
-    enabled=True,       # whether the schedule is active
-) -> CronJob
-```
-
-Schedule this UDF to run on a cron schedule.
-
-Example:
-
-```python
-# Run every day at 8:00 AM
-udf.schedule(minute=0, hour=8)
-
-# Run every Monday at noon
-udf.schedule(minute=0, hour=12, day_of_week=1)
-```
-
----
-
-## shared_url
-
-```python
-udf.shared_url(
-    format=None,  # result format (file type) for the URL
-) -> str | None
-```
-
-Get the shared URL for this UDF.
-
----
-
-## to_directory
-
-```python
-udf.to_directory(
-    where=None,       # directory path (defaults to UDF name)
-    *,
-    overwrite=False,  # allow overwriting
-)
-```
-
-Write the UDF to disk as a directory.
-
----
-
-## to_file
-
-```python
-udf.to_file(
-    where,            # file path or file-like object
-    *,
-    overwrite=False,  # allow overwriting
-)
-```
-
-Write the UDF to disk as a zip file.
-
----
-
-## to_fused
-
-```python
-udf.to_fused(
-    *,
-    overwrite=None,       # if True, overwrite existing remote UDF
-    collection_name=None, # collection to save to (default: "default")
-)
-```
-
-Save this UDF to the Fused service.

--- a/docs/python-sdk/top-level-functions.mdx
+++ b/docs/python-sdk/top-level-functions.mdx
@@ -1,0 +1,929 @@
+---
+sidebar_label: Top-Level Functions
+title: Top-Level Functions
+toc_max_heading_level: 4
+---
+
+## @fused.udf
+
+```python
+udf(
+    fn: Optional[Callable] = None,
+    *,
+    name: Optional[str] = None,
+    cache_max_age: Optional[str] = None,
+    engine: Optional[str] = None,
+    instance_type: Optional[str] = None,
+    disk_size_gb: Optional[int] = None,
+    region: Optional[str] = None,
+    default_parameters: Optional[Dict[str, Any]] = None,
+    headers: Optional[Sequence[Union[str, Header]]] = None
+) -> Callable[..., Udf]
+```
+
+A decorator that transforms a function into a Fused UDF.
+
+**Parameters:**
+
+- **name** (<code>Optional[str]</code>) – The name of the UDF object. Defaults to the name of the function.
+
+- **cache_max_age** (<code>Optional[str]</code>) – The maximum age when returning a result from the cache.
+
+- **engine** (<code>Optional[str]</code>) – The execution engine to use ('remote', 'local', 'realtime', or a batch
+  instance type like 'small', 'medium', 'large', 'm5.large', etc.).
+  If not specified (and also not specified in `fused.run()`), defaults
+  to 'realtime'.
+
+- **disk_size_gb** (<code>Optional[int]</code>) – The size of the disk in GB to use for remote execution
+  (only supported for a batch instance type).
+
+- **default_parameters** (<code>Optional\[Dict[str, Any]\]</code>) – Parameters to embed in the UDF object, separately from the arguments
+  list of the function. Defaults to None for empty parameters.
+
+- **headers** (<code>Optional\[Sequence\[Union[str, Header]\]\]</code>) – A list of files to include as modules when running the UDF. For example,
+  when specifying `headers=['my_header.py']`, inside the UDF function it may be
+  referenced as:
+
+  ```py
+  import my_header
+  my_header.my_function()
+  ```
+
+  Defaults to None for no headers.
+
+**Returns:**
+
+- <code>[Callable](#typing.Callable)\[..., [Udf](#fused.models.udf.Udf)\]</code> – A callable that represents the transformed UDF. This callable can be used
+- <code>[Callable](#typing.Callable)\[..., [Udf](#fused.models.udf.Udf)\]</code> – within GeoPandas workflows to apply the defined operation on geospatial data.
+
+**Examples:**
+
+To create a simple UDF that calls a utility function to calculate the area of geometries in a GeoDataFrame:
+
+```py
+@fused.udf
+def udf(bbox, table_path="s3://fused-asset/infra/building_msft_us"):
+    ...
+    gdf = table_to_tile(bbox, table=table_path)
+    return gdf
+```
+
+To create a UDF that runs on a specific instance type:
+
+```py
+@fused.udf(engine='large')
+def udf(bbox):
+    # This will run on a large batch instance
+    ...
+    return result
+```
+
+---
+
+## @fused.cache
+
+```python
+cache(
+    func: Callable[..., Any] | None = None,
+    cache_max_age: str | int | None = None,
+    cache_folder_path: str = "tmp",
+    concurrent_lock_timeout: str | int = 120,
+    cache_reset: bool | None = None,
+    cache_storage: StorageStr | None = None,
+    cache_key_exclude: Iterable[str] = None,
+    cache_verbose: bool | None = None,
+) -> Callable[..., Any]
+```
+
+Decorator to cache the return value of a function.
+
+This function serves as a decorator that can be applied to any function
+to cache its return values. The cache behavior can be customized through
+keyword arguments.
+
+**Parameters:**
+
+- **func** (<code>Callable</code>) – The function to be decorated. If None, this
+  returns a partial decorator with the passed keyword arguments.
+- **cache_max_age** (<code>str | int | None</code>) – A string with a numbered component and units. Supported units are seconds (s), minutes (m), hours (h), and
+  days (d) (e.g. "48h", "10s", etc.).
+- **cache_folder_path** (<code>str</code>) – Folder to append to the configured cache directory.
+- **concurrent_lock_timeout** (<code>str | int</code>) – Max amount of time in seconds for subsequent concurrent calls to wait for a previous
+  concurrent call to finish execution and to write the cache file.
+- **cache_reset** (<code>bool | None</code>) – Ignore `cache_max_age` and overwrite cached result.
+- **cache_storage** (<code>StorageStr | None</code>) – Set where the cache data is stored. Supported values are "auto", "mount" and "local". Auto will
+  automatically select the storage location defined in options (mount if it exists, otherwise local) and
+  ensures that it exists and is writable. Mount gets shared across executions where local will only be shared
+  within the same execution.
+- **cache_key_exclude** (<code>Iterable[str]</code>) – An iterable of parameter names to exclude from the cache key calculation. Useful for
+  arguments that do not affect the result of the function and could cause unintended cache expiry (e.g.
+  database connection objects)
+- **cache_verbose** (<code>bool | None</code>) – Print a message when a cached result is returned
+
+Returns:
+Callable: A decorator that, when applied to a function, caches its
+return values according to the specified keyword arguments.
+
+**Examples:**
+
+Use the `@cache` decorator to cache the return value of a function:
+
+```py
+@fused.cache
+def expensive_function():
+    # Function implementation goes here
+    return result
+```
+
+If the output of a cached function changes, for example if remote data is modified,
+it can be reset by running the function with the `cache_reset` keyword argument. Afterward,
+the argument can be cleared.
+
+```py
+expensive_function(cache_reset=True)
+```
+
+---
+
+## fused.load
+
+```python
+load(
+    url_or_udf: Union[str, Path],
+    /,
+    *,
+    cache_key: Any = None,
+    import_globals: bool = True,
+    collection_name: str | None = None,
+) -> AnyBaseUdf
+```
+
+Loads a UDF from various sources including GitHub URLs,
+and a Fused platform-specific identifier.
+
+This function supports loading UDFs from a GitHub repository URL, or a Fused
+platform-specific identifier composed of an email and UDF name. It intelligently
+determines the source type based on the format of the input and retrieves the UDF
+accordingly.
+
+**Parameters:**
+
+- **url_or_udf** (<code>Union[str, Path]</code>) – A string representing the location of the UDF, or the raw code of the UDF.
+  The location can be a GitHub URL starting with "https://github.com",
+  a Fused platform-specific identifier in the format "email/udf_name",
+  or a local file path pointing to a Python file.
+- **cache_key** (<code>Any</code>) – An optional key used for caching the loaded UDF. If provided, the function
+  will attempt to load the UDF from cache using this key before attempting to
+  load it from the specified source. Defaults to None, indicating no caching.
+- **import_globals** (<code>bool</code>) – Expose the globals defined in the UDF's context as attributes on the UDF object (default True).
+  This requires executing the code of the UDF. To globally configure this behavior, use `fused.options.never_import`.
+- **collection_name** (<code>str | None</code>) – Collection name to load the UDF from. If not provided, will attempt to
+  use the collection of the currently executing UDF, or default to "default".
+
+**Returns:**
+
+- **AnyBaseUdf** (<code>[AnyBaseUdf](#fused.models.udf.AnyBaseUdf)</code>) – An instance of the loaded UDF.
+
+**Raises:**
+
+- <code>[ValueError](#ValueError)</code> – If the URL or Fused platform-specific identifier format is incorrect or
+  cannot be parsed.
+- <code>[Exception](#Exception)</code> – For errors related to network issues, file access permissions, or other
+  unforeseen errors during the loading process.
+
+**Examples:**
+
+Load a UDF from a GitHub URL:
+
+```py
+udf = fused.load("https://github.com/fusedio/udfs/tree/main/public/REM_with_HyRiver/")
+```
+
+Load a UDF using a Fused platform-specific identifier:
+
+```py
+udf = fused.load("username@fused.io/REM_with_HyRiver")
+```
+
+---
+
+## fused.run
+
+```python
+run(
+    udf: Union[str, None, UdfJobStepConfig, Udf, UdfAccessToken] = None,
+    *,
+    x: Optional[int] = None,
+    y: Optional[int] = None,
+    z: Optional[int] = None,
+    sync: bool = True,
+    engine: Optional[Literal["remote", "local"]] = None,
+    instance_type: Optional[InstanceType] = None,
+    type: Optional[Literal["tile", "file"]] = None,
+    max_retry: int = 0,
+    cache_max_age: Optional[str] = None,
+    cache: bool = True,
+    parameters: Optional[Dict[str, Any]] = None,
+    disk_size_gb: Optional[int] = None,
+    _return_response: Optional[bool] = False,
+    _ignore_unknown_arguments: bool = False,
+    _cancel_callback: Callable[[], bool] | None = None,
+    **kw_parameters: Callable[[], bool] | None
+) -> Union[
+    ResultType,
+    Coroutine[ResultType, None, None],
+    UdfEvaluationResult,
+    Coroutine[UdfEvaluationResult, None, None],
+]
+```
+
+Executes a user-defined function (UDF) with various execution and input options.
+
+This function supports executing UDFs in different environments (local or remote),
+with different types of inputs (tile coordinates, geographical bounding boxes, etc.), and
+allows for both synchronous and asynchronous execution. It dynamically determines the execution
+path based on the provided parameters.
+
+**Parameters:**
+
+- **udf** (<code>str, Udf or UdfJobStepConfig</code>) – the UDF to execute.
+  The UDF can be specified in several ways:
+  - A string representing a UDF name or UDF shared token.
+  - A UDF object.
+  - A UdfJobStepConfig object for detailed execution configuration.
+- **x, y, z** – Tile coordinates for tile-based UDF execution.
+- **sync** (<code>bool</code>) – If True, execute the UDF synchronously. If False, execute asynchronously.
+- **engine** (<code>Optional\[Literal['remote', 'local']\]</code>) – The execution engine to use ('remote' or 'local').
+- **instance_type** (<code>Optional[InstanceType]</code>) – The type of instance to use for remote execution ('realtime',
+  or 'small', 'medium', 'large' or one of the whitelisted instance types).
+  If not specified, gets the default from the UDF (if specified in the
+  `@fused.udf()` decorator, and the UDF is not run as a shared token),
+  or otherwise defaults to 'realtime'.
+- **disk_size_gb** (<code>Optional[int]</code>) – The size of the disk in GB to use for remote execution
+  (only supported for a batch (non-realtime) instance type).
+- **type** (<code>Optional\[Literal['tile', 'file']\]</code>) – The type of UDF execution ('tile' or 'file').
+- **max_retry** (<code>int</code>) – The maximum number of retries to attempt if the UDF fails.
+  By default does not retry.
+- **cache_max_age** (<code>Optional[str]</code>) – The maximum age when returning a result from the cache.
+  Supported units are seconds (s), minutes (m), hours (h), and days (d) (e.g. “48h”, “10s”, etc.).
+  Default is `None` so a UDF run with `fused.run()` will follow `cache_max_age` defined in `@fused.udf()` unless this value is changed.
+- **cache** (<code>bool</code>) – Set to False as a shortcut for `cache_max_age='0s'` to disable caching.
+- **verbose** – Set to False to suppress any print statements from the UDF.
+- **parameters** (<code>Optional\[Dict[str, Any]\]</code>) – Additional parameters to pass to the UDF.
+- \*\***kw_parameters** – Additional parameters to pass to the UDF.
+
+**Raises:**
+
+- <code>[ValueError](#ValueError)</code> – If the UDF is not specified or is specified in more than one way.
+- <code>[TypeError](#TypeError)</code> – If the first parameter is not of an expected type.
+- <code>[Warning](#Warning)</code> – Various warnings are issued for ignored parameters based on the execution path chosen.
+
+**Returns:**
+
+- <code>[Union](#typing.Union)\[[ResultType](#fused._run.ResultType), [Coroutine](#typing.Coroutine)\[[ResultType](#fused._run.ResultType), None, None\], [UdfEvaluationResult](#fused.models.udf._eval_result.UdfEvaluationResult), [Coroutine](#typing.Coroutine)\[[UdfEvaluationResult](#fused.models.udf._eval_result.UdfEvaluationResult), None, None\]\]</code> – The result of the UDF execution, which varies based on the UDF and execution path.
+
+**Examples:**
+
+Run a UDF saved in the Fused system:
+
+```py
+fused.run("username@fused.io/my_udf_name")
+```
+
+Run a UDF saved in GitHub:
+
+```py
+loaded_udf = fused.load("https://github.com/fusedio/udfs/tree/main/public/Building_Tile_Example")
+fused.run(loaded_udf, bbox=bbox)
+```
+
+Run a UDF saved in a local directory:
+
+```py
+loaded_udf = fused.load("/Users/local/dir/Building_Tile_Example")
+fused.run(loaded_udf, bbox=bbox)
+```
+
+<details class="note" open>
+<summary>Note</summary>
+This function dynamically determines the execution path and parameters based on the inputs.
+It is designed to be flexible and support various UDF execution scenarios.
+</details>
+
+---
+
+## fused.submit
+
+```python
+submit(
+    udf: AnyBaseUdf | FunctionType | str,
+    arg_list: list | pd.DataFrame,
+    *,
+    engine: Literal["remote", "local"] | None = "remote",
+    instance_type: InstanceType | None = None,
+    max_workers: int | None = None,
+    n_processes_per_worker: int | None = None,
+    max_retry: int = 2,
+    debug_mode: bool = False,
+    collect: bool = True,
+    execution_type: ExecutionType = "thread_pool",
+    cache_max_age: str | None = None,
+    run_cache_max_age: str | int | None = None,
+    cache: bool = True,
+    ignore_exceptions: bool = False,
+    flatten: bool = True,
+    _before_run: float | None = None,
+    _before_submit: float | None = 0.01,
+    _isolate_streams: bool = True,
+    drop_index: bool = False,
+    **kwargs: bool
+) -> JobPool | ResultType | pd.DataFrame
+```
+
+Executes a user-defined function (UDF) multiple times for a list of input
+parameters, and return immediately a "lazy" JobPool object allowing
+to inspect the jobs and wait on the results.
+
+Each individual UDF run will be cached following the standard caching logic as with `fused.run()`
+and the specified `cache_max_age`. Additionally, when `collect=True` (the default), the collected results
+are cached locally for the duration of `cache_max_age` or 12h by default.
+
+See `fused.run` for more details on the UDF execution.
+
+**Parameters:**
+
+- **udf** (<code>AnyBaseUdf | FunctionType | str</code>) – the UDF to execute.
+  See `fused.run` for more details on how to specify the UDF.
+- **arg_list** (<code>list | pd.DataFrame</code>) – a list of input parameters for the UDF. Can be specified as:
+  - a list of values for parametrizing over a single parameter, i.e.
+    the first parameter of the UDF
+  - a list of dictionaries for parametrizing over multiple parameters
+  - A DataFrame for parametrizing over multiple parameters where each
+    row is a set of parameters
+- **engine** (<code>Literal['remote', 'local'] | None</code>) – The execution engine to use. Defaults to 'remote'.
+- **instance_type** (<code>InstanceType | None</code>) – The type of instance to use for remote execution ('realtime',
+  or 'small', 'medium', 'large' or one of the whitelisted instance types).
+  If not specified, gets the default from the UDF (if specified in the
+  `@fused.udf()` decorator, and the UDF is not run as a shared token),
+  or otherwise defaults to 'realtime'.
+- **max_workers** (<code>int | None</code>) – The maximum number of workers to use. Defaults to 32 for
+  the realtime engine (with a maximum of 1024), and 1 for other batch
+  instances (with a maximum of 5).
+- **n_processes_per_worker** (<code>int | None</code>) – The number of processes to use per worker.
+  For realtime instances, defaults to 1 (each arg processes in its own lambda).
+  Set to >1 to chunk the arg_list and process multiple items in parallel within
+  each realtime lambda instance, reducing the total number of lambda invocations.
+  For batch instances, defaults to the number of cores.
+- **max_retry** (<code>int</code>) – The maximum number of retries for failed jobs. Defaults to 2.
+  Note that retries will only be attempted if the JobPool object is waited on,
+  e.g. with `pool.wait()`, `pool.tail()`, or `pool.df()`.
+- **debug_mode** (<code>bool</code>) – If True, executes only the first item in arg_list directly using
+  `fused.run()`, useful for debugging UDF execution. Default is False.
+- **collect** (<code>bool</code>) – If True, waits for all jobs to complete and returns the collected DataFrame
+  containing the results. If False, returns a JobPool object, which is non-blocking
+  and allows you to inspect the individual results and logs.
+  Default is True.
+- **execution_type** (<code>ExecutionType</code>) – The type of batching to use. Either "thread_pool" (default) for
+  ThreadPoolExecutor-based concurrency or "async_loop" for asyncio-based concurrency.
+- **cache_max_age** (<code>str | None</code>) – The maximum age when returning a result from the cache.
+  Supported units are seconds (s), minutes (m), hours (h), and days (d)
+  (e.g. "48h", "10s", etc.).
+  Default is `None` so a UDF run with `fused.run()` will follow
+  `cache_max_age` defined in `@fused.udf()` unless this value is changed.
+- **cache** (<code>bool</code>) – Set to False as a shortcut for `cache_max_age='0s'` to disable caching.
+- **run_cache_max_age** (<code>str | int | None</code>) – When set, wraps each inner `fused.run` with `fused.cache` so
+  cache hits skip the HTTP round-trip (client-side disk cache). Uses the same
+  `cache_reset`, `cache_storage`, and `cache_verbose` as the submit-level cache.
+- **ignore_exceptions** (<code>bool</code>) – Set to True to ignore exceptions when collecting results.
+  Runs that result in exceptions will be silently ignored. Defaults to False.
+- **flatten** (<code>bool</code>) – Set to True to receive a DataFrame of results, without nesting of a
+  `results` column, when collecting results. When False, results will be nested
+  in a `results` column. If the UDF does not return a DataFrame (e.g. a string
+  instead,) results will be nested in a `results` column regardless of this setting.
+  Defaults to False.
+- **drop_index** (<code>bool</code>) – Set to False to use the position of the argument as the index instead
+  of the argument values. Defaults to True.
+- \*\***kwargs** – Additional (constant) keyword arguments to pass to the UDF.
+
+**Returns:**
+
+- <code>[JobPool](#fused._submit.JobPool) | [ResultType](#fused._run.ResultType) | [DataFrame](#pandas.DataFrame)</code> – JobPool, or DataFrame depending on execution_type and collect parameters
+
+**Examples:**
+
+Run a UDF multiple times for the values 0 to 9 passed to as the first
+positional argument of the UDF:
+
+```py
+df = fused.submit("username@fused.io/my_udf_name", range(10))
+```
+
+Using async batch type:
+
+```py
+df = fused.submit(udf, range(10), execution_type="async_loop")
+```
+
+Being explicit about the parameter name:
+
+```py
+df = fused.submit(udf, [dict(n=i) for i in range(10)])
+```
+
+Get the pool of ongoing tasks:
+
+```py
+pool = fused.submit(udf, [dict(n=i) for i in range(10)], collect=False)
+```
+
+---
+
+## fused.download
+
+```python
+download(url: str, file_path: str, storage: StorageStr = 'auto') -> str
+```
+
+Download a file.
+
+May be called from multiple processes with the same inputs to get the same result.
+
+Fused runs UDFs from top to bottom each time code changes. This means objects in the UDF are recreated each time, which can slow down a UDF that downloads files from a remote server.
+
+💡 Downloaded files are written to a mounted volume shared across all UDFs in an organization. This means that a file downloaded by one UDF can be read by other UDFs.
+
+Fused addresses the latency of downloading files with the download utility function. It stores files in the mounted filesystem so they only download the first time.
+
+💡 Because a Tile UDF runs multiple chunks in parallel, the download function sets a signal lock during the first download attempt, to ensure the download happens only once.
+
+**Parameters:**
+
+- **url** (<code>str</code>) – The URL to download.
+- **file_path** (<code>str</code>) – The local path where to save the file.
+- **storage** (<code>StorageStr</code>) – Set where the cache data is stored. Supported values are "auto", "mount" and "local". Auto will
+  automatically select the storage location defined in options (mount if it exists, otherwise local) and
+  ensures that it exists and is writable. Mount gets shared across executions where local will only be shared
+  within the same execution.
+
+**Returns:**
+
+- <code>[str](#str)</code> – The function downloads the file only on the first execution, and returns the file path.
+
+**Examples:**
+
+```python
+@fused.udf
+def geodataframe_from_geojson():
+    import geopandas as gpd
+    url = "s3://sample_bucket/my_geojson.zip"
+    path = fused.core.download(url, "tmp/my_geojson.zip")
+    gdf = gpd.read_file(path)
+    return gdf
+```
+
+---
+
+## fused.ingest
+
+```python
+ingest(
+    input: str | Path | Sequence[str | Path] | gpd.GeoDataFrame,
+    output: str | None = None,
+    *,
+    output_metadata: str | None = None,
+    schema: Schema | None = None,
+    file_suffix: str | None = None,
+    load_columns: Sequence[str] | None = None,
+    remove_cols: Sequence[str] | None = None,
+    explode_geometries: bool = False,
+    drop_out_of_bounds: bool | None = None,
+    partitioning_method: Literal["area", "length", "coords", "rows"] = "rows",
+    partitioning_maximum_per_file: int | float | None = None,
+    partitioning_maximum_per_chunk: int | float | None = None,
+    partitioning_max_width_ratio: int | float = 2,
+    partitioning_max_height_ratio: int | float = 2,
+    partitioning_force_utm: Literal["file", "chunk", None] = "chunk",
+    partitioning_split_method: Literal["mean", "median"] = "mean",
+    subdivide_method: Literal["area", None] = None,
+    subdivide_start: float | None = None,
+    subdivide_stop: float | None = None,
+    split_identical_centroids: bool = True,
+    target_num_chunks: int = 500,
+    lonlat_cols: tuple[str, str] | None = None,
+    partitioning_schema_input: str | pd.DataFrame | None = None,
+    gdal_config: GDALOpenConfig | dict[str, Any] | None = None,
+    overwrite: bool = False,
+    write_covering_bbox: bool = False,
+    as_udf: bool = False
+) -> GeospatialPartitionJobStepConfig
+```
+
+Ingest a dataset into the Fused partitioned format.
+
+**Parameters:**
+
+- **input** (<code>str | Path | Sequence[str | Path] | gpd.GeoDataFrame</code>) – A GeoPandas `GeoDataFrame` or a path to file or files on S3 to ingest. Files may be Parquet or another geo data format.
+
+- **output** (<code>str | None</code>) – Location on S3 to write the `main` table to.
+
+- **output_metadata** (<code>str | None</code>) – Location on S3 to write the `fused` table to.
+
+- **schema** (<code>Schema | None</code>) – Schema of the data to be ingested. This is optional and will be inferred from the data if not provided.
+
+- **file_suffix** (<code>str | None</code>) – filter which files are used for ingestion. If `input` is a directory on S3, all files under that directory will be listed and used for ingestion. If `file_suffix` is not None, it will be used to filter paths by checking the trailing characters of each filename. E.g. pass `file_suffix=".geojson"` to include only GeoJSON files inside the directory.
+
+- **load_columns** (<code>Sequence[str] | None</code>) – Read only this set of columns when ingesting geospatial datasets. Defaults to all columns.
+
+- **remove_cols** (<code>Sequence[str] | None</code>) – The named columns to drop when ingesting geospatial datasets. Defaults to not drop any columns.
+
+- **explode_geometries** (<code>bool</code>) – Whether to unpack multipart geometries to single geometries when ingesting geospatial datasets, saving each part as its own row. Defaults to `False`.
+
+- **drop_out_of_bounds** (<code>bool | None</code>) – Whether to drop geometries outside of the expected WGS84 bounds. Defaults to True.
+
+- **partitioning_method** (<code>Literal['area', 'length', 'coords', 'rows']</code>) – The method to use for grouping rows into partitions. Defaults to `"rows"`.
+
+  - `"area"`: Construct partitions where all contain a maximum total area among geometries.
+  - `"length"`: Construct partitions where all contain a maximum total length among geometries.
+  - `"coords"`: Construct partitions where all contain a maximum total number of coordinates among geometries.
+  - `"rows"`: Construct partitions where all contain a maximum number of rows.
+
+- **partitioning_maximum_per_file** (<code>int | float | None</code>) – Maximum value for `partitioning_method` to use per file. If `None`, defaults to _1/10th_ of the total value of `partitioning_method`. So if the value is `None` and `partitioning_method` is `"area"`, then each file will have no more than 1/10th the total area of all geometries. Defaults to `None`.
+
+- **partitioning_maximum_per_chunk** (<code>int | float | None</code>) – Maximum value for `partitioning_method` to use per chunk. If `None`, defaults to _1/100th_ of the total value of `partitioning_method`. So if the value is `None` and `partitioning_method` is `"area"`, then each file will have no more than 1/100th the total area of all geometries. Defaults to `None`.
+
+- **partitioning_max_width_ratio** (<code>int | float</code>) – The maximum ratio of width to height of each partition to use in the ingestion process. So for example, if the value is `2`, then if the width divided by the height is greater than `2`, the box will be split in half along the horizontal axis. Defaults to `2`.
+
+- **partitioning_max_height_ratio** (<code>int | float</code>) – The maximum ratio of height to width of each partition to use in the ingestion process. So for example, if the value is `2`, then if the height divided by the width is greater than `2`, the box will be split in half along the vertical axis. Defaults to `2`.
+
+- **partitioning_force_utm** (<code>Literal['file', 'chunk', None]</code>) – Whether to force partitioning within UTM zones. If set to `"file"`, this will ensure that the centroid of all geometries per _file_ are contained in the same UTM zone. If set to `"chunk"`, this will ensure that the centroid of all geometries per _chunk_ are contained in the same UTM zone. If set to `None`, then no UTM-based partitioning will be done. Defaults to "chunk".
+
+- **partitioning_split_method** (<code>Literal['mean', 'median']</code>) – How to split one partition into children. Defaults to `"mean"` (this may change in the future).
+
+  - `"mean"`: Split each axis according to the mean of the centroid values.
+  - `"median"`: Split each axis according to the median of the centroid values.
+
+- **subdivide_method** (<code>Literal['area', None]</code>) – The method to use for subdividing large geometries into multiple rows. Currently the only option is `"area"`, where geometries will be subdivided based on their area (in WGS84 degrees).
+
+- **subdivide_start** (<code>float | None</code>) – The value above which geometries will be subdivided into smaller parts, according to `subdivide_method`.
+
+- **subdivide_stop** (<code>float | None</code>) – The value below which geometries will not be subdivided into smaller parts, according to `subdivide_method`. Recommended to be equal to subdivide_start. If `None`, geometries will be subdivided up to a recursion depth of 100 or until the subdivided geometry is rectangular.
+
+- **split_identical_centroids** (<code>bool</code>) – If `True`, should split a partition that has
+  identical centroids (such as if all geometries in the partition are the
+  same) if there are more such rows than defined in "partitioning_maximum_per_file" and
+  "partitioning_maximum_per_chunk".
+
+- **target_num_chunks** (<code>int</code>) – The target for the number of files if `partitioning_maximum_per_file` is None. Note that this number is only a _target_ and the actual number of files generated can be higher or lower than this number, depending on the spatial distribution of the data itself.
+  Defaults to 500, rough default to use in most cases.
+
+- **lonlat_cols** (<code>tuple[str, str] | None</code>) – Names of longitude, latitude columns to construct point geometries from.
+
+  If your point columns are named `"x"` and `"y"`, then pass:
+
+  ```py
+  fused.ingest(
+      ...,
+      lonlat_cols=("x", "y")
+  )
+  ```
+
+  This only applies to reading from Parquet files. For reading from CSV files, pass options to `gdal_config`.
+
+- **gdal_config** (<code>GDALOpenConfig | dict[str, Any] | None</code>) – Configuration options to pass to GDAL for how to read these files. For all files other than Parquet files, Fused uses GDAL as a step in the ingestion process. For some inputs, like CSV files or zipped shapefiles, you may need to pass some parameters to GDAL to tell it how to open your files.
+
+  This config is expected to be a dictionary with up to two keys:
+
+  - `layer`: `str`. Define the layer of the input file you wish to read when the source contains multiple layers, as in GeoPackage.
+  - `open_options`: `Dict[str, str]`. Pass in key-value pairs with GDAL open options. These are defined on each driver's page in the GDAL documentation. For example, the [CSV driver](https://gdal.org/drivers/vector/csv.html) defines [these open options](https://gdal.org/drivers/vector/csv.html#open-options) you can pass in.
+
+  For example, if you're ingesting a CSV file with two columns
+  `"longitude"` and `"latitude"` denoting the coordinate information, pass
+
+  ```py
+  fused.ingest(
+      ...,
+      gdal_config={
+          "open_options": {
+              "X_POSSIBLE_NAMES": "longitude",
+              "Y_POSSIBLE_NAMES": "latitude",
+          }
+      }
+  )
+  ```
+
+- **overwrite** (<code>bool</code>) – If True, overwrite the output directory if it already exists
+  (by first removing all existing content of the directory, i.e. it
+  does not only overwrite conflicting files).
+  Defaults to False.
+
+- **write_covering_bbox** (<code>bool</code>) – If True, write output as GeoParquet 1.1 with a per-row
+  bbox covering column, enabling efficient spatial filtering. Defaults to False.
+
+- **as_udf** (<code>bool</code>) – Return the ingestion workflow as a UDF that can be executed using
+  `fused.run()`. Local files or python objects passed to `input` or
+  `partitioning_schema_input` are still uploaded to S3 first such that
+  those are available when executing the UDF remotely. Defaults to False.
+
+**Returns:**
+
+- <code>[GeospatialPartitionJobStepConfig](#fused.models.api.GeospatialPartitionJobStepConfig)</code> – Configuration object describing the ingestion process. Call `.execute` on this object to start a job.
+
+**Examples:**
+
+For example, to ingest the California Census dataset for the year 2022:
+
+```py
+job = fused.ingest(
+    input="https://www2.census.gov/geo/tiger/TIGER_RD18/STATE/06_CALIFORNIA/06/tl_rd22_06_bg.zip",
+    output="s3://fused-sample/census/ca_bg_2022/main/",
+    output_metadata="s3://fused-sample/census/ca_bg_2022/fused/",
+    explode_geometries=True,
+    partitioning_maximum_per_file=2000,
+    partitioning_maximum_per_chunk=200,
+).execute()
+```
+
+---
+
+
+#### `job.run_batch`
+
+```python showLineNumbers
+def run_batch(output_table: Optional[str] = ...,
+    instance_type: Optional[WHITELISTED_INSTANCE_TYPES] = None,
+    *,
+    region: str | None = None,
+    disk_size_gb: int | None = None,
+    additional_env: List[str] | None = None,
+    image_name: Optional[str] = None,
+    ignore_no_udf: bool = False,
+    ignore_no_output: bool = False,
+    validate_imports: Optional[bool] = None,
+    validate_inputs: bool = True,
+    overwrite: Optional[bool] = None) -> RunResponse
+```
+
+Begin execution of the ingestion job by calling `run_batch` on the job object.
+
+**Arguments**:
+
+- `output_table` - The name of the table to write to. Defaults to None.
+- `instance_type` - The AWS EC2 instance type to use for the job. Acceptable strings are `m5.large`, `m5.xlarge`, `m5.2xlarge`, `m5.4xlarge`, `m5.8xlarge`, `m5.12xlarge`, `m5.16xlarge`, `r5.large`, `r5.xlarge`, `r5.2xlarge`, `r5.4xlarge`, `r5.8xlarge`, `r5.12xlarge`, or `r5.16xlarge`. Defaults to None.
+- `region` - The AWS region in which to run. Defaults to None.
+- `disk_size_gb` - The disk size to specify for the job. Defaults to None.
+- `additional_env` - Any additional environment variables to be passed into the job. Defaults to None.
+- `image_name` - Custom image name to run. Defaults to None for default image.
+- `ignore_no_udf` - Ignore validation errors about not specifying a UDF. Defaults to False.
+- `ignore_no_output` - Ignore validation errors about not specifying output location. Defaults to False.
+
+#### Monitor and manage job
+
+Calling `run_batch` returns a `RunResponse` object with helper methods.
+
+```python showLineNumbers
+# Declare ingest job
+job = fused.ingest(
+  input="https://www2.census.gov/geo/tiger/TIGER_RD18/STATE/06_CALIFORNIA/06/tl_rd22_06_bg.zip",
+  output="s3://fused-sample/census/ca_bg_2022/main/"
+)
+
+# Start ingest job
+job_id = job.run_batch()
+```
+
+Fetch the job status.
+
+```python showLineNumbers
+job_id.get_status()
+```
+
+Fetch and print the job's logs.
+
+```python showLineNumbers
+job_id.print_logs()
+```
+
+Determine the job's execution time.
+
+```python showLineNumbers
+job_id.get_exec_time()
+```
+
+Continuously print the job's logs.
+
+```python showLineNumbers
+job_id.tail_logs()
+```
+
+Cancel the job.
+
+```python showLineNumbers
+job_id.cancel()
+```
+
+---
+
+#### `job.run_remote`
+
+Alias of `job.run_batch` for backwards compatibility. See `job.run_batch` above
+for details.
+
+---
+
+## fused.ingest_nongeospatial
+
+```python
+ingest_nongeospatial(
+    input: str | Path | Sequence[str, Path] | pd.DataFrame | gpd.GeoDataFrame,
+    output: str | None = None,
+    *,
+    output_metadata: str | None = None,
+    partition_col: str | None = None,
+    partitioning_maximum_per_file: int = 2500000,
+    partitioning_maximum_per_chunk: int = 65000
+) -> NonGeospatialPartitionJobStepConfig
+```
+
+Ingest a dataset into the Fused partitioned format.
+
+**Parameters:**
+
+- **input** (<code>str | Path | Sequence[str, Path] | pd.DataFrame | gpd.GeoDataFrame</code>) – A GeoPandas `GeoDataFrame` or a path to file or files on S3 to ingest. Files may be Parquet or another geo data format.
+- **output** (<code>str | None</code>) – Location on S3 to write the `main` table to.
+- **output_metadata** (<code>str | None</code>) – Location on S3 to write the `fused` table to.
+- **partition_col** (<code>str | None</code>) – Partition along this column for nongeospatial datasets.
+- **partitioning_maximum_per_file** (<code>int</code>) – Maximum number of items to store in a single file. Defaults to 2,500,000.
+- **partitioning_maximum_per_chunk** (<code>int</code>) – Maximum number of items to store in a single file. Defaults to 65,000.
+
+**Returns:**
+
+- <code>[NonGeospatialPartitionJobStepConfig](#fused.models.api.NonGeospatialPartitionJobStepConfig)</code> – Configuration object describing the ingestion process. Call `.execute` on this object to start a job.
+
+**Examples:**
+
+```py
+job = fused.ingest_nongeospatial(
+    input=gdf,
+    output="s3://sample-bucket/file.parquet",
+).execute()
+```
+
+---
+
+## fused.file_path
+
+```python
+file_path(
+    file_path: str, mkdir: bool = True, storage: StorageStr = "auto"
+) -> str
+```
+
+Creates a directory in a predefined temporary directory.
+
+This gives users the ability to manage directories during the execution of a UDF.
+It takes a relative file_path, creates the corresponding directory structure,
+and returns its absolute path.
+
+This is useful for UDFs that temporarily store intermediate results as files,
+such as when writing intermediary files to disk when processing large datasets.
+`file_path` ensures that necessary directories exist.
+The directory is kept for 12h.
+
+**Parameters:**
+
+- **file_path** (<code>str</code>) – The relative file path to locate.
+- **mkdir** (<code>bool</code>) – If True, create the directory if it doesn't already exist. Defaults to True.
+- **storage** (<code>StorageStr</code>) – Set where the cache data is stored. Supported values are "auto", "mount" and "local". Auto will
+  automatically select the storage location defined in options (mount if it exists, otherwise local) and
+  ensures that it exists and is writable. Mount gets shared across executions where local will only be shared
+  within the same execution.
+
+**Returns:**
+
+- <code>[str](#str)</code> – The located file path.
+
+---
+
+## fused.get_chunks_metadata
+
+```python
+get_chunks_metadata(url: str) -> gpd.GeoDataFrame
+```
+
+Returns a GeoDataFrame with each chunk in the table as a row.
+
+**Parameters:**
+
+- **url** (<code>str</code>) – URL of the table.
+
+---
+
+## fused.get_chunk_from_table
+
+```python
+get_chunk_from_table(
+    url: str,
+    file_id: Union[str, int, None],
+    chunk_id: Optional[int],
+    *,
+    columns: Optional[Iterable[str]] = None
+) -> gpd.GeoDataFrame
+```
+
+Returns a chunk from a table and chunk coordinates.
+
+This can be called with file_id and chunk_id from `get_chunks_metadata`.
+
+**Parameters:**
+
+- **url** (<code>str</code>) – URL of the table.
+- **file_id** (<code>Union[str, int, None]</code>) – File ID to read.
+- **chunk_id** (<code>Optional[int]</code>) – Chunk ID to read.
+- **columns** (<code>Optional\[Iterable[str]\]</code>) – Read only the specified columns.
+
+---
+
+## fused.find_dataset
+
+```python
+find_dataset(location: str, base_url: Optional[str] = None) -> Dict[str, Any]
+```
+
+Find the dataset that contains a specific location URL.
+
+Uses hierarchical prefix matching: if the exact path isn't registered,
+searches progressively shorter prefixes to find the containing dataset.
+
+**Parameters:**
+
+- **location** (<code>str</code>) – Full URL to search for (s3://, gs://, http://, etc.).
+  Can be a file, partition, or directory path.
+- **base_url** (<code>Optional[str]</code>) – Base URL for API. If None, uses current environment.
+
+**Returns:**
+
+- <code>[Dict](#typing.Dict)\[[str](#str), [Any](#typing.Any)\]</code> – Dataset dict with keys: id, location, description, storage_type,
+- <code>[Dict](#typing.Dict)\[[str](#str), [Any](#typing.Any)\]</code> – owner, public, created_at, updated_at, etc.
+
+**Raises:**
+
+- <code>[HTTPError](#requests.HTTPError)</code> – If dataset not found (404) or request fails
+
+<details class="example" open>
+<summary>Example</summary>
+# Find dataset containing a file
+dataset = fused.find_dataset("s3://bucket/data/year=2024/file.parquet")
+print(f"Found dataset: {dataset['location']}")
+</details>
+
+---
+
+## fused.register_dataset
+
+```python
+register_dataset(
+    dataset_path: str, base_url: Optional[str] = None
+) -> Dict[str, Any]
+```
+
+Register a dataset for indexed queries.
+
+This function registers a directory in your file storage as a dataset,
+enabling fast geospatial queries using H3 indexing.
+
+**Parameters:**
+
+- **dataset_path** (<code>str</code>) – Path to the dataset directory. The path should point to
+  a directory containing parquet files.
+- **base_url** (<code>Optional[str]</code>) – Base URL for API. If None, uses current environment.
+
+**Returns:**
+
+- <code>[Dict](#typing.Dict)\[[str](#str), [Any](#typing.Any)\]</code> – Dictionary with registration results:
+- dataset_id: ID of the created/updated dataset
+- location: Normalized URL of the dataset
+- visit_status: Status of the dataset visit (success/timeout/error)
+- items_discovered: Total number of items found
+- new_items: Number of new items added
+
+**Raises:**
+
+- <code>[HTTPError](#requests.HTTPError)</code> – If the API request fails
+
+<details class="example" open>
+<summary>Example</summary>
+# Register a dataset from your storage
+result = fused.register_dataset("s3://my-bucket/my-data/buildings/")
+print(f"Registered dataset with ID: {result['dataset_id']}")
+print(f"Found {result['items_discovered']} files")
+</details>
+
+<details class="note" open>
+<summary>Note</summary>
+- Regular users can use any storage paths they have access to
+- Datasets are registered as private (only accessible to your team)
+- Files are automatically queued for metadata extraction
+</details>
+
+---
+

--- a/utils/generate_reference_docs.py
+++ b/utils/generate_reference_docs.py
@@ -48,6 +48,8 @@ api_listing = [
     "file_path",
     "get_chunks_metadata",
     "get_chunk_from_table",
+    "find_dataset",
+    "register_dataset",
 ]
 
 result = """\
@@ -209,6 +211,14 @@ api_listing = [
     # Snowflake
     "snowflake_connect",
     "snowflake_query",
+    # Integrations (added in fused-py v2.8.0)
+    "anthropic_connect",
+    "huggingface_connect",
+    "huggingface_inference",
+    "airtable_connect",
+    "airtable_list_records",
+    "hubspot_connect",
+    "notion_connect",
     # Note: Functions that no longer exist will be automatically skipped with a warning
 ]
 
@@ -250,7 +260,7 @@ for obj in api_listing:
 methods = [
     "create_udf_access_token",
     "upload",
-    "start_job", 
+    "start_job",
     "get_jobs",
     "get_status",
     "get_logs",
@@ -258,6 +268,31 @@ methods = [
     "wait_for_job",
     "cancel_job",
     "auth_token",
+    # Secrets (added in fused-py v2.8.0)
+    "get_secret_value",
+    "set_secret_value",
+    "delete_secret_value",
+    "list_secrets",
+    "get_user_custom_secret",
+    "list_user_custom_secrets",
+    # Cron jobs (added in fused-py v2.8.0)
+    "list_cronjobs",
+    "create_cronjob",
+    "update_cronjob",
+    "delete_cronjob",
+    "get_cronjob",
+    "get_cronjobs_for_udf",
+    "run_cronjob",
+    # Collections (added in fused-py v2.8.0)
+    "list_collections",
+    "get_collection_by_name",
+    "get_team_collection_by_name",
+    "get_collection_by_id",
+    "create_collection",
+    "update_collection",
+    "delete_collection",
+    "share_collection",
+    "unshare_collection",
 ]
 config = dict(default_config)
 config["filters"] = ["__init__"]
@@ -333,6 +368,72 @@ if "FusedSnowflakeConnection" in mod_api.members:
             print(f"Warning: {meth} not found in FusedSnowflakeConnection class, skipping")
             continue
         result += render_object_docs(mod_api["FusedSnowflakeConnection"][meth], config_sf) + "\n---\n\n"
+
+# fused.api.FusedAirtableConnection class
+
+airtable_methods = [
+    "list_bases",
+    "list_tables",
+    "list_records",
+    "get_record",
+    "create_records",
+    "update_records",
+    "delete_records",
+]
+
+if "FusedAirtableConnection" in mod_api.members:
+    airtable_note = """\
+## Airtable
+
+## FusedAirtableConnection
+
+"""
+    config_at = dict(default_config)
+    config_at["filters"] = ["__init__"]
+    config_at["summary"] = False
+    result += airtable_note + render_object_docs(mod_api["FusedAirtableConnection"], config_at) + "\n---\n\n"
+
+    config_at["heading_level"] = default_config["heading_level"] + 1
+    config_at["show_root_full_path"] = False
+    for meth in airtable_methods:
+        if meth not in mod_api["FusedAirtableConnection"].members:
+            print(f"Warning: {meth} not found in FusedAirtableConnection class, skipping")
+            continue
+        result += render_object_docs(mod_api["FusedAirtableConnection"][meth], config_at) + "\n---\n\n"
+
+# fused.api.FusedNotionConnection class
+
+notion_methods = [
+    "get_page",
+    "create_page",
+    "update_page",
+    "delete_page",
+    "list_comments",
+    "create_comment",
+    "list_users",
+    "get_user",
+    "search",
+]
+
+if "FusedNotionConnection" in mod_api.members:
+    notion_note = """\
+## Notion
+
+## FusedNotionConnection
+
+"""
+    config_no = dict(default_config)
+    config_no["filters"] = ["__init__"]
+    config_no["summary"] = False
+    result += notion_note + render_object_docs(mod_api["FusedNotionConnection"], config_no) + "\n---\n\n"
+
+    config_no["heading_level"] = default_config["heading_level"] + 1
+    config_no["show_root_full_path"] = False
+    for meth in notion_methods:
+        if meth not in mod_api["FusedNotionConnection"].members:
+            print(f"Warning: {meth} not found in FusedNotionConnection class, skipping")
+            continue
+        result += render_object_docs(mod_api["FusedNotionConnection"][meth], config_no) + "\n---\n\n"
 
 with open(ROOT / "docs" / "python-sdk" / "api-reference" / "api.mdx", "w") as f:
     f.write(result)
@@ -439,14 +540,13 @@ a saved UDF with [`fused.load()`](/python-sdk/top-level-functions/#fusedload).
 # listing and rendering the methods separately to avoid including the Udf 
 # class signature and docstring (which is not public)
 methods = [
-    "to_fused",
     "to_directory",
     "to_file",
-    "create_access_token",
-    "get_access_tokens",
-    "delete_saved",
-    "invalidate_cache",
-    "catalog_url",
+    "set_parameters",
+    "eval_schema",
+    "run_local",
+    "map",
+    "map_async",
 ]
 
 config = dict(default_config)
@@ -472,6 +572,7 @@ api_listing = [
     "read_hex_table",
     "read_hex_table_slow",
     "read_hex_table_with_persisted_metadata",
+    "run_partition_to_h3",
 ]
 
 result = """\

--- a/utils/test_api_reference_coverage.py
+++ b/utils/test_api_reference_coverage.py
@@ -1,0 +1,324 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "fused",
+#   "griffe ~= 1.7",
+# ]
+# ///
+#
+# Checks that every method in the allowlists from generate_reference_docs.py:
+#   1. Exists in the installed fused package
+#   2. Appears as a heading in the corresponding MDX file
+#
+# Red-green usage:
+#   uv run utils/test_api_reference_coverage.py           # red: see what's missing
+#   uv run --reinstall-package fused utils/generate_reference_docs.py  # fix
+#   uv run utils/test_api_reference_coverage.py           # green: confirm all pass
+
+import sys
+from pathlib import Path
+
+import griffe
+import fused
+
+ROOT = Path(__file__).parent / ".."
+
+# ── Allowlists (keep in sync with generate_reference_docs.py) ─────────────────
+
+TOP_LEVEL_FUNCTIONS = [
+    "udf",
+    "cache",
+    "load",
+    "run",
+    "submit",
+    "download",
+    "ingest",
+    "ingest_nongeospatial",
+    "file_path",
+    "get_chunks_metadata",
+    "get_chunk_from_table",
+    "find_dataset",
+    "register_dataset",
+]
+
+FUSED_API_FUNCTIONS = [
+    "whoami",
+    "access_token",
+    "auth_scheme",
+    "logout",
+    "delete",
+    "list",
+    "get",
+    "download",
+    "upload",
+    "sign_url",
+    "sign_url_prefix",
+    "resolve",
+    "get_udfs",
+    "get_apps",
+    "job_get_logs",
+    "job_print_logs",
+    "job_tail_logs",
+    "job_get_status",
+    "job_cancel",
+    "job_get_exec_time",
+    "job_wait_for_job",
+    "job_get_results",
+    "job_wait_for_results",
+    "schedule_udf",
+    "schedule_list",
+    "session_token",
+    "team_info",
+    "enable_gcs",
+    "log",
+    "snowflake_connect",
+    "snowflake_query",
+    # Integrations (added in fused-py v2.8.0)
+    "anthropic_connect",
+    "huggingface_connect",
+    "huggingface_inference",
+    "airtable_connect",
+    "airtable_list_records",
+    "hubspot_connect",
+    "notion_connect",
+]
+
+FUSED_API_CLASS_METHODS = [
+    "create_udf_access_token",
+    "upload",
+    "start_job",
+    "get_jobs",
+    "get_status",
+    "get_logs",
+    "tail_logs",
+    "wait_for_job",
+    "cancel_job",
+    "auth_token",
+    # Secrets (added in fused-py v2.8.0)
+    "get_secret_value",
+    "set_secret_value",
+    "delete_secret_value",
+    "list_secrets",
+    "get_user_custom_secret",
+    "list_user_custom_secrets",
+    # Cron jobs (added in fused-py v2.8.0)
+    "list_cronjobs",
+    "create_cronjob",
+    "update_cronjob",
+    "delete_cronjob",
+    "get_cronjob",
+    "get_cronjobs_for_udf",
+    "run_cronjob",
+    # Collections (added in fused-py v2.8.0)
+    "list_collections",
+    "get_collection_by_name",
+    "get_team_collection_by_name",
+    "get_collection_by_id",
+    "create_collection",
+    "update_collection",
+    "delete_collection",
+    "share_collection",
+    "unshare_collection",
+]
+
+FUSED_AIRTABLE_METHODS = [
+    "list_bases",
+    "list_tables",
+    "list_records",
+    "get_record",
+    "create_records",
+    "update_records",
+    "delete_records",
+]
+
+FUSED_NOTION_METHODS = [
+    "get_page",
+    "create_page",
+    "update_page",
+    "delete_page",
+    "list_comments",
+    "create_comment",
+    "list_users",
+    "get_user",
+    "search",
+]
+
+JOBPOOL_METHODS = sorted(
+    k for k in fused._submit.JobPool.__dict__ if not k.startswith("_")
+)
+
+UDF_METHODS = [
+    "to_directory",
+    "to_file",
+    "set_parameters",
+    "eval_schema",
+    "run_local",
+    "map",
+    "map_async",
+]
+
+H3_FUNCTIONS = [
+    "run_ingest_raster_to_h3",
+    "persist_hex_table_metadata",
+    "read_hex_table",
+    "read_hex_table_slow",
+    "read_hex_table_with_persisted_metadata",
+    "run_partition_to_h3",
+]
+
+# ── Griffe module load ─────────────────────────────────────────────────────────
+
+print(f"Testing API reference coverage for fused v{fused.__version__}\n")
+mod = griffe.load("fused", docstring_parser="google")
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+failures: list[str] = []
+warnings: list[str] = []
+checks_run = 0
+
+# Heading format per file (from inspecting generate_reference_docs.py output):
+#   top-level-functions.mdx : ## @fused.udf / ## fused.run  (level 2, full path)
+#   api.mdx module functions : ## fused.api.{name}           (level 2, full path)
+#   api.mdx FusedAPI methods : ### {name}                    (level 3, bare name)
+#   h3.mdx                  : ## fused.h3.{name}             (level 2, full path)
+#   udf.mdx methods         : ### {name}                     (level 3, bare name)
+#   jobpool.mdx methods     : ### {name}                     (level 3, bare name)
+
+
+def check_in_package(mod_obj, name: str, context: str) -> bool:
+    """Returns True if name exists in the package; warns (doesn't fail) if missing."""
+    global checks_run
+    checks_run += 1
+    if name not in mod_obj.members:
+        warnings.append(
+            f"[STALE ALLOWLIST] {context}.{name} not in package"
+            " — remove from allowlist in generate_reference_docs.py"
+        )
+        return False
+    return True
+
+
+_missing_mdx_reported: set[Path] = set()
+
+
+def check_in_mdx(mdx_path: Path, heading: str, context: str, level: int = 2) -> bool:
+    """Fails if the MDX file is missing or doesn't contain the expected heading."""
+    global checks_run
+    checks_run += 1
+    if not mdx_path.exists():
+        if mdx_path not in _missing_mdx_reported:
+            failures.append(
+                f"[MDX FILE MISSING] {mdx_path.relative_to(ROOT)}"
+                " — run generate_reference_docs.py to create it"
+            )
+            _missing_mdx_reported.add(mdx_path)
+        return False
+    content = mdx_path.read_text()
+    marker = f"{'#' * level} {heading}"
+    if marker not in content:
+        failures.append(
+            f"[NOT IN DOCS] {context}"
+            f" — heading '{marker}' missing in {mdx_path.name}"
+        )
+        return False
+    return True
+
+
+# ── Top-level functions ────────────────────────────────────────────────────────
+# Headings: ## @fused.udf / ## @fused.cache  OR  ## fused.{name}
+
+top_level_mdx = ROOT / "docs" / "python-sdk" / "top-level-functions.mdx"
+
+for name in TOP_LEVEL_FUNCTIONS:
+    if not check_in_package(mod, name, "fused"):
+        continue
+    if name in ("udf", "cache"):
+        heading = f"@fused.{name}"
+    else:
+        heading = f"fused.{name}"
+    check_in_mdx(top_level_mdx, heading, f"fused.{name}", level=2)
+
+# ── fused.api module functions ─────────────────────────────────────────────────
+# Headings: ## fused.api.{name}
+
+api_mdx = ROOT / "docs" / "python-sdk" / "api-reference" / "api.mdx"
+mod_api = mod["api"]
+
+for name in FUSED_API_FUNCTIONS:
+    if check_in_package(mod_api, name, "fused.api"):
+        check_in_mdx(api_mdx, f"fused.api.{name}", f"fused.api.{name}", level=2)
+
+# ── FusedAPI class methods ─────────────────────────────────────────────────────
+# Headings: ### {name}  (under ## fused.api.FusedAPI)
+
+if "FusedAPI" in mod_api.members:
+    for name in FUSED_API_CLASS_METHODS:
+        if check_in_package(mod_api["FusedAPI"], name, "fused.api.FusedAPI"):
+            check_in_mdx(api_mdx, name, f"FusedAPI.{name}", level=3)
+
+# ── FusedAirtableConnection methods ───────────────────────────────────────────
+# Headings: ### {name}  (under ## FusedAirtableConnection)
+
+if "FusedAirtableConnection" in mod_api.members:
+    for name in FUSED_AIRTABLE_METHODS:
+        if check_in_package(mod_api["FusedAirtableConnection"], name, "FusedAirtableConnection"):
+            check_in_mdx(api_mdx, name, f"FusedAirtableConnection.{name}", level=3)
+
+# ── FusedNotionConnection methods ─────────────────────────────────────────────
+# Headings: ### {name}  (under ## FusedNotionConnection)
+
+if "FusedNotionConnection" in mod_api.members:
+    for name in FUSED_NOTION_METHODS:
+        if check_in_package(mod_api["FusedNotionConnection"], name, "FusedNotionConnection"):
+            check_in_mdx(api_mdx, name, f"FusedNotionConnection.{name}", level=3)
+
+# ── JobPool methods ────────────────────────────────────────────────────────────
+# Headings: ### {name}  (under ## JobPool)
+
+jobpool_mdx = ROOT / "docs" / "python-sdk" / "api-reference" / "jobpool.mdx"
+
+for name in JOBPOOL_METHODS:
+    if check_in_package(mod["_submit"]["JobPool"], name, "JobPool"):
+        check_in_mdx(jobpool_mdx, name, f"JobPool.{name}", level=3)
+
+# ── Udf methods ────────────────────────────────────────────────────────────────
+# Headings: ### {name}  (under ## Udf)
+
+udf_mdx = ROOT / "docs" / "python-sdk" / "api-reference" / "udf.mdx"
+
+for name in UDF_METHODS:
+    if check_in_package(mod["models"]["Udf"], name, "Udf"):
+        check_in_mdx(udf_mdx, name, f"Udf.{name}", level=3)
+
+# ── fused.h3 functions ─────────────────────────────────────────────────────────
+# Headings: ## fused.h3.{name}
+
+h3_mdx = ROOT / "docs" / "python-sdk" / "api-reference" / "h3.mdx"
+mod_h3 = mod["h3"]
+
+for name in H3_FUNCTIONS:
+    if check_in_package(mod_h3, name, "fused.h3"):
+        check_in_mdx(h3_mdx, f"fused.h3.{name}", f"fused.h3.{name}", level=2)
+
+# ── Report ────────────────────────────────────────────────────────────────────
+
+if warnings:
+    print(f"Warnings ({len(warnings)} stale allowlist entries):\n")
+    for w in warnings:
+        print(f"  {w}")
+    print()
+
+if failures:
+    print(f"FAILED — {len(failures)} issue(s) found (out of {checks_run} checks):\n")
+    for f in failures:
+        print(f"  {f}")
+    print(
+        "\nTo regenerate missing or stale docs, run:\n"
+        "  uv run --reinstall-package fused utils/generate_reference_docs.py\n"
+        "Then re-run this script to confirm all checks pass."
+    )
+    sys.exit(1)
+else:
+    print(f"PASSED — all {checks_run} checks passed")
+    sys.exit(0)


### PR DESCRIPTION
## Summary

The API reference docs were out of sync with the published fused-py v2.8.0 package. This PR regenerates all auto-generated MDX files and expands the generator's allowlists to cover the new API surface introduced in v2.8.0.

**69 out of 178 coverage checks were failing before this PR.** All 274 pass after it.

## What changed in the docs

- **`api.mdx`** — adds 7 integration connector functions (Anthropic, HuggingFace ×2, Airtable ×2, HubSpot, Notion), two new connection classes (`FusedAirtableConnection`, `FusedNotionConnection`), and 19 new `FusedAPI` methods for secrets management, cron job management, and collections
- **`udf.mdx`** — updated to current `Udf` class (`set_parameters`, `eval_schema`, `run_local`, `map`, `map_async`); removed methods that no longer exist in fused-py
- **`h3.mdx`** — adds `run_partition_to_h3`
- **`top-level-functions.mdx`** — recreated (was missing from repo); adds `find_dataset` and `register_dataset`
- **`jobpool.mdx` / `options.mdx`** — regenerated with current content

## What changed in tooling

- **`utils/generate_reference_docs.py`** — expanded allowlists to cover the full v2.8.0 API surface
- **`utils/test_api_reference_coverage.py`** (new) — red-green coverage test; verifies every allowlisted item exists in both the package and the MDX files

```bash
# Regenerate docs
uv run --reinstall-package fused utils/generate_reference_docs.py

# Verify coverage (274 checks)
uv run utils/test_api_reference_coverage.py
```

## Test plan

- [x] `uv run utils/test_api_reference_coverage.py` passes (274/274) locally
- [ ] Docs build succeeds on staging preview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and doc-generation tooling only; no runtime product code changes in this diff.
> 
> **Overview**
> Regenerates the Python SDK **API reference** MDX so it matches **fused-py v2.8.0**, fixing a large doc–package drift (69 failing coverage checks before; **274/274** after).
> 
> **`api.mdx`** is reorganized around `fused.api.*` names, switches examples from raw `s3://` paths to **`fd://`**, and documents new surface: auth helpers (`whoami`, `logout`), storage/signing (`sign_url`, `resolve`, upload), scheduling/audit APIs, **Snowflake** helpers, **session tokens**, and many **third-party connectors** (Anthropic, Hugging Face, Airtable, HubSpot, Notion) plus expanded **`FusedAPI`** (jobs, secrets, cron, collections) and connection-class sections.
> 
> **`h3.mdx`**, **`udf.mdx`**, **`jobpool.mdx`**, and **`options.mdx`** are rewritten to current signatures and docstrings (e.g. H3 ingest/partition params, `Udf.map` / deprecated `map_async`, JobPool method catalog, new options like `fused_cache_disable_stream` and conflict-overwrite defaults).
> 
> Adds **`top-level-functions.mdx`** for decorators and core entrypoints (`udf`, `cache`, `load`, `run`, `submit`, `ingest`, dataset registration, etc.).
> 
> Tooling: **`utils/generate_reference_docs.py`** allowlists expanded for v2.8.0; new **`utils/test_api_reference_coverage.py`** enforces every allowlisted symbol exists in the package and generated MDX.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b52d7557b7ee3e9c64daa5ff4a727d4e4f37962. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->