### PR TITLE
feat: auto-update API reference on fused-py release

### DIFF
--- a/.github/workflows/update-api-reference.yml
+++ b/.github/workflows/update-api-reference.yml
@@ -1,0 +1,96 @@
+name: Update API Reference on fused-py Release
+
+on:
+  # Triggered from fusedlabs/application after a fused-py release
+  # gh api repos/fusedio/fused-docs/dispatches \
+  #   -f event_type=fused-py-release \
+  #   -f 'client_payload[version]=2.8.0'
+  repository_dispatch:
+    types: [fused-py-release]
+
+  # Manual trigger for testing without waiting for a real release
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'fused-py version (e.g. 2.8.0) — used only for branch/PR naming'
+        required: false
+        default: 'manual'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-api-reference:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Regenerate API reference docs
+        run: uv run --reinstall-package fused utils/generate_reference_docs.py
+
+      - name: Check if docs changed
+        id: diff
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "No changes detected — docs are already up to date"
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "Changes detected:"
+            git diff --stat
+          fi
+
+      - name: Run coverage test
+        run: uv run utils/test_api_reference_coverage.py
+
+      - name: Create PR with updated docs
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ github.event.client_payload.version || inputs.version || 'manual' }}"
+          BRANCH="auto/api-ref-fused-py-${VERSION}"
+          FUSED_VERSION=$(python -c "import fused; print(fused.__version__)" 2>/dev/null || echo "$VERSION")
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+          git add docs/python-sdk/
+          git commit -m "docs: regenerate API reference for fused-py v${FUSED_VERSION}"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "docs: update API reference for fused-py v${FUSED_VERSION}" \
+            --body "$(cat <<EOF
+          ## Summary
+
+          Auto-generated API reference update for **fused-py v${FUSED_VERSION}**.
+
+          This PR was created automatically after a new fused-py release. It re-runs
+          \`utils/generate_reference_docs.py\` against the latest published package and
+          commits any changes to the API reference MDX files.
+
+          ## What changed
+
+          \`\`\`
+          $(git diff HEAD~1 --stat)
+          \`\`\`
+
+          ## Checklist
+
+          - [ ] Review the diff for any unexpected removals or missing new methods
+          - [ ] Confirm \`test_api_reference_coverage.py\` passes (runs automatically in CI)
+
+          ---
+          *Triggered by: \`${{ github.event_name }}\` — fused-py v${VERSION}*
+          EOF
+          )" \
+            --head "$BRANCH" \
+            --base main


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically keeps the API reference in sync whenever a new fused-py release is published — no manual PR needed.

**Depends on #1131** (adds `utils/test_api_reference_coverage.py` which this workflow runs).

## How it works

```
fusedlabs/application repo
  └─ release workflow creates fused-py-vX.Y.Z tag
       └─ POST /repos/fusedio/fused-docs/dispatches
            event_type: fused-py-release
            client_payload: { version: "X.Y.Z" }

fusedio/fused-docs
  └─ update-api-reference.yml (this PR)
       ├─ Install uv + latest fused from PyPI
       ├─ Run generate_reference_docs.py
       ├─ Run test_api_reference_coverage.py (274 checks)
       └─ If docs changed → open PR automatically
```

## Testing without a release

```bash
# Trigger manually via workflow_dispatch (no release required):
gh workflow run update-api-reference.yml -f version=2.8.0 --repo fusedio/fused-docs
```

## One-time setup required

Add to the `fusedlabs/application` release workflow after the fused-py tag is published:

```yaml
- name: Trigger fused-docs API reference update
  run: |
    gh api repos/fusedio/fused-docs/dispatches \
      -f event_type=fused-py-release \
      -f 'client_payload[version]=${{ env.FUSED_PY_VERSION }}'
  env:
    GH_TOKEN: ${{ secrets.FUSED_DOCS_DISPATCH_TOKEN }}
```

This requires a PAT (`contents:write` on `fusedio/fused-docs`) stored as `FUSED_DOCS_DISPATCH_TOKEN` in the application repo's secrets.

## Test plan

- [ ] Merge #1131 first
- [ ] Trigger via `gh workflow run update-api-reference.yml -f version=test`
- [ ] Confirm workflow runs, coverage test passes, and a PR is opened if docs changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New CI-only workflow for doc regeneration and automated PRs; no runtime app, auth, or data-path changes.
> 
> **Overview**
> Adds **`.github/workflows/update-api-reference.yml`** so the Python SDK API reference can refresh after a **fused-py** release without a manual docs PR.
> 
> The workflow runs on **`repository_dispatch`** (`fused-py-release`, with optional version in `client_payload`) or **`workflow_dispatch`** for testing. It checks out the repo, installs **uv**, reinstalls the latest **`fused`** from PyPI, runs **`utils/generate_reference_docs.py`**, then **`utils/test_api_reference_coverage.py`**. If `docs/python-sdk/` differs from `main`, it pushes a versioned branch and opens a PR via **`gh`** using **`contents: write`** and **`pull-requests: write`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e5c1b665b6139f788f9a9b2668e0ae1eedadd5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->