### PR TITLE
docs: add CLAUDE.md v1 — contributing guide for humans and agents

### DIFF
--- a/.claude/commands/api-reference.md
+++ b/.claude/commands/api-reference.md
@@ -1,0 +1,76 @@
+# API reference pipeline — fused-docs
+
+Everything in `docs/python-sdk/api-reference/` and `docs/python-sdk/top-level-functions.mdx` is **generated**. Never edit these files directly.
+
+---
+
+## How to regenerate
+
+```bash
+# Regenerate all API reference MDX against the latest published fused package
+uv run --reinstall-package fused utils/generate_reference_docs.py
+
+# Verify coverage (every allowlisted method exists in the package AND in the MDX)
+uv run utils/test_api_reference_coverage.py
+```
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `utils/generate_reference_docs.py` | Generator — parses fused-py with griffe, renders MDX via griffe2md |
+| `utils/test_api_reference_coverage.py` | Coverage gate — red/green test for the generator output |
+| `.github/workflows/update-api-reference.yml` | Automation — triggers on fused-py release, opens a PR with updated docs |
+
+---
+
+## Design rules — don't change without understanding why
+
+**Bare name headings**
+`fused.api` functions render as `## access_token`, not `## fused.api.access_token`.
+Controlled by `show_root_full_path = False` in the per-section griffe2md config.
+Same for `fused.h3`. FusedAPI class methods are `### method_name` (level 3).
+
+**Alphabetical ordering**
+All function/method lists in the generator are sorted. This makes release diffs stable — new methods slot in without displacing existing ones.
+
+**MDX brace escaping**
+griffe2md can emit docstring template variables like `{source_dir}` as raw text. MDX 3 treats bare `{expr}` as JSX and fails the SSG production build. The `escape_mdx_braces()` post-processor rewrites these to `\{source_dir\}` — except inside fenced code blocks and inline backtick spans.
+
+**`<code>` tag replacement**
+griffe2md templates emit `<code>str</code>` HTML for parameter types. The `fix_code_tags()` post-processor converts these to backtick inline code for readability. Both post-processors run at every file write.
+
+**Test script is a gate, not a wishlist**
+Allowlists in `test_api_reference_coverage.py` must match what the generator actually produces. Method in package but not in the allowlist → warning (stale allowlist). Method in allowlist but missing from MDX → failure.
+
+---
+
+## Before pushing
+
+Run both checks in parallel:
+
+```bash
+uv run utils/test_api_reference_coverage.py &
+npm run build &
+wait
+```
+
+Use `npm run build` (SSG), not `npm run serve` — dev mode hides MDX errors that only surface in production.
+
+---
+
+## Automation
+
+Trigger manually (no release needed):
+```bash
+gh workflow run update-api-reference.yml -f version=2.8.0
+```
+
+Wire up automatic triggering from `fusedlabs/application` after a release:
+```bash
+gh api repos/fusedio/fused-docs/dispatches \
+  -f event_type=fused-py-release \
+  -f 'client_payload[version]=2.8.0'
+```

--- a/.claude/commands/mdx-components.md
+++ b/.claude/commands/mdx-components.md
@@ -1,0 +1,154 @@
+# MDX components — fused-docs
+
+Reference for every component and pattern available in fused-docs MDX files.
+
+---
+
+## Admonitions (Docusaurus built-in)
+
+Use `:::type` fenced blocks. Always add a blank line before and after.
+
+```md
+:::note
+Use for neutral supplementary info — something helpful but not critical.
+:::
+
+:::tip
+Use for recommended approaches, shortcuts, or best practices.
+:::
+
+:::info
+Use for context or background that readers might want but don't need.
+:::
+
+:::warning
+Use when the reader might do something that causes data loss, a failed job, or unexpected behaviour.
+:::
+
+:::danger
+Reserved for irreversible actions (deleting data, revoking tokens, etc.).
+:::
+```
+
+**Rule:** Don't stack multiple admonitions back to back — if you need two, the content probably belongs in the body prose instead.
+
+---
+
+## Custom components
+
+### `<Tag>`
+
+Coloured inline label. Use for status badges (Experimental, Beta, Deprecated).
+
+```mdx
+import Tag from '@site/src/components/Tag';
+
+<Tag color="#f0a500">Experimental</Tag>
+<Tag color="#e53e3e" fontColor="#fff">Deprecated</Tag>
+```
+
+### `<CellOutput>`
+
+Renders a notebook-style output cell below a code block.
+
+```mdx
+import CellOutput from "@site/src/components/CellOutput.jsx";
+
+```python
+df.head()
+```
+<CellOutput>
+{/* paste rendered output here */}
+</CellOutput>
+```
+
+### `<LazyReactPlayer>`
+
+Embeds a video (YouTube, Loom, etc.) with lazy loading.
+
+```mdx
+import LazyReactPlayer from "@site/src/components/LazyReactPlayer.jsx";
+
+<LazyReactPlayer url="https://youtu.be/..." />
+```
+
+### `<ClickZoomImage>`
+
+Makes an image clickable to zoom. Use for screenshots that need detail.
+
+```mdx
+import ClickZoomImage from "@site/src/components/ClickZoomImage.tsx";
+
+<ClickZoomImage src="/img/path/to/image.png" alt="Description" />
+```
+
+### `<Tabs>` / `<TabItem>`
+
+Use for showing the same thing in multiple languages or environments.
+
+```mdx
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+  <TabItem value="python" label="Python">
+    ```python
+    fused.run(...)
+    ```
+  </TabItem>
+  <TabItem value="cli" label="CLI">
+    ```bash
+    fused run ...
+    ```
+  </TabItem>
+</Tabs>
+```
+
+**Rule:** Tabs are for equivalent alternatives only — not for sequential steps.
+
+### `<Details>`
+
+Collapsible section. Use for optional deep-dives that most readers can skip.
+
+```mdx
+import Details from '@theme/MDXComponents/Details';
+
+<Details>
+<summary>How this works under the hood</summary>
+
+Content here...
+
+</Details>
+```
+
+---
+
+## Code blocks
+
+Always specify the language. Use `showLineNumbers` for multi-step examples. Use `// highlight-next-line` to call out a key line.
+
+```md
+```python showLineNumbers
+@fused.udf
+def udf(bbox):
+    import geopandas as gpd
+    # highlight-next-line
+    return gpd.read_file(...)
+```
+```
+
+For CLI commands, use `bash`. For output, use `text` or `console`.
+
+---
+
+## Frontmatter fields used in this repo
+
+```yaml
+---
+title: Page title          # shown in browser tab and OG
+sidebar_label: Short label # shown in sidebar (use if title is long)
+sidebar_position: 3        # controls order within the section
+toc_max_heading_level: 4   # default is 3; use 4 for API reference pages
+unlisted: true             # hides from sidebar but keeps the URL live
+---
+```

--- a/.claude/commands/mdx-components.md
+++ b/.claude/commands/mdx-components.md
@@ -51,7 +51,7 @@ import Tag from '@site/src/components/Tag';
 
 Renders a notebook-style output cell below a code block.
 
-```mdx
+````mdx
 import CellOutput from "@site/src/components/CellOutput.jsx";
 
 ```python
@@ -60,7 +60,7 @@ df.head()
 <CellOutput>
 {/* paste rendered output here */}
 </CellOutput>
-```
+````
 
 ### `<LazyReactPlayer>`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,19 @@
 # fused-docs — Claude instructions
 
+See @README.md for project overview and @package.json for available npm scripts.
+
 ## Core rules
 
-- **Test before documenting**: Before changing any doc reference or code block, run the code yourself. Spin up a small UDF with the fused CLI and confirm it works. Don't document something you haven't verified.
-- **Write for humans and agents**: Humans can click — link to the UI, to other pages, to live examples. Agents use the CLI — include the exact commands to run. A good doc serves both.
-- **No hand-editing generated files**: Everything under `docs/python-sdk/api-reference/` and `docs/python-sdk/top-level-functions.mdx` is generated. Edit the generator, not the output.
+- **Test before documenting**: Before changing any doc reference or code block, run the code yourself. Spin up a small UDF with the fused CLI and confirm it works.
+- **Write for humans and agents**: Humans can click — link to the UI, to other pages, to live examples. Agents use the CLI — include the exact commands to run.
+- **Use absolute links**: `[page](/python-sdk/quickstart)` not `[page](../quickstart)`. Relative links break when pages move.
+
+## Do not
+
+- Hand-edit any file under `docs/python-sdk/api-reference/` or `docs/python-sdk/top-level-functions.mdx` — these are generated. Edit the generator instead.
+- Use `npm run serve` to validate — dev mode hides MDX errors that only surface in the SSG production build. Use `npm run build`.
+- Document code you haven't run. Test it first.
+- Duplicate prose that already exists — check `docs/` for existing content before writing new sections.
 
 ## Slash commands (`.claude/commands/`)
 
@@ -16,9 +25,12 @@
 ## Build & test
 
 ```bash
-npm run build        # full SSG build — use this, not npm run serve
-npm run serve        # dev mode only — hides MDX errors that break production
+npm run build        # full SSG build — required before any PR
 uv run utils/test_api_reference_coverage.py   # API reference coverage gate
 ```
 
-Before pushing any branch touching `docs/python-sdk/` or `utils/generate_reference_docs.py`, run the coverage test and `npm run build` in parallel. Check CI after pushing.
+Before pushing any branch touching `docs/python-sdk/` or `utils/generate_reference_docs.py`, run both in parallel. Check CI after pushing.
+
+## When compacting
+
+Always preserve: the list of files modified in this session, any test commands that were run and their results, and open PR numbers with their branch names.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,38 +1,24 @@
 # fused-docs — Claude instructions
 
-## General rules
+## Core rules
 
-- **Test before documenting**: Before changing any doc reference or code block, run the code yourself. Use `fused run` locally with a small UDF to confirm it works. Don't document something you haven't verified.
-- **Write for humans and agents**: Humans can click — link to the UI, to pages, to examples. Agents use the CLI — include the exact commands to run. A good doc serves both.
+- **Test before documenting**: Before changing any doc reference or code block, run the code yourself. Spin up a small UDF with the fused CLI and confirm it works. Don't document something you haven't verified.
+- **Write for humans and agents**: Humans can click — link to the UI, to other pages, to live examples. Agents use the CLI — include the exact commands to run. A good doc serves both.
+- **No hand-editing generated files**: Everything under `docs/python-sdk/api-reference/` and `docs/python-sdk/top-level-functions.mdx` is generated. Edit the generator, not the output.
 
----
+## Slash commands (`.claude/commands/`)
 
-## API reference PRs
+| Command | When to use |
+|---|---|
+| `/mdx-components` | Before adding or editing any MDX — lists every custom component, admonition, and when to use each |
+| `/api-reference` | Before touching anything in `docs/python-sdk/` or `utils/` — covers the generation pipeline, test gate, and design rules |
 
-Before pushing any branch that touches `docs/python-sdk/` or `utils/generate_reference_docs.py`, always run these two checks **in parallel**:
+## Build & test
 
-1. **Coverage test** — `uv run utils/test_api_reference_coverage.py`
-2. **Full production build** — `npm run build`
-
-Do not rely on `npm run serve` — dev mode hides MDX rendering errors that only surface in the SSG production build.
-
-After pushing, check that CI passes on the PR before reporting it as done.
-
----
-
-## API reference pipeline
-
-The Python SDK API reference is **fully generated** from the fused-py package. Docs are never edited by hand.
-
-**Run the generator:**
 ```bash
-uv run --reinstall-package fused utils/generate_reference_docs.py
+npm run build        # full SSG build — use this, not npm run serve
+npm run serve        # dev mode only — hides MDX errors that break production
+uv run utils/test_api_reference_coverage.py   # API reference coverage gate
 ```
 
-**Key design rules — don't change without understanding why:**
-
-- **Bare name headings**: `fused.api` functions render as `## access_token`, not `## fused.api.access_token`. Controlled by `show_root_full_path = False` in the per-section config. Same for `fused.h3`.
-- **Alphabetical ordering**: All function lists must be sorted so diffs are stable across releases.
-- **MDX brace escaping**: griffe2md can render docstring variables like `{source_dir}` into text. MDX 3 evaluates bare `{expr}` as JSX and fails the SSG build. The `escape_mdx_braces()` post-processor in the generator escapes these — except inside fenced code blocks and inline backtick spans.
-- **`<code>` tag replacement**: griffe2md templates emit `<code>str</code>` for parameter types. The `fix_code_tags()` post-processor converts these to backticks. Both post-processors run at every file write.
-- **Test script is a gate, not a wishlist**: allowlists in `test_api_reference_coverage.py` must match what the generator actually produces. Method in package but not in allowlist → warning. Method in allowlist but missing from MDX → failure.
+Before pushing any branch touching `docs/python-sdk/` or `utils/generate_reference_docs.py`, run the coverage test and `npm run build` in parallel. Check CI after pushing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,43 @@
 
 See @README.md for project overview and @package.json for available npm scripts.
 
+## Docs structure
+
+Understanding where content belongs and how each section is written:
+
+| Section | Purpose | Writing style |
+|---|---|---|
+| **Guide** (`docs/guide/`) | Explore all aspects of Fused — concepts, setup, workflows | Concept-first. Explain the why, then the how. Link to API Reference for method details. |
+| **Examples** (`docs/examples/`) | Hands-on, concrete things you can build | Task-first. Show the code, explain what it does. Link back to Guide for concepts, API Reference for method signatures. |
+| **API Reference** (`docs/python-sdk/`) | Exhaustive source of truth for the `fused` Python API and all available widgets | Generated — do not hand-edit. Every method, every parameter. No prose beyond what the docstring provides. |
+| **Workbench Manual** (`docs/workbench/`) | Reference for the Workbench UI — same philosophy as API Reference but for the interface | UI-first. Screenshot-heavy. Describe what each element does, not how to build with it. |
+
+Before adding a page, ask: is this a concept (Guide), a recipe (Examples), a reference entry (API Reference), or a UI element (Workbench Manual)? Put it in the right section and write it in that section's voice.
+
 ## Core rules
 
-- **Test before documenting**: Before changing any doc reference or code block, run the code yourself. Spin up a small UDF with the fused CLI and confirm it works.
+- **Test before documenting**: Before changing any doc reference or code block, verify the code runs. See [Testing code](#testing-code) below.
 - **Write for humans and agents**: Humans can click — link to the UI, to other pages, to live examples. Agents use the CLI — include the exact commands to run.
 - **Use absolute links**: `[page](/python-sdk/quickstart)` not `[page](../quickstart)`. Relative links break when pages move.
+
+## Testing code
+
+Every code block in the docs must be runnable. Before committing:
+
+1. Write a minimal UDF that exercises the feature:
+    ```python
+    @fused.udf
+    def udf():
+        # your test code here
+        return result
+    ```
+2. Run it locally:
+    ```bash
+    fused run udf.py
+    ```
+3. Confirm the output matches what the docs claim. Only then update the doc.
+
+For code that requires credentials or external services, note this explicitly in the doc with a `:::note` admonition.
 
 ## Do not
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,72 +1,78 @@
-# fused-docs — Claude instructions
+# fused-docs — contributing guide
 
 See @README.md for project overview and @package.json for available npm scripts.
 
 ## Docs structure
 
-Understanding where content belongs and how each section is written:
+Each section has a distinct purpose and writing voice. Put content in the right section and write it in that section's style.
 
-| Section | Purpose | Writing style |
-|---|---|---|
-| **Guide** (`docs/guide/`) | Explore all aspects of Fused — concepts, setup, workflows | Concept-first. Explain the why, then the how. Link to API Reference for method details. |
-| **Examples** (`docs/examples/`) | Hands-on, concrete things you can build | Task-first. Show the code, explain what it does. Link back to Guide for concepts, API Reference for method signatures. |
-| **API Reference** (`docs/python-sdk/`) | Exhaustive source of truth for the `fused` Python API and all available widgets | Generated — do not hand-edit. Every method, every parameter. No prose beyond what the docstring provides. |
-| **Workbench Manual** (`docs/workbench/`) | Reference for the Workbench UI — same philosophy as API Reference but for the interface | UI-first. Screenshot-heavy. Describe what each element does, not how to build with it. |
+| Section | Path | Purpose | Writing style |
+|---|---|---|---|
+| **Guide** | `docs/guide/` | Explore all aspects of Fused — concepts, setup, workflows | Concept-first. Explain the why, then the how. Link to API Reference for method details. |
+| **Examples** | `docs/examples/` | Hands-on, concrete things you can build | Task-first. Show the code, explain what it does. Link back to Guide for concepts, API Reference for method signatures. |
+| **Python SDK** | `docs/python-sdk/` | Exhaustive reference for the `fused` Python API | Generated — do not hand-edit. Every method, every parameter. No prose beyond what the docstring provides. |
+| **Widget API** | `docs/widget-api/` | Reference for all available Fused widgets and their configuration | Schema-driven. Exhaustive props list, show minimal and full examples. |
+| **Workbench Manual** | `docs/workbench/` | Reference for the Workbench UI | UI-first. Screenshot-heavy. Describe what each element does, not how to build with it. |
 
-Before adding a page, ask: is this a concept (Guide), a recipe (Examples), a reference entry (API Reference), or a UI element (Workbench Manual)? Put it in the right section and write it in that section's voice.
+Before adding a page, ask: is this a concept (Guide), a recipe (Examples), a reference entry (Python SDK / Widget API), or a UI element (Workbench)? Put it in the right section and write in that section's voice.
 
 ## Core rules
 
-- **Test before documenting**: Before changing any doc reference or code block, verify the code runs. See [Testing code](#testing-code) below.
-- **Write for humans and agents**: Humans can click — link to the UI, to other pages, to live examples. Agents use the CLI — include the exact commands to run.
+- **Test before documenting**: Before changing any code reference or code block, run the code and confirm it works. See [Testing code](#testing-code) below.
+- **Write for humans and agents**: Humans can click — link to the UI, to other pages, to live examples. Agents use the CLI — include the exact commands to run. A good doc serves both.
 - **Use absolute links**: `[page](/python-sdk/quickstart)` not `[page](../quickstart)`. Relative links break when pages move.
+- **Check before writing**: Search `docs/` for existing content on the topic before writing new sections. Don't duplicate.
 
 ## Testing code
 
-Every code block in the docs must be runnable. Before committing:
+Every code block must be runnable. How to test depends on what you're documenting:
 
-1. Write a minimal UDF that exercises the feature:
-    ```python
-    @fused.udf
-    def udf():
-        # your test code here
-        return result
-    ```
-2. Run it with the fused CLI (`CANVAS` is required but `""` works for local files):
-    ```bash
-    fused run "" udf.py
-    ```
-    Or run it locally without hitting the remote server:
-    ```bash
-    fused run "" udf.py --engine local
-    ```
-3. Confirm the output matches what the docs claim. Only then update the doc.
+**UDF code** — run with the fused CLI:
+```bash
+# Remote (default) — runs on Fused servers, results printed locally
+fused run "" udf.py
 
-For code that requires credentials or external services, note this explicitly in the doc with a `:::note` admonition.
+# Local — runs in your environment, no network call
+fused run "" udf.py --engine local
+```
+The `CANVAS` argument is required; `""` works for local files. Make sure `fused` is installed and on your PATH (`pip install fused`).
+
+**SDK/API code** — run as a plain Python script in an environment with `fused` and its dependencies installed:
+```bash
+python script.py
+# or
+uv run script.py
+```
+
+**Configuration or CLI snippets** — run the exact command shown and confirm the output matches what the doc claims.
+
+For code that requires credentials or external services, note this in the doc with a `:::note` admonition so readers know what they need before running it.
 
 ## Do not
 
-- Hand-edit any file under `docs/python-sdk/api-reference/` or `docs/python-sdk/top-level-functions.mdx` — these are generated. Edit the generator instead.
-- Use `npm run serve` to validate — dev mode hides MDX errors that only surface in the SSG production build. Use `npm run build`.
-- Document code you haven't run. Test it first.
-- Duplicate prose that already exists — check `docs/` for existing content before writing new sections.
+- Hand-edit any file under `docs/python-sdk/api-reference/` or `docs/python-sdk/top-level-functions.mdx` — these are generated from fused-py source. Edit the generator (`utils/generate_reference_docs.py`) instead.
+- Use `npm run serve` to validate — dev mode hides MDX rendering errors that only surface in the SSG production build. Always use `npm run build`.
+- Document code you haven't run yourself.
+- Use relative links between pages.
 
-## Slash commands (`.claude/commands/`)
+## Reference docs
 
-| Command | When to use |
+Detailed references for common tasks are in `.claude/commands/` — readable directly as Markdown, and available as slash commands in Claude Code:
+
+| File / Command | When to use |
 |---|---|
-| `/mdx-components` | Before adding or editing any MDX — lists every custom component, admonition, and when to use each |
-| `/api-reference` | Before touching anything in `docs/python-sdk/` or `utils/` — covers the generation pipeline, test gate, and design rules |
+| `mdx-components.md` / `/mdx-components` | Before adding or editing any MDX — every custom component, admonition type, and when to use each |
+| `api-reference.md` / `/api-reference` | Before touching `docs/python-sdk/` or `utils/` — generation pipeline, design decisions, automation |
 
-## Build & test
+## Build & CI
 
 ```bash
 npm run build        # full SSG build — required before any PR
 uv run utils/test_api_reference_coverage.py   # API reference coverage gate
 ```
 
-Before pushing any branch touching `docs/python-sdk/` or `utils/generate_reference_docs.py`, run both in parallel. Check CI after pushing.
+Before pushing any branch touching `docs/python-sdk/` or `utils/generate_reference_docs.py`, run both. Check that CI passes on the PR before calling it done.
 
-## When compacting
+## For AI agents — when compacting
 
-Always preserve: the list of files modified in this session, any test commands that were run and their results, and open PR numbers with their branch names.
+Preserve across `/compact`: files modified this session, test commands run and their results, open PR numbers with branch names.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,13 @@ Every code block in the docs must be runnable. Before committing:
         # your test code here
         return result
     ```
-2. Run it locally:
+2. Run it with the fused CLI (`CANVAS` is required but `""` works for local files):
     ```bash
-    fused run udf.py
+    fused run "" udf.py
+    ```
+    Or run it locally without hitting the remote server:
+    ```bash
+    fused run "" udf.py --engine local
     ```
 3. Confirm the output matches what the docs claim. Only then update the doc.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# fused-docs — Claude instructions
+
+## General rules
+
+- **Test before documenting**: Before changing any doc reference or code block, run the code yourself. Use `fused run` locally with a small UDF to confirm it works. Don't document something you haven't verified.
+- **Write for humans and agents**: Humans can click — link to the UI, to pages, to examples. Agents use the CLI — include the exact commands to run. A good doc serves both.
+
+---
+
+## API reference PRs
+
+Before pushing any branch that touches `docs/python-sdk/` or `utils/generate_reference_docs.py`, always run these two checks **in parallel**:
+
+1. **Coverage test** — `uv run utils/test_api_reference_coverage.py`
+2. **Full production build** — `npm run build`
+
+Do not rely on `npm run serve` — dev mode hides MDX rendering errors that only surface in the SSG production build.
+
+After pushing, check that CI passes on the PR before reporting it as done.
+
+---
+
+## API reference pipeline
+
+The Python SDK API reference is **fully generated** from the fused-py package. Docs are never edited by hand.
+
+**Run the generator:**
+```bash
+uv run --reinstall-package fused utils/generate_reference_docs.py
+```
+
+**Key design rules — don't change without understanding why:**
+
+- **Bare name headings**: `fused.api` functions render as `## access_token`, not `## fused.api.access_token`. Controlled by `show_root_full_path = False` in the per-section config. Same for `fused.h3`.
+- **Alphabetical ordering**: All function lists must be sorted so diffs are stable across releases.
+- **MDX brace escaping**: griffe2md can render docstring variables like `{source_dir}` into text. MDX 3 evaluates bare `{expr}` as JSX and fails the SSG build. The `escape_mdx_braces()` post-processor in the generator escapes these — except inside fenced code blocks and inline backtick spans.
+- **`<code>` tag replacement**: griffe2md templates emit `<code>str</code>` for parameter types. The `fix_code_tags()` post-processor converts these to backticks. Both post-processors run at every file write.
+- **Test script is a gate, not a wishlist**: allowlists in `test_api_reference_coverage.py` must match what the generator actually produces. Method in package but not in allowlist → warning. Method in allowlist but missing from MDX → failure.


### PR DESCRIPTION
## Summary

Adds a `CLAUDE.md` contributing guide and two reference docs under `.claude/commands/` so anyone working in this repo — human contributors and AI agents alike — has a shared, tested set of conventions from day one.

## What's included

**`CLAUDE.md`** — the always-loaded entry point (78 lines):
- Docs structure table: Guide / Examples / Python SDK / Widget API / Workbench — path, purpose, and writing voice for each section
- Core rules: test before documenting, write for humans and agents, absolute links only, check before writing
- Testing workflow: how to verify UDF code (`fused run "" udf.py`), SDK/API code (plain Python), and CLI snippets — each tested and confirmed working
- Do Not section: no hand-editing generated files, no `npm run serve` for validation
- Reference docs table: points to `.claude/commands/` files, readable as plain Markdown or as slash commands in Claude Code
- Build & CI gate: `npm run build` + coverage test before any PR

**`.claude/commands/mdx-components.md`** — every component and pattern in the repo

**`.claude/commands/api-reference.md`** — the Python SDK generation pipeline with design decisions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no runtime, build config, or generated doc changes.
> 
> **Overview**
> Adds **root `CLAUDE.md`** so Claude Code and other agents load fused-docs contribution rules automatically, plus **`.claude/commands/`** deep-dives exposed as slash commands.
> 
> **`CLAUDE.md`** maps each docs section (`guide`, `examples`, `python-sdk`, etc.) to purpose and voice, and sets core expectations: run code before documenting, prefer absolute links, avoid hand-editing generated Python SDK MDX, and use **`npm run build`** (not `serve`) before PRs. It points agents at the command references and lists parallel pre-push checks for API-reference work.
> 
> **`api-reference.md`** documents the fused-py → MDX pipeline (`generate_reference_docs.py`, coverage test, release workflow) and explains *why* bare headings, sorted symbols, MDX brace escaping, and `<code>` → backtick post-processing exist so agents do not regress them.
> 
> **`mdx-components.md`** is a contributor cheat sheet for Docusaurus admonitions, site components (`Tag`, `CellOutput`, players, tabs, details), code-block conventions, and common frontmatter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 052cc38ae33838e44de200a92642d5ce0e93d4d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->