### PR TITLE
fix: opt into Node.js 24 for update-api-reference workflow

### DIFF
--- a/.github/workflows/update-api-reference.yml
+++ b/.github/workflows/update-api-reference.yml
@@ -23,6 +23,8 @@ permissions:
 jobs:
   update-api-reference:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the job env in `.github/workflows/update-api-reference.yml`
- Suppresses the Node.js 20 deprecation warnings from `actions/checkout@v4` and `astral-sh/setup-uv@v5`
- Needed ahead of GitHub's June 2nd 2026 forced Node 24 cutover

Longer-term: bump action versions to Node 24-native releases once maintainers publish them (tracked in Notion).

## Test plan

- [ ] Trigger `gh workflow run update-api-reference.yml -f version=test` after merge — confirm no Node.js deprecation annotation in the run log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts the Actions runner env for one workflow; no application, auth, or data-path changes.
> 
> **Overview**
> Sets **`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`** on the `update-api-reference` job so JavaScript-based steps (e.g. `actions/checkout@v4`, `astral-sh/setup-uv@v5`) run on Node.js 24 instead of the default Node 20 runtime.
> 
> This is a CI-only change ahead of GitHub’s Node 20 deprecation; it should remove Node 20 deprecation annotations from that workflow’s logs without changing doc generation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d95d9e4ee5f2f3fa5ec28cefb3f284770ea42f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->