### PR TITLE
docs: fix UDF code in live-data-mcp-endpoint example

### DIFF
--- a/docs/examples/live-data-mcp-endpoint.mdx
+++ b/docs/examples/live-data-mcp-endpoint.mdx
@@ -67,8 +67,10 @@ def udf(n: int = 5):
         block_id=fused.secrets["SIGNALS_PAGE_ID"]
     )["results"]
 
-    code_block = next(b for b in blocks if b["type"] == "code")
-    signals = json.loads(code_block["code"]["rich_text"][0]["text"]["content"])
+    code_blocks = [b for b in blocks if b["type"] == "code"]
+    if not code_blocks:
+        return pd.DataFrame()
+    signals = json.loads(code_blocks[0]["code"]["rich_text"][0]["text"]["content"])
 
     df = pd.DataFrame(signals)
     df["date"] = pd.to_datetime(df["date"])
@@ -100,10 +102,13 @@ def udf(date: str = "2026-05-28"):
         block_id=fused.secrets["SIGNALS_PAGE_ID"]
     )["results"]
 
-    code_block = next(b for b in blocks if b["type"] == "code")
-    signals = json.loads(code_block["code"]["rich_text"][0]["text"]["content"])
+    code_blocks = [b for b in blocks if b["type"] == "code"]
+    if not code_blocks:
+        return pd.DataFrame()
+    signals = json.loads(code_blocks[0]["code"]["rich_text"][0]["text"]["content"])
 
     df = pd.DataFrame(signals)
+    df["date"] = pd.to_datetime(df["date"]).dt.date.astype(str)
     return df[df["date"] == date]
 ```
 


### PR DESCRIPTION
## Summary

Follow-up fixes to code issues found during review of the live-data-mcp-endpoint example:

- **Guard against missing code block**: `next(...)` raised `StopIteration` if the Notion page had no code block (e.g. not yet written). Now returns an empty DataFrame instead.
- **Fix silent date mismatch in `get_by_date`**: the date column is now normalized to `YYYY-MM-DD` strings before filtering, so comparisons work regardless of how Notion stores the date values internally.

## Test plan

- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to example code in an MDX file; no runtime or production code paths are modified.
> 
> **Overview**
> Updates the **live-data-mcp-endpoint** example UDF snippets so they match safer, working behavior.
> 
> Both `get_latest_signals` and `get_by_date` no longer use `next(...)` on Notion code blocks. They collect code blocks, return an **empty DataFrame** when none exist, and parse the first block—avoiding `StopIteration` on an empty or not-yet-populated page.
> 
> `get_by_date` now normalizes the `date` column to **`YYYY-MM-DD` strings** before filtering, so the `date` parameter matches stored values instead of failing silently on type/format mismatches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60b2faf84dfe527748718cab7690e2d60bf78f2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->