### PR TITLE
docs: add CLI Reference to CLAUDE.md structure table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,10 @@ Each section has a distinct purpose and writing voice. Put content in the right 
 | **Examples** | `docs/examples/` | Hands-on, concrete things you can build | Task-first. Show the code, explain what it does. Link back to Guide for concepts, API Reference for method signatures. |
 | **Python SDK** | `docs/python-sdk/` | Exhaustive reference for the `fused` Python API | Generated — do not hand-edit. Every method, every parameter. No prose beyond what the docstring provides. |
 | **Widget API** | `docs/widget-api/` | Reference for all available Fused widgets and their configuration | Schema-driven. Exhaustive props list, show minimal and full examples. |
+| **CLI Reference** | `docs/cli/` | One page per `fused` CLI command — flags, subcommands, examples | Reference-style. One page per top-level command. Flags table + examples, no prose beyond what's needed to understand the flag. |
 | **Workbench Manual** | `docs/workbench/` | Reference for the Workbench UI | UI-first. Screenshot-heavy. Describe what each element does, not how to build with it. |
 
-Before adding a page, ask: is this a concept (Guide), a recipe (Examples), a reference entry (Python SDK / Widget API), or a UI element (Workbench)? Put it in the right section and write in that section's voice.
+Before adding a page, ask: is this a concept (Guide), a recipe (Examples), a reference entry (Python SDK / Widget API / CLI), or a UI element (Workbench)? Put it in the right section and write in that section's voice.
 
 ## Core rules
 


### PR DESCRIPTION
## Summary

- Adds `docs/cli/` row to the docs structure table so future contributors and agents know where CLI reference pages live and what writing style to follow
- Updates the "before adding a page" prompt to include CLI as a reference option

Follows up on #1138 which added the CLI Reference section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contributor-documentation only; no product code, build, or published user docs behavior changes.
> 
> **Overview**
> Updates the contributor guide in **CLAUDE.md** so the docs structure table documents the **CLI Reference** section at `docs/cli/` (path, purpose, and reference-style voice).
> 
> The “before adding a page” checklist now treats **CLI** alongside Python SDK and Widget API as a reference destination, aligning agent and contributor routing with the CLI docs added in #1138.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edcce9264f93c0d7a7bc5b891ba2217e00ec1a4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->