### PR TITLE
fix: repoint pre-existing broken doc anchors surfaced by build

### DIFF
--- a/docs/examples/airbnb-explore-on-the-fly.mdx
+++ b/docs/examples/airbnb-explore-on-the-fly.mdx
@@ -101,5 +101,5 @@ The Canvas can be shared as a link or as a standalone widget. [Share the full Ca
 Open the [Fused Canvas](https://www.fused.io/canvas/fc_5SyzybeWalreHjKfpAymBL?outline=false&bounds=1096%2C-674%2C2648%2C1204) to explore the live Airbnb dataset, or go straight to the [interactive widget](https://www.fused.io/share/fc_5SyzybeWalreHjKfpAymBL/widget_2) to ask questions directly.
 
 :::tip Make it your own
-Clone the Canvas to customize it. Swap the data source, change the default chart, or adjust the AI panel position. See the [Widgets guide](/guide/data-input-outputs/import-connection/widgets#available-props) for the full list of `widget-builder` props.
+Clone the Canvas to customize it. Swap the data source, change the default chart, or adjust the AI panel position. See the [Widgets guide](/guide/data-input-outputs/import-connection/widgets#available-widgets) for the full list of `widget-builder` props.
 :::

--- a/docs/examples/ais-dark-vessels.mdx
+++ b/docs/examples/ais-dark-vessels.mdx
@@ -256,7 +256,7 @@ print(date_ranges.head())
 4  2024_09_05
 ```
 
-[`fused.submit()`](/guide/working-with-udfs/udf-best-practices/scaling-out#parallel-execution) requires inputs as a list or `DataFrame`, in which case columns should have the argument names that our UDF expects, in this case `datestr`. We also recommend you always do a first run with `debug_mode=True` to [test your submit job](/guide/working-with-udfs/udf-best-practices/scaling-out#test-first-with-debug-mode):
+[`fused.submit()`](/guide/working-with-udfs/udf-best-practices/scaling-out#parallel-execution) requires inputs as a list or `DataFrame`, in which case columns should have the argument names that our UDF expects, in this case `datestr`. We also recommend you always do a first run with `debug_mode=True` to [test your submit job](/guide/working-with-udfs/udf-best-practices/scaling-out#start-small-then-scale):
 
 ```python {4} showLineNumbers
 # doctest: skip

--- a/docs/examples/branded-text-to-image.mdx
+++ b/docs/examples/branded-text-to-image.mdx
@@ -71,14 +71,14 @@ Provide an existing image — a hand-drawn sketch, a rough diagram, a photo — 
 
 You could wire up OpenRouter locally in a script, but running it on Fused gives you:
 
-- **[Secure secrets management](/workbench/preferences#secrets-management)** — API keys are stored as Fused secrets, never in code or environment variables. The key never touches team members' machines.
+- **[Secure secrets management](/workbench/integrations-secrets#secrets)** — API keys are stored as Fused secrets, never in code or environment variables. The key never touches team members' machines.
 - **[Team sharing](/guide/working-with-udfs/udf-best-practices/version-control)** — share the Canvas URL with anyone in your org. They open a browser, type a prompt, and get an on-brand image — no Python environment, no local setup, no credential sharing. Access stays within your organization.
 - **[Response caching](/python-sdk/api-reference/fused-cache)** — identical prompt + style combinations return instantly without re-calling the API. Running the same prompt twice costs nothing extra.
 - **One style update, everywhere** — edit the style library once and every future generation picks up the change automatically.
 - **Fast iteration** — tweak prompts, switch styles, and compare outputs in the browser in seconds.
 
 :::tip Setting up your OpenRouter API key
-Add your key once as a [Fused secret](/workbench/preferences#secrets-management) named `openrouter_api_key`:
+Add your key once as a [Fused secret](/workbench/integrations-secrets#secrets) named `openrouter_api_key`:
 
 1. Go to **Workbench → Preferences → Secrets**
 2. Click **Add secret**, name it `openrouter_api_key`, paste your key
@@ -127,7 +127,7 @@ The `color` parameter propagates your brand accent across all styles at once —
 ## See also
 
 - [Widgets](/guide/data-input-outputs/import-connection/widgets/) — how image output widgets work on the Canvas
-- [Secrets management](/workbench/preferences#secrets-management) — storing API keys securely
+- [Secrets management](/workbench/integrations-secrets#secrets) — storing API keys securely
 - [`@fused.cache`](/python-sdk/api-reference/fused-cache) — avoid duplicate API charges
 - [Working as a team](/guide/working-with-udfs/udf-best-practices/version-control)
 - [Using AI inside a UDF](/guide/data-input-outputs/import-connection/using-ai-inside-udf)

--- a/docs/examples/comfyui-fused-workflows.mdx
+++ b/docs/examples/comfyui-fused-workflows.mdx
@@ -11,7 +11,7 @@ sidebar_label: ComfyUI workflows
 ComfyUI is a powerful node-based tool for diffusion model pipelines — but sharing, scheduling, and caching those runs requires orchestration outside ComfyUI. Fused acts as that layer: it calls ComfyUI (via [Comfy Cloud](https://cloud.comfy.org) or a self-hosted GPU), caches results so identical runs are instant, stores outputs to S3, and makes everything shareable as a live link.
 
 :::tip Setting up your Comfy Cloud API key
-Add your key once as a [Fused secret](/workbench/preferences#secrets-management) named `COMFY_API_KEY`:
+Add your key once as a [Fused secret](/workbench/integrations-secrets#secrets) named `COMFY_API_KEY`:
 
 1. Go to **Workbench → Integrations & secrets → Personal/Team secrets**
 2. Click **Add new secret**, name it `COMFY_API_KEY`, paste your key
@@ -264,7 +264,7 @@ The IDs `"104:90"` and `"104:92"` above are specific to this z-image-turbo workf
 ## See also
 
 - [`@fused.cache`](/python-sdk/api-reference/fused-cache) — result caching reference
-- [Secrets management](/workbench/preferences#secrets-management) — storing API keys
+- [Secrets management](/workbench/integrations-secrets#secrets) — storing API keys
 - [Widgets](/guide/data-input-outputs/import-connection/widgets/) — building canvas controls
 - [Sharing canvas dashboards](/examples/sharing-canvas-dashboards) — sharing your work
 - [Branded text to image](/examples/branded-text-to-image) — another generative AI pipeline on Fused

--- a/docs/examples/google-calendar-meetings.mdx
+++ b/docs/examples/google-calendar-meetings.mdx
@@ -307,7 +307,7 @@ To run this with your own calendar you need:
 1. Get an API key from the [Google Cloud Console](https://console.cloud.google.com/apis/credentials)
 2. Enable the [Routes API](https://console.cloud.google.com/apis/library/routes.googleapis.com) and [Calendar API](https://console.cloud.google.com/apis/library/calendar-json.googleapis.com)
 :::info Store your API key in Fused Secrets
-In Fused Workbench, go to **Preferences** → **Environment** → **Secrets management** ([docs](/workbench/preferences#secrets-management)) and add your API key with the name **`google_maps_api`**. The pipeline references it as `fused.secrets["google_maps_api"]`.
+In Fused Workbench, go to **Preferences** → **Environment** → **Secrets management** ([docs](/workbench/integrations-secrets#secrets)) and add your API key with the name **`google_maps_api`**. The pipeline references it as `fused.secrets["google_maps_api"]`.
 :::
 
 **Google Calendar** — must be publicly accessible:

--- a/docs/examples/maxar-satellite-imagery.mdx
+++ b/docs/examples/maxar-satellite-imagery.mdx
@@ -209,7 +209,7 @@ def udf():
 
 Let's unpack this:
 - We're calling the UDF called `"Maxar_Open_Data_STAC_single_catalog"` that we renamed earlier over `collections_df`. At the time of writing this example this represents 46 events.
-- We use `fused.submit(..., debug_mode = True)` to run only the 1st value from `collections_df`. This allows us to test that our `fused.submit()` job is [written correctly](/guide/working-with-udfs/udf-best-practices/scaling-out#test-first-with-debug-mode). 
+- We use `fused.submit(..., debug_mode = True)` to run only the 1st value from `collections_df`. This allows us to test that our `fused.submit()` job is [written correctly](/guide/working-with-udfs/udf-best-practices/scaling-out#start-small-then-scale). 
 
 :::tip
 `fused.submit()` allows you to run a single over a list / dataframe of inputs in parallel. Under the hood Fused spins up many realtime instances (see [technical docs for details](/python-sdk/api-reference/fused-submit)) that will each run the given UDF (in this case `"Maxar_Open_Data_STAC_single_catalog"`) all at the same time.

--- a/docs/examples/pdf-scraping.mdx
+++ b/docs/examples/pdf-scraping.mdx
@@ -164,7 +164,7 @@ You can make a copy of the UDF from the [UDF Explorer](https://www.fused.io/work
 You will need to:
 - Setup an account on [DataLab](https://www.datalab.to/)
 - Get an [API Key](https://www.datalab.to/app/keys)
-- Add `datalab` as a secret in the [Preferences](/workbench/preferences#secrets-management)
+- Add `datalab` as a secret in the [Preferences](/workbench/integrations-secrets#secrets)
 
 And now you get edit this UDF for yourself:
 

--- a/docs/examples/web-scraping.mdx
+++ b/docs/examples/web-scraping.mdx
@@ -159,7 +159,7 @@ curl "https://www.fused.io/server/v1/realtime-shared/fsh_6mpu2dqoEBc1W80GjhZLSM/
 
 These are community UDFs that you can fork and customize for your needs. Simply click on the "Make a copy to modify" in the Fused Workbench to create your own copy.
 
-**API Setup Required**: You'll need to configure your own API keys for third party services as [fused secrets](/workbench/preferences#secrets-management)
+**API Setup Required**: You'll need to configure your own API keys for third party services as [fused secrets](/workbench/integrations-secrets#secrets)
 
 ## See Also
 

--- a/docs/guide/data-input-outputs/export-api/securing-shared-tokens.mdx
+++ b/docs/guide/data-input-outputs/export-api/securing-shared-tokens.mdx
@@ -13,7 +13,7 @@ Shared tokens are set on the canvas level. Every UDF on the canvas will inherit 
 
 ## Scoping access with canvases
 
-Access is managed **per canvas** ([team vs public](/workbench/udf-builder/canvas#share-modal) and share links). [Canvas passcode](/guide/working-with-udfs/udf-best-practices/security#experimental-protect-endpoints-with-canvas-passcode) is an extra gate that exists only for **publicly shared** canvases. Everyone who can open a canvas sees the same UDFs on it and the same rules for calling them over HTTPS.
+Access is managed **per canvas** ([team vs public](/workbench/udf-builder/canvas#share-modal) and share links). [Canvas passcode](/guide/working-with-udfs/udf-best-practices/security#protect-endpoints-with-canvas-passcode) is an extra gate that exists only for **publicly shared** canvases. Everyone who can open a canvas sees the same UDFs on it and the same rules for calling them over HTTPS.
 
 If you only want to expose **some** UDFs—or a **different** audience—use a **separate canvas**: keep public or broadly shared work on one canvas, and move UDFs that need tighter access to another canvas with **team-only** sharing.
 
@@ -135,6 +135,6 @@ Use that URL in iframes, map tile layers, or `fetch` from the browser.
 
 ## See also
 
-- [Write UDFs securely](/guide/working-with-udfs/udf-best-practices/security) — SQL, parameters, secrets, and [experimental canvas passcodes](/guide/working-with-udfs/udf-best-practices/security#experimental-protect-endpoints-with-canvas-passcode) (publicly shared canvases only)
+- [Write UDFs securely](/guide/working-with-udfs/udf-best-practices/security) — SQL, parameters, secrets, and [experimental canvas passcodes](/guide/working-with-udfs/udf-best-practices/security#protect-endpoints-with-canvas-passcode) (publicly shared canvases only)
 - [Tokens & endpoints](/guide/data-input-outputs/export-api/tokens-endpoints)
 - [Canvas — Share modal](/workbench/udf-builder/canvas#share-modal)

--- a/docs/guide/data-input-outputs/import-connection/cloud-storage.mdx
+++ b/docs/guide/data-input-outputs/import-connection/cloud-storage.mdx
@@ -124,7 +124,7 @@ Download the JSON Key file associated with the Service Account. This file contai
 
 **3. Set the JSON Key as a Secret**
 
-Set the JSON Key as a secret in the [secrets management UI](/workbench/preferences#secrets-management). The secret must be named `gcs_fused`.
+Set the JSON Key as a secret in the [secrets management UI](/workbench/integrations-secrets#secrets). The secret must be named `gcs_fused`.
 
 You then need to write these credentials to a JSON file and pass them to Google:
 

--- a/docs/guide/getting-started/first-udf-basics.mdx
+++ b/docs/guide/getting-started/first-udf-basics.mdx
@@ -51,7 +51,7 @@ def udf():
     return pd.read_csv("s3://your-bucket/your-data.csv")
 ```
 
-Need credentials for private data? See [secrets management](/workbench/preferences#secrets-management).
+Need credentials for private data? See [secrets management](/workbench/integrations-secrets#secrets).
 
 ## Formats
 

--- a/docs/guide/working-with-udfs/udf-best-practices/batch-jobs.mdx
+++ b/docs/guide/working-with-udfs/udf-best-practices/batch-jobs.mdx
@@ -109,7 +109,7 @@ def my_udf():
 In Workbench, dedicated instance UDFs require manual execution (`Shift+Enter`) and show a confirmation modal.
 
 :::note
-Dedicated instance and realtime jobs have [separate caches](/guide/working-with-udfs/udf-best-practices/caching#realtime-vs-batch-have-separate-caches). Running the same UDF with different `engine` values will cache results independently.
+Dedicated instance and realtime jobs have [separate caches](/guide/working-with-udfs/udf-best-practices/caching#realtime-vs-dedicated-instance-have-separate-caches). Running the same UDF with different `engine` values will cache results independently.
 :::
 
 ### Write to disk, don't return data

--- a/docs/guide/working-with-udfs/udf-best-practices/debugging-playbook.mdx
+++ b/docs/guide/working-with-udfs/udf-best-practices/debugging-playbook.mdx
@@ -40,7 +40,7 @@ Cached results can mask bugs — a fix won't appear until the cache is invalidat
 | Workbench cache | **Clear cache** button in the Workbench toolbar |
 
 :::warning Workbench cache ≠ HTTP endpoint cache
-**Clear cache** only clears the Workbench-level cache. Calls via the HTTP endpoint use a separate cache. See [Each execution context has its own cache](/guide/working-with-udfs/udf-best-practices/caching#each-execution-context-has-its-own-cache).
+**Clear cache** only clears the Workbench-level cache. Calls via the HTTP endpoint use a separate cache. See [Each execution context has its own cache](/guide/working-with-udfs/udf-best-practices/caching#two-types-of-cache).
 :::
 
 Disable the UDF cache at call time:

--- a/docs/python-sdk/batch.mdx
+++ b/docs/python-sdk/batch.mdx
@@ -54,7 +54,7 @@ def udf(
 
 ## 2. Run UDF [on an offline instance](/guide/working-with-udfs/udf-best-practices/scaling-out#dedicated-instances)
 
-To go beyond the 120s limit of the default [`fused.run(udf)`](/python-sdk/api-reference/fused-run) call we'll define a job and use [`job.run_batch()`](/guide/working-with-udfs/udf-best-practices/scaling-out#starting-a-batch-job) to kick off a call on a large, offline instance.
+To go beyond the 120s limit of the default [`fused.run(udf)`](/python-sdk/api-reference/fused-run) call we'll define a job and use [`job.run_batch()`](/guide/working-with-udfs/udf-best-practices/scaling-out#starting-a-dedicated-instance-job) to kick off a call on a large, offline instance.
 Get in touch with Fused if your account doesn't have batch-mode enabled.
 
 Note: Make sure to replace `<YOUR_DIR>` with your own directory.

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -723,7 +723,7 @@ This is a major release introducing a new Canvas-first architecture. UDFs now li
 
 If you have UDFs calling `fused.load()` or `fused.run()` to UDFs in other Canvases:
 1. **Copy the UDF** into the current Canvas, or
-2. **Load from GitHub:** `fused.load("https://github.com/...")` ([see load methods](/guide/working-with-udfs/fused-run#udf--ways-to-reference-a-udf)), or
+2. **Load from GitHub:** `fused.load("https://github.com/...")` ([see load methods](/guide/working-with-udfs/fused-run#loading-a-udf)), or
 
 ## v1.30.1 (2026-01-22)
 

--- a/docs/workbench/integrations/gcs.mdx
+++ b/docs/workbench/integrations/gcs.mdx
@@ -44,7 +44,7 @@ Download the JSON key file associated with the Service Account. This file contai
 
 ## 3. Store the key as a secret
 
-In the [Secrets management UI](/workbench/preferences#secrets-management), store the JSON key file contents as a secret named `gcs_fused`.
+In the [Secrets management UI](/workbench/integrations-secrets#secrets), store the JSON key file contents as a secret named `gcs_fused`.
 
 ## 4. Use the credentials in a UDF
 


### PR DESCRIPTION
## Summary

`npm run build` reported **18 broken anchors** — links pointing at heading anchors that no longer exist on their target pages (pre-existing, unrelated to any recent PR). This repoints each link to the heading that exists today, verified by reopening every target page and re-running the full SSG build.

Result: **18 → 3** broken anchors.

| Old anchor | New anchor |
|---|---|
| `/workbench/preferences#secrets-management` | `/workbench/integrations-secrets#secrets` |
| `security#experimental-protect-endpoints-with-canvas-passcode` | `security#protect-endpoints-with-canvas-passcode` |
| `caching#realtime-vs-batch-have-separate-caches` | `caching#realtime-vs-dedicated-instance-have-separate-caches` |
| `caching#each-execution-context-has-its-own-cache` | `caching#two-types-of-cache` |
| `scaling-out#test-first-with-debug-mode` | `scaling-out#start-small-then-scale` |
| `scaling-out#starting-a-batch-job` | `scaling-out#starting-a-dedicated-instance-job` |
| `fused-run#udf--ways-to-reference-a-udf` | `fused-run#loading-a-udf` |
| `widgets#available-props` | `widgets#available-widgets` |

## Deferred (separate bug)

The remaining 3 anchors — `udf#schedule`, `udf#get_schedule`, `udf#to_fused` — are **not** a link problem: those methods are missing from the generated `Udf` API reference (`docs/python-sdk/api-reference/udf.mdx`). That's a generator bug tracked in its own ticket and will be handled in a follow-up PR.

## Test plan

- [x] `npm run build` — broken-anchor warnings dropped from 18 to the 3 deferred ones; build succeeds
- [ ] Spot-check repointed links on the staging preview build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link target updates; no runtime, API, or auth changes.
> 
> **Overview**
> This PR **fixes broken internal doc links** surfaced by the static site build: cross-references are updated to match **current heading anchors** on their target pages, with no changes to product behavior or code.
> 
> Most updates move **secrets** documentation links from `/workbench/preferences#secrets-management` to **`/workbench/integrations-secrets#secrets`** across examples (Airbnb, branded T2I, ComfyUI, Google Calendar, PDF/web scraping) and guides (cloud storage, first UDF, GCS integration). Other repoints align **scaling-out** (`#start-small-then-scale`, `#starting-a-dedicated-instance-job`), **caching** (`#two-types-of-cache`, `#realtime-vs-dedicated-instance-have-separate-caches`), **security** (canvas passcode anchor without `experimental-`), **widgets** (`#available-widgets`), and **`fused-run`** (`#loading-a-udf`).
> 
> Per the PR description, **three** broken anchors on the generated `Udf` API reference remain deferred (missing methods in generated docs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91fd4a5e9102cdfbd5cbd4cb30cd20157704cc28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->