### PR TITLE
fix: include inherited Udf methods in generated API reference

### DIFF
--- a/docs/python-sdk/api-reference/api.mdx
+++ b/docs/python-sdk/api-reference/api.mdx
@@ -27,6 +27,63 @@ Get an access token for the Fused service.
 
 ---
 
+## airtable_connect
+
+```python
+airtable_connect(*, base_id: str | None = None) -> FusedAirtableConnection
+```
+
+Create an Airtable connection using Fused-managed OAuth.
+
+**Parameters:**
+
+- **base_id** (`str | None`) – Default Airtable base ID (e.g. `"appXXXXXXXXXXXXXX"`).
+  When provided, methods that accept a `base_id` parameter will
+  fall back to this value.
+
+**Returns:**
+
+- **A** (`[FusedAirtableConnection](#fused.api._airtable.FusedAirtableConnection)`) – class:`FusedAirtableConnection` instance.
+
+---
+
+## airtable_list_records
+
+```python
+airtable_list_records(table: str, *, base_id: str, **params: Any) -> list[dict]
+```
+
+List records from an Airtable table.
+
+This is a convenience wrapper around
+:meth:`FusedAirtableConnection.list_records`.
+
+**Parameters:**
+
+- **table** (`str`) – Table name or ID.
+- **base_id** (`str`) – Airtable base ID.
+- \*\***params** (`Any`) – Extra query parameters forwarded to the Airtable
+  List Records endpoint (e.g. `maxRecords`, `view`,
+  `filterByFormula`).
+
+**Returns:**
+
+- `[list](#fused.api._public_api.list)\[[dict](#dict)\]` – A list of record dicts.
+
+---
+
+## anthropic_connect
+
+```python
+anthropic_connect() -> anthropic.Anthropic
+```
+
+Return an authenticated Anthropic client for Claude model inference.
+
+The API key is read from `fused.secrets["ANTHROPIC_API_KEY"]`.
+
+---
+
 ## auth_scheme
 
 ```python
@@ -178,6 +235,44 @@ Fetch UDFs under the user account:
 ```py
 fused.api.get_udfs()
 ```
+
+---
+
+## hubspot_connect
+
+```python
+hubspot_connect()
+```
+
+Create a HubSpot client using Fused-managed OAuth.
+
+Returns an official `hubspot.HubSpot` client instance initialized
+with a short-lived access token. See the hubspot-api-client docs for
+the full API surface.
+
+---
+
+## huggingface_connect
+
+```python
+huggingface_connect() -> HfApi
+```
+
+Return an authenticated HfApi client for repos, models, and datasets.
+
+The token is read from `fused.secrets["HUGGINGFACE_API_KEY"]`.
+
+---
+
+## huggingface_inference
+
+```python
+huggingface_inference() -> InferenceClient
+```
+
+Return an authenticated InferenceClient for model inference.
+
+The token is read from `fused.secrets["HUGGINGFACE_API_KEY"]`.
 
 ---
 
@@ -450,6 +545,28 @@ logout()
 Log out the current user.
 
 This deletes the credentials saved to disk and resets the global Fused API.
+
+---
+
+## modal_connect
+
+```python
+modal_connect() -> modal.Client
+```
+
+---
+
+## notion_connect
+
+```python
+notion_connect() -> FusedNotionConnection
+```
+
+Create a Notion connection using Fused-managed OAuth.
+
+**Returns:**
+
+- **A** (`[FusedNotionConnection](#fused.api._notion.FusedNotionConnection)`) – class:`FusedNotionConnection` instance.
 
 ---
 
@@ -999,6 +1116,339 @@ Returns the current user's Fused environment (team) auth token
 
 ---
 
+## Airtable
+
+## FusedAirtableConnection
+
+## fused.api.FusedAirtableConnection
+
+```python
+FusedAirtableConnection(base_id: str | None = None)
+```
+
+Airtable integration using Fused-managed OAuth tokens.
+
+The connection lazily fetches a short-lived OAuth access token from the
+Fused server and uses the Airtable REST API directly.
+
+**Parameters:**
+
+- **base_id** (`str | None`) – Default Airtable base ID (e.g. `"appXXXXXXXXXXXXXX"`).
+  When provided, methods that accept a `base_id` parameter will
+  fall back to this value.
+
+---
+
+### create_records
+
+```python
+create_records(
+    table: str, records: list[dict[str, Any]], *, base_id: str | None = None
+) -> list[dict[str, Any]]
+```
+
+Create one or more records.
+
+**Parameters:**
+
+- **table** (`str`) – Table name or ID.
+- **records** (`list\[dict[str, Any]\]`) – List of `{"fields": {...}}` dicts.
+- **base_id** (`str | None`) – Airtable base ID. Falls back to the default.
+
+---
+
+### delete_records
+
+```python
+delete_records(
+    table: str, record_ids: list[str], *, base_id: str | None = None
+) -> list[dict[str, Any]]
+```
+
+Delete one or more records by ID.
+
+**Parameters:**
+
+- **table** (`str`) – Table name or ID.
+- **record_ids** (`list[str]`) – List of record IDs to delete.
+- **base_id** (`str | None`) – Airtable base ID. Falls back to the default.
+
+---
+
+### get_record
+
+```python
+get_record(
+    table: str, record_id: str, *, base_id: str | None = None
+) -> dict[str, Any]
+```
+
+Fetch a single record by ID.
+
+**Parameters:**
+
+- **table** (`str`) – Table name or ID.
+- **record_id** (`str`) – Airtable record ID (e.g. `"recXXXXXXXXXXXXXX"`).
+- **base_id** (`str | None`) – Airtable base ID. Falls back to the default.
+
+---
+
+### list_bases
+
+```python
+list_bases() -> list[dict[str, Any]]
+```
+
+Return the list of bases the token has access to.
+
+---
+
+### list_records
+
+```python
+list_records(
+    table: str, *, base_id: str | None = None, **params: Any
+) -> list[dict[str, Any]]
+```
+
+List records from a table (auto-paginates).
+
+**Parameters:**
+
+- **table** (`str`) – Table name or ID.
+- **base_id** (`str | None`) – Airtable base ID. Falls back to the default.
+- \*\***params** (`Any`) – Extra query parameters forwarded to the Airtable
+  List Records endpoint (e.g. `maxRecords`, `view`,
+  `filterByFormula`).
+
+---
+
+### list_tables
+
+```python
+list_tables(base_id: str | None = None) -> list[dict[str, Any]]
+```
+
+Return the tables in a base.
+
+**Parameters:**
+
+- **base_id** (`str | None`) – Airtable base ID. Falls back to the default.
+
+---
+
+### update_records
+
+```python
+update_records(
+    table: str, records: list[dict[str, Any]], *, base_id: str | None = None
+) -> list[dict[str, Any]]
+```
+
+Update one or more records (PATCH -- partial update).
+
+**Parameters:**
+
+- **table** (`str`) – Table name or ID.
+- **records** (`list\[dict[str, Any]\]`) – List of `{"id": "rec...", "fields": {...}}` dicts.
+- **base_id** (`str | None`) – Airtable base ID. Falls back to the default.
+
+---
+
+## Notion
+
+## FusedNotionConnection
+
+## fused.api.FusedNotionConnection
+
+Notion integration using Fused-managed OAuth tokens.
+
+The connection lazily fetches a short-lived OAuth access token from the
+Fused server and uses the Notion REST API directly.
+
+---
+
+### client
+
+```python
+client() -> NotionClient
+```
+
+Return a configured `notion_client.Client` using the Fused-managed OAuth token.
+
+Requires the `notion-client` package::
+
+```
+pip install notion-client
+```
+
+---
+
+### create_comment
+
+```python
+create_comment(
+    rich_text: list[dict[str, Any]],
+    *,
+    parent_id: str | None = None,
+    discussion_id: str | None = None
+) -> dict[str, Any]
+```
+
+Create a comment on a page or as a reply in a discussion.
+
+Provide exactly one of `parent_id` (top-level comment on a page)
+or `discussion_id` (reply to an existing discussion thread).
+
+**Parameters:**
+
+- **rich_text** (`list\[dict[str, Any]\]`) – List of rich text objects for the comment body.
+- **parent_id** (`str | None`) – Page ID for a new top-level comment.
+- **discussion_id** (`str | None`) – Discussion ID to reply to.
+
+---
+
+### create_page
+
+```python
+create_page(
+    parent: dict[str, Any],
+    properties: dict[str, Any],
+    *,
+    children: list[dict[str, Any]] | None = None
+) -> dict[str, Any]
+```
+
+Create a new page.
+
+**Parameters:**
+
+- **parent** (`dict[str, Any]`) – Parent object, e.g. `{"page_id": "..."}` or
+  `{"database_id": "..."}`.
+- **properties** (`dict[str, Any]`) – Page properties matching the parent schema.
+- **children** (`list\[dict[str, Any]\] | None`) – Optional list of block objects for the page body.
+
+---
+
+### delete_page
+
+```python
+delete_page(page_id: str) -> dict[str, Any]
+```
+
+Move a page to the trash.
+
+Notion does not support permanent deletion via the API.
+
+**Parameters:**
+
+- **page_id** (`str`) – Notion page ID.
+
+---
+
+### get_page
+
+```python
+get_page(page_id: str) -> dict[str, Any]
+```
+
+Retrieve a page by ID.
+
+**Parameters:**
+
+- **page_id** (`str`) – Notion page ID.
+
+---
+
+### get_user
+
+```python
+get_user(user_id: str) -> dict[str, Any]
+```
+
+Retrieve a user by ID.
+
+**Parameters:**
+
+- **user_id** (`str`) – Notion user ID.
+
+---
+
+### list_comments
+
+```python
+list_comments(block_id: str, *, page_size: int = 100) -> list[dict[str, Any]]
+```
+
+List comments on a block or page (auto-paginates).
+
+**Parameters:**
+
+- **block_id** (`str`) – The block or page ID to list comments for.
+- **page_size** (`int`) – Number of results per request (max 100).
+
+---
+
+### list_users
+
+```python
+list_users(*, _page_size: int = 100) -> list[dict[str, Any]]
+```
+
+List all users in the workspace (auto-paginates).
+
+**Parameters:**
+
+- **page_size** – Number of results per request (max 100).
+
+---
+
+### search
+
+```python
+search(
+    query: str | None = None,
+    *,
+    filter: dict[str, Any] | None = None,
+    sort: dict[str, Any] | None = None,
+    _page_size: int = 100
+) -> list[dict[str, Any]]
+```
+
+Search pages and databases by title (auto-paginates).
+
+**Parameters:**
+
+- **query** (`str | None`) – Text to search for in page/database titles.
+- **filter** (`dict[str, Any] | None`) – Optional filter object, e.g.
+  `{"value": "page", "property": "object"}`.
+- **sort** (`dict[str, Any] | None`) – Optional sort object, e.g.
+  `{"direction": "descending", "timestamp": "last_edited_time"}`.
+- **\_page_size** (`int`) – Number of results per request (max 100).
+
+---
+
+### update_page
+
+```python
+update_page(
+    page_id: str,
+    *,
+    properties: dict[str, Any] | None = None,
+    in_trash: bool | None = None
+) -> dict[str, Any]
+```
+
+Update a page's properties or trash/restore it.
+
+**Parameters:**
+
+- **page_id** (`str`) – Notion page ID.
+- **properties** (`dict[str, Any] | None`) – Property values to update.
+- **in_trash** (`bool | None`) – Set `True` to move to trash, `False` to restore.
+
+---
+
 ## Snowflake
 
 ## FusedSnowflakeConnection
@@ -1039,16 +1489,6 @@ Create a Snowflake connection using OAuth token.
 
 ---
 
-### query
-
-```python
-query(sql: str, *args: str, **kwargs: str) -> pd.DataFrame
-```
-
-Execute SQL and return results as a DataFrame.
-
----
-
 ### execute
 
 ```python
@@ -1081,17 +1521,20 @@ Note: database is not escaped.
 
 ---
 
-### list_tables
+### list_stage_files
 
 ```python
-list_tables(
-    database: str | None = None, schema: str | None = None
-) -> list[str]
+list_stage_files(stage: str, pattern: str | None = None) -> list[str]
 ```
 
-Return table names. Optionally scoped to *database*/*schema*.
+List files in a stage (`LIST @stage`).
 
-Note: database and schema are not escaped.
+**Parameters:**
+
+- **stage** (`str`) – Stage reference, e.g. `"@my_stage"` or `"@db.schema.stage"`.
+- **pattern** (`str | None`) – Optional SQL LIKE pattern to filter files.
+
+Note: stage and pattern are not escaped.
 
 ---
 
@@ -1109,20 +1552,27 @@ Note: database and schema are not escaped.
 
 ---
 
-### list_stage_files
+### list_tables
 
 ```python
-list_stage_files(stage: str, pattern: str | None = None) -> list[str]
+list_tables(
+    database: str | None = None, schema: str | None = None
+) -> list[str]
 ```
 
-List files in a stage (`LIST @stage`).
+Return table names. Optionally scoped to *database*/*schema*.
 
-**Parameters:**
+Note: database and schema are not escaped.
 
-- **stage** (`str`) – Stage reference, e.g. `"@my_stage"` or `"@db.schema.stage"`.
-- **pattern** (`str | None`) – Optional SQL LIKE pattern to filter files.
+---
 
-Note: stage and pattern are not escaped.
+### query
+
+```python
+query(sql: str, *args: str, **kwargs: str) -> pd.DataFrame
+```
+
+Execute SQL and return results as a DataFrame.
 
 ---
 

--- a/docs/python-sdk/api-reference/udf.mdx
+++ b/docs/python-sdk/api-reference/udf.mdx
@@ -21,6 +21,58 @@ The maximum age when returning a result from the cache.
 
 ---
 
+### catalog_url
+
+```python
+catalog_url: str | None
+```
+
+Returns the link to open this UDF in the Workbench Catalog, or None if the UDF is not saved.
+
+---
+
+### create_access_token
+
+```python
+create_access_token(
+    *,
+    client_id: str | Ellipsis | None = ...,
+    public_read: bool | None = None,
+    access_scope: str | None = None,
+    cache: bool = True,
+    metadata_json: dict[str, Any] | None = None,
+    enabled: bool = True
+) -> UdfAccessToken
+```
+
+Create a UDF access token (share token) for this UDF.
+
+**Parameters:**
+
+- **client_id** (`str | Ellipsis | None`) – The client ID to use for the access token. (Default: detect automatically)
+- **public_read** (`bool | None`) – Whether the access token should have public read access. (Default: off)
+- **access_scope** (`str | None`) – The access scope to use for the access token. (Default: world)
+- **cache** (`bool`) – Whether to enable caching on the access token. (Default True)
+- **metadata_json** (`dict[str, Any] | None`) – Additional metadata to serve as part of the tiles metadata.json. (Default None)
+- **enabled** (`bool`) – Whether the access token is enabled. (Default True)
+
+---
+
+### delete_saved
+
+```python
+delete_saved(inplace: bool = True)
+```
+
+Delete this UDF from the Fused service.
+
+**Parameters:**
+
+- **inplace** (`bool`) – If True, modify the UDF metadata in place. (Default True)
+  If False, return a new UDF object with the metadata removed.
+
+---
+
 ### disk_size_gb
 
 ```python
@@ -68,6 +120,66 @@ Note that this will evaluate the UDF function.
 - **inplace** (`bool`) – If True, update this UDF object. Otherwise return a new UDF object (default).
 
 Deprecated: Do not call this.
+
+---
+
+### from_gist
+
+```python
+from_gist(gist_id: str)
+```
+
+Create a Udf from a GitHub gist.
+
+---
+
+### get_access_token
+
+```python
+get_access_token() -> UdfAccessToken | None
+```
+
+Get a UDF access token (share token) for this UDF, or None if no token exists.
+
+---
+
+### get_access_tokens
+
+```python
+get_access_tokens() -> UdfAccessTokenList
+```
+
+Get all UDF access tokens (share tokens) for this UDF.
+
+---
+
+### get_canvas_share_token
+
+```python
+get_canvas_share_token() -> str
+```
+
+Get the canvas share token (`fc_...`) for the UDF's collection.
+
+---
+
+### get_schedule
+
+```python
+get_schedule() -> CronJobSequence
+```
+
+Retrieve any scheduled runs of this UDF
+
+---
+
+### invalidate_cache
+
+```python
+invalidate_cache()
+```
+
+Invalidate the result cache for this UDF.
 
 ---
 
@@ -256,6 +368,37 @@ Deprecated: Call the UDF instead.
 
 ---
 
+### schedule
+
+```python
+schedule(
+    minute: list[int] | int,
+    hour: list[int] | int,
+    day_of_month: list[int] | int | None = None,
+    month: list[int] | int | None = None,
+    day_of_week: list[int] | int | None = None,
+    udf_args: dict[str, Any] | None = None,
+    enabled: bool = True,
+    _create_udf: bool = True,
+    **kwargs: bool
+) -> CronJob
+```
+
+Schedule this UDF to run on a cron schedule.
+
+**Parameters:**
+
+- **minute** (`list[int] | int`) – The minute to run the UDF on.
+- **hour** (`list[int] | int`) – The hour to run the UDF on.
+- **day_of_month** (`list[int] | int | None`) – The day of the month to run the UDF on. (Default every day)
+- **month** (`list[int] | int | None`) – The month to run the UDF on. (Default every month)
+- **day_of_week** (`list[int] | int | None`) – The day of the week to run the UDF on. (Default every day)
+- **udf_args** (`dict[str, Any] | None`) – The arguments to pass to the UDF. (Default None)
+- **enabled** (`bool`) – Whether the cron job is enabled. (Default True)
+- **\_create_udf** (`bool`) – Save the UDF to Fused before creating the CronJob. (Default True)
+
+---
+
 ### set_parameters
 
 ```python
@@ -275,6 +418,20 @@ Set the parameters on this UDF.
 - **inplace** (`bool`) – If True, modify this object. If False, return a new object. Defaults to True.
 
 Deprecated: Set parameters when calling the UDF or using `UDF.map()` instead.
+
+---
+
+### shared_url
+
+```python
+shared_url(format: str | None = None) -> str | None
+```
+
+Get the shared URL for this UDF.
+
+**Parameters:**
+
+- **format** (`str | None`) – The result format (file type) for the URL. (Default None)
 
 ---
 
@@ -313,6 +470,29 @@ The UDF will be written as a Zip file.
 **Other Parameters:**
 
 - **overwrite** (`[bool](#bool)`) – If true, overwriting is allowed.
+
+---
+
+### to_fused
+
+```python
+to_fused(
+    *,
+    overwrite: bool | None = None,
+    collection_name: str | None = None,
+    create_collection: bool = False,
+    **kwargs: dict[str, Any]
+)
+```
+
+Save this UDF on the Fused service.
+
+**Parameters:**
+
+- **overwrite** (`bool | None`) – If True, overwrite existing remote UDF with the UDF object.
+- **collection_name** (`str | None`) – The collection name to associate with this UDF. If not provided,
+  falls back to the collection of the currently executing UDF, or defaults to "default".
+- **create_collection** (`bool`) – If True, create a new collection if it doesn't exist.
 
 ---
 

--- a/docs/python-sdk/top-level-functions.mdx
+++ b/docs/python-sdk/top-level-functions.mdx
@@ -843,3 +843,234 @@ This can be called with file_id and chunk_id from `get_chunks_metadata`.
 
 ---
 
+## fused.find_dataset
+
+```python
+find_dataset(location: str, base_url: Optional[str] = None) -> Dict[str, Any]
+```
+
+Find the dataset that contains a specific location URL.
+
+Uses hierarchical prefix matching: if the exact path isn't registered,
+searches progressively shorter prefixes to find the containing dataset.
+
+**Parameters:**
+
+- **location** (`str`) – Full URL to search for (s3://, gs://, http://, etc.).
+  Can be a file, partition, or directory path.
+- **base_url** (`Optional[str]`) – Base URL for API. If None, uses current environment.
+
+**Returns:**
+
+- `[Dict](#typing.Dict)\[[str](#str), [Any](#typing.Any)\]` – Dataset dict with keys: id, location, description, storage_type,
+- `[Dict](#typing.Dict)\[[str](#str), [Any](#typing.Any)\]` – owner, public, created_at, updated_at, etc.
+
+**Raises:**
+
+- `[HTTPError](#requests.HTTPError)` – If dataset not found (404) or request fails
+
+**Example:**
+
+```python
+# Find dataset containing a file
+dataset = fused.find_dataset("s3://bucket/data/year=2024/file.parquet")
+print(f"Found dataset: {dataset['location']}")
+```
+
+---
+
+## fused.load_async
+
+```python
+load_async(
+    url_or_udf: Union[str, Path],
+    /,
+    *,
+    cache_key: Any = None,
+    import_globals: bool = True,
+    collection_name: str | None = None,
+) -> AnyBaseUdf
+```
+
+Asynchronously loads a UDF from various sources including GitHub URLs,
+and a Fused platform-specific identifier.
+
+This is the async-optimized version of fused.load() that uses async HTTP requests
+to avoid blocking the event loop during UDF metadata fetching.
+
+**Parameters:**
+
+- **url_or_udf** (`Union[str, Path]`) – A string representing the location of the UDF, or the raw code of the UDF.
+- **cache_key** (`Any`) – An optional key used for caching the loaded UDF.
+- **import_globals** (`bool`) – Expose the globals defined in the UDF's context as attributes on the UDF object.
+- **collection_name** (`str | None`) – Collection name to load the UDF from. If not provided, will attempt to
+  use the collection of the currently executing UDF, or default to "default".
+
+**Returns:**
+
+- **AnyBaseUdf** (`[AnyBaseUdf](#fused.models.udf.AnyBaseUdf)`) – An instance of the loaded UDF.
+
+**Examples:**
+
+Load a UDF asynchronously:
+
+```py
+udf = await fused.load_async("username@fused.io/my_udf_name")
+```
+
+Use in parameter validation:
+
+```py
+if not isinstance(udf, Udf):
+    udf = await fused.load_async(udf)
+```
+
+---
+
+## fused.register_dataset
+
+```python
+register_dataset(
+    dataset_path: str, base_url: Optional[str] = None
+) -> Dict[str, Any]
+```
+
+Register a dataset for indexed queries.
+
+This function registers a directory in your file storage as a dataset,
+enabling fast geospatial queries using H3 indexing.
+
+**Parameters:**
+
+- **dataset_path** (`str`) – Path to the dataset directory. The path should point to
+  a directory containing parquet files.
+- **base_url** (`Optional[str]`) – Base URL for API. If None, uses current environment.
+
+**Returns:**
+
+- `[Dict](#typing.Dict)\[[str](#str), [Any](#typing.Any)\]` – Dictionary with registration results:
+- dataset_id: ID of the created/updated dataset
+- location: Normalized URL of the dataset
+- visit_status: Status of the dataset visit (success/timeout/error)
+- items_discovered: Total number of items found
+- new_items: Number of new items added
+
+**Raises:**
+
+- `[HTTPError](#requests.HTTPError)` – If the API request fails
+
+**Example:**
+
+```python
+# Register a dataset from your storage
+result = fused.register_dataset("s3://my-bucket/my-data/buildings/")
+print(f"Registered dataset with ID: {result['dataset_id']}")
+print(f"Found {result['items_discovered']} files")
+```
+
+<details class="note" open>
+<summary>Note</summary>
+- Regular users can use any storage paths they have access to
+- Datasets are registered as private (only accessible to your team)
+- Files are automatically queued for metadata extraction
+</details>
+
+---
+
+## fused.run_async
+
+```python
+run_async(
+    udf: Union[str, None, UdfJobStepConfig, Udf, UdfAccessToken] = None,
+    *,
+    x: Optional[int] = None,
+    y: Optional[int] = None,
+    z: Optional[int] = None,
+    engine: Optional[Literal["remote", "local"]] = None,
+    instance_type: Optional[InstanceType] = None,
+    type: Optional[Literal["tile", "file"]] = None,
+    max_retry: int = 0,
+    cache_max_age: Optional[str] = None,
+    cache: bool = True,
+    parameters: Optional[Dict[str, Any]] = None,
+    disk_size_gb: Optional[int] = None,
+    _return_response: Optional[bool] = False,
+    _ignore_unknown_arguments: bool = False,
+    _cancel_callback: Callable[[], bool] | None = None,
+    **kw_parameters: Callable[[], bool] | None
+) -> Union[ResultType, UdfEvaluationResult]
+```
+
+Async version of run() that executes a user-defined function (UDF) asynchronously.
+
+This function provides the same functionality as run() but with async execution.
+It supports executing UDFs in different environments (local or remote),
+with different types of inputs (tile coordinates, geographical bounding boxes, etc.).
+
+**Parameters:**
+
+- **udf** (`str, Udf or UdfJobStepConfig`) – the UDF to execute.
+  The UDF can be specified in several ways:
+  - A string representing a UDF name or UDF shared token.
+  - A UDF object.
+  - A UdfJobStepConfig object for detailed execution configuration.
+- **x, y, z** – Tile coordinates for tile-based UDF execution.
+- **engine** (`Optional\[Literal['remote', 'local']\]`) – The execution engine to use ('remote' or 'local').
+- **instance_type** (`Optional[InstanceType]`) – The type of instance to use for remote execution ('realtime',
+  or 'small', 'medium', 'large' or one of the whitelisted instance types).
+  If not specified, gets the default from the UDF (if specified in the
+  `@fused.udf()` decorator, and the UDF is not run as a shared token),
+  or otherwise defaults to 'realtime'.
+- **disk_size_gb** (`Optional[int]`) – The size of the disk in GB to use for remote execution
+  (only supported for a batch (non-realtime) instance type).
+- **type** (`Optional\[Literal['tile', 'file']\]`) – The type of UDF execution ('tile' or 'file').
+- **max_retry** (`int`) – The maximum number of retries to attempt if the UDF fails.
+  By default does not retry.
+- **cache_max_age** (`Optional[str]`) – The maximum age when returning a result from the cache.
+  Supported units are seconds (s), minutes (m), hours (h), and days (d) (e.g. "48h", "10s", etc.).
+  Default is `None` so a UDF run with `fused.run_async()` will follow `cache_max_age` defined in `@fused.udf()` unless this value is changed.
+- **cache** (`bool`) – Set to False as a shortcut for `cache_max_age='0s'` to disable caching.
+- **verbose** – Set to False to suppress any print statements from the UDF.
+- **parameters** (`Optional\[Dict[str, Any]\]`) – Additional parameters to pass to the UDF.
+- \*\***kw_parameters** – Additional parameters to pass to the UDF.
+
+**Raises:**
+
+- `[ValueError](#ValueError)` – If the UDF is not specified or is specified in more than one way.
+- `[TypeError](#TypeError)` – If the first parameter is not of an expected type.
+- `[Warning](#Warning)` – Various warnings are issued for ignored parameters based on the execution path chosen.
+
+**Returns:**
+
+- `[Union](#typing.Union)\[[ResultType](#fused._run.ResultType), [UdfEvaluationResult](#fused.models.udf._eval_result.UdfEvaluationResult)\]` – The result of the UDF execution, which varies based on the UDF and execution path.
+
+**Examples:**
+
+Run a UDF saved in the Fused system asynchronously:
+
+```py
+result = await fused.run_async("username@fused.io/my_udf_name")
+```
+
+Run a UDF saved in GitHub asynchronously:
+
+```py
+loaded_udf = fused.load("https://github.com/fusedio/udfs/tree/main/public/Building_Tile_Example")
+result = await fused.run_async(loaded_udf, bbox=bbox)
+```
+
+Run a UDF saved in a local directory asynchronously:
+
+```py
+loaded_udf = fused.load("/Users/local/dir/Building_Tile_Example")
+result = await fused.run_async(loaded_udf, bbox=bbox)
+```
+
+<details class="note" open>
+<summary>Note</summary>
+This function always executes asynchronously. For synchronous execution, use run().
+It uses the same parameter validation and UDF resolution logic as run().
+</details>
+
+---
+

--- a/utils/generate_reference_docs.py
+++ b/utils/generate_reference_docs.py
@@ -248,7 +248,7 @@ result = result.replace("## fused.cache", "## @fused.cache")
 # griffe cannot handl the x, y, z multiple parameters on one line
 result = result.replace("**x,** (<code>y, z</code>)", "**x, y, z** (`int`)")
 
-with open(ROOT / "docs" / "python-sdk" / "top-level-functions.mdx", "w") as f:
+with open(ROOT / "docs" / "python-sdk" / "top-level-functions.mdx", "w", encoding="utf-8") as f:
     f.write(escape_mdx_braces(fix_code_tags(result)))
 
 
@@ -421,7 +421,7 @@ if "FusedSnowflakeConnection" in mod_api.members:
             continue
         result += render_object_docs(mod_api["FusedSnowflakeConnection"][meth], config_sf) + "\n---\n\n"
 
-with open(ROOT / "docs" / "python-sdk" / "api-reference" / "api.mdx", "w") as f:
+with open(ROOT / "docs" / "python-sdk" / "api-reference" / "api.mdx", "w", encoding="utf-8") as f:
     f.write(escape_mdx_braces(fix_code_tags(result)))
 
 
@@ -458,7 +458,7 @@ config["filters"] = ["!model_config"]
 docstring = render_object_docs(mod["_options"]["Options"], config)
 result += docstring
 
-with open(ROOT / "docs" / "python-sdk" / "api-reference" / "options.mdx", "w") as f:
+with open(ROOT / "docs" / "python-sdk" / "api-reference" / "options.mdx", "w", encoding="utf-8") as f:
     f.write(escape_mdx_braces(fix_code_tags(result)))
 
 
@@ -522,7 +522,7 @@ for meth in async_methods:
     docstring = render_object_docs(mod["_submit"]["AsyncJobPool"][meth], config_async)
     result += docstring + "\n---\n\n"
 
-with open(ROOT / "docs" / "python-sdk" / "api-reference" / "jobpool.mdx", "w") as f:
+with open(ROOT / "docs" / "python-sdk" / "api-reference" / "jobpool.mdx", "w", encoding="utf-8") as f:
     f.write(escape_mdx_braces(fix_code_tags(result)))
 
 
@@ -547,14 +547,17 @@ a saved UDF with [`fused.load()`](/python-sdk/top-level-functions/#fusedload).
 
 """
 
-# Dynamic: all public Udf members with docstrings (methods + pydantic fields)
-# Picks up new additions automatically — no hardcoded list to maintain.
-# Exclude `original_headers`: its only docstring is "Deprecated." and it's an internal field.
+# Dynamic: all public Udf members with docstrings (methods + pydantic fields).
+# Use `all_members` so methods inherited from `BaseUdf` (schedule, get_schedule,
+# to_fused, etc.) are included — `members` only holds members defined directly on
+# `Udf`. Picks up new additions automatically — no hardcoded list to maintain.
+# Skip deprecation stubs (e.g. `original_headers`, `headers`, `utils`) whose only
+# docstring is "Deprecated.".
 methods = sorted(
-    name for name, member in mod["models"]["Udf"].members.items()
+    name for name, member in mod["models"]["Udf"].all_members.items()
     if not name.startswith("_")
-    and name != "original_headers"
     and member.docstring and member.docstring.value.strip()
+    and member.docstring.value.strip() != "Deprecated."
 )
 
 config = dict(default_config)
@@ -565,7 +568,7 @@ for meth in methods:
     docstring = render_object_docs(mod["models"]["Udf"][meth], config)
     result += docstring + "\n---\n\n"
 
-with open(ROOT / "docs" / "python-sdk" / "api-reference" / "udf.mdx", "w") as f:
+with open(ROOT / "docs" / "python-sdk" / "api-reference" / "udf.mdx", "w", encoding="utf-8") as f:
     f.write(escape_mdx_braces(fix_code_tags(result)))
 
 
@@ -605,5 +608,5 @@ for obj in api_listing:
 
 result = result.replace("`fused.submit()`", "[`fused.submit()`](/python-sdk/top-level-functions/#fusedsubmit)")
 
-with open(ROOT / "docs" / "python-sdk" / "api-reference" / "h3.mdx", "w") as f:
+with open(ROOT / "docs" / "python-sdk" / "api-reference" / "h3.mdx", "w", encoding="utf-8") as f:
     f.write(escape_mdx_braces(fix_code_tags(result)))

--- a/utils/generate_reference_docs.py
+++ b/utils/generate_reference_docs.py
@@ -135,6 +135,29 @@ api_listing = [
     "get_chunk_from_table",
 ]
 
+# Append any public top-level functions from `fused.__all__` not already listed
+# (e.g. find_dataset, load_async, register_dataset, run_async) so new functions
+# appear automatically. The curated entries above keep their preferred order;
+# auto-detected ones are appended alphabetically. Modules, attributes, and
+# unresolvable re-export aliases are skipped.
+_known_top = set(api_listing)
+for name in sorted(fused.__all__):
+    if name.startswith("_") or name in _known_top:
+        continue
+    member = mod.members.get(name)
+    if member is None:
+        continue
+    try:
+        if (
+            member.kind.value == "function"
+            and member.docstring
+            and member.docstring.value.strip()
+        ):
+            api_listing.append(name)
+    except Exception:
+        # Unresolvable alias (e.g. load_ipython_extension) — skip
+        continue
+
 result = """\
 ---
 sidebar_label: Top-Level Functions
@@ -255,47 +278,45 @@ with open(ROOT / "docs" / "python-sdk" / "top-level-functions.mdx", "w", encodin
 
 ## `fused.api` page
 
-api_listing = [
-    # Auth
-    "whoami",
-    "access_token",
-    "auth_scheme",
-    "logout",
-    # File operations
-    "delete",
-    "list",
-    "get",
-    "download",
-    "upload",
-    "sign_url",
-    "sign_url_prefix",
-    "resolve",
-    # UDFs / apps
-    "get_udfs",
-    "get_apps",
-    # Jobs
-    "job_get_logs",
-    "job_print_logs",
-    "job_tail_logs",
-    "job_get_status",
-    "job_cancel",
-    "job_get_exec_time",
-    "job_wait_for_job",
-    "job_get_results",
-    "job_wait_for_results",
-    # Scheduling
-    "schedule_udf",
-    "schedule_list",
-    # Utilities
-    "session_token",
-    "team_info",
-    "enable_gcs",
-    "log",
-    # Snowflake
-    "snowflake_connect",
-    "snowflake_query",
-    # Note: Functions that no longer exist will be automatically skipped with a warning
-]
+import fused.api as _fused_api
+
+mod_api = mod["api"]
+
+# Auto-detect public fused.api symbols from the module's `__all__`, minus a
+# blocklist of internal/infra items. New integrations (airtable, notion,
+# huggingface, etc.) then appear automatically — no allowlist to maintain.
+API_BLOCKLIST = {
+    "_session_token",       # internal
+    "FusedAPI",             # rendered in its own section below
+    "FusedDockerAPI",       # internal infra
+    "DriveFileSystem",      # internal infra
+    "FdFileSystem",         # internal infra
+    "NotebookCredentials",  # internal infra
+}
+
+# Public but absent from `__all__` — always include.
+_AUTH_SUPPLEMENT = {"access_token", "auth_scheme", "logout"}
+
+# Module-level functions: everything public in `__all__` except the blocklist and
+# the Fused*Connection classes (documented in their own sections below).
+api_listing = sorted(
+    _AUTH_SUPPLEMENT
+    | {
+        name for name in _fused_api.__all__
+        if not name.startswith("_")
+        and name not in API_BLOCKLIST
+        and not (name.startswith("Fused") and name.endswith("Connection"))
+        and name in mod_api.members
+        and mod_api[name].kind.value == "function"
+    }
+)
+
+# Fused*Connection classes each get their own section (Snowflake, Airtable, Notion, …).
+connection_classes = sorted(
+    name for name in _fused_api.__all__
+    if name.startswith("Fused") and name.endswith("Connection")
+    and name not in API_BLOCKLIST
+)
 
 result = """\
 ---
@@ -319,13 +340,11 @@ fused.api.function_name()
 
 """
 
-mod_api = mod["api"]
-
 # fused.api functions — bare name headings (## access_token, not ## fused.api.access_token)
 config_api_mod = dict(default_config)
 config_api_mod["show_root_full_path"] = False
 
-for obj in sorted(api_listing):
+for obj in api_listing:
     if obj not in mod_api.members:
         print(f"Warning: {obj} not found in fused.api module, skipping")
         continue
@@ -386,40 +405,35 @@ for meth in methods:
 """
     result += docstring + "\n" + usage_note + "\n---\n\n"
 
-# fused.api.FusedSnowflakeConnection class
+# fused.api Fused*Connection classes (Snowflake, Airtable, Notion, …).
+# One section per class; methods discovered dynamically so new connections and
+# new methods appear automatically.
+config_conn = dict(default_config)
+config_conn["filters"] = ["__init__"]
+config_conn["summary"] = False
 
-snowflake_methods = [
-    "connect",
-    "query",
-    "execute",
-    "list_databases",
-    "list_schemas",
-    "list_tables",
-    "list_stages",
-    "list_stage_files",
-    "read_stage",
-    "write",
-]
+config_conn_meth = dict(config_conn)
+config_conn_meth["heading_level"] = default_config["heading_level"] + 1
+config_conn_meth["show_root_full_path"] = False
 
-if "FusedSnowflakeConnection" in mod_api.members:
-    snowflake_note = """\
-## Snowflake
+for class_name in connection_classes:
+    if class_name not in mod_api.members:
+        print(f"Warning: {class_name} not found in fused.api module, skipping")
+        continue
+    cls = mod_api[class_name]
+    # Friendly label: FusedSnowflakeConnection -> Snowflake
+    label = class_name.removeprefix("Fused").removesuffix("Connection")
+    result += f"## {label}\n\n## {class_name}\n\n"
+    result += render_object_docs(cls, config_conn) + "\n---\n\n"
 
-## FusedSnowflakeConnection
-
-"""
-    config_sf = dict(default_config)
-    config_sf["filters"] = ["__init__"]
-    config_sf["summary"] = False
-    result += snowflake_note + render_object_docs(mod_api["FusedSnowflakeConnection"], config_sf) + "\n---\n\n"
-
-    config_sf["heading_level"] = default_config["heading_level"] + 1
-    config_sf["show_root_full_path"] = False
-    for meth in snowflake_methods:
-        if meth not in mod_api["FusedSnowflakeConnection"].members:
-            print(f"Warning: {meth} not found in FusedSnowflakeConnection class, skipping")
-            continue
-        result += render_object_docs(mod_api["FusedSnowflakeConnection"][meth], config_sf) + "\n---\n\n"
+    methods = sorted(
+        name for name, member in cls.members.items()
+        if not name.startswith("_")
+        and member.kind.value == "function"
+        and member.docstring and member.docstring.value.strip()
+    )
+    for meth in methods:
+        result += render_object_docs(cls[meth], config_conn_meth) + "\n---\n\n"
 
 with open(ROOT / "docs" / "python-sdk" / "api-reference" / "api.mdx", "w", encoding="utf-8") as f:
     f.write(escape_mdx_braces(fix_code_tags(result)))

--- a/utils/test_api_reference_coverage.py
+++ b/utils/test_api_reference_coverage.py
@@ -122,11 +122,14 @@ JOBPOOL_METHODS = sorted(
     and member.docstring and member.docstring.value.strip()
 )
 
+# Mirror the generator: `all_members` includes methods inherited from `BaseUdf`
+# (schedule, get_schedule, to_fused, etc.); skip deprecation stubs whose only
+# docstring is "Deprecated." (original_headers, headers, utils).
 UDF_MEMBERS = sorted(
-    name for name, member in mod["models"]["Udf"].members.items()
+    name for name, member in mod["models"]["Udf"].all_members.items()
     if not name.startswith("_")
-    and name != "original_headers"
     and member.docstring and member.docstring.value.strip()
+    and member.docstring.value.strip() != "Deprecated."
 )
 
 ASYNC_JOBPOOL_ASYNC_METHODS = sorted(

--- a/utils/test_api_reference_coverage.py
+++ b/utils/test_api_reference_coverage.py
@@ -179,7 +179,7 @@ def check_in_mdx(mdx_path: Path, heading: str, context: str, level: int = 2) -> 
             )
             _missing_mdx_reported.add(mdx_path)
         return False
-    content = mdx_path.read_text()
+    content = mdx_path.read_text(encoding="utf-8")
     marker = f"{'#' * level} {heading}"
     if marker not in content:
         failures.append(

--- a/utils/test_api_reference_coverage.py
+++ b/utils/test_api_reference_coverage.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import griffe
 import fused
+import fused.api as _fused_api
 
 ROOT = Path(__file__).parent / ".."
 
@@ -27,11 +28,14 @@ ROOT = Path(__file__).parent / ".."
 
 print(f"Testing API reference coverage for fused v{fused.__version__}\n")
 mod = griffe.load("fused", docstring_parser="google")
+mod_api = mod["api"]
 
 # ── Allowlists ─────────────────────────────────────────────────────────────────
 # Curated lists (intentional subsets of larger modules — stay hardcoded)
 # Class-level lists are dynamic (all public documented members auto-discovered)
 
+# Mirror generate_reference_docs.py: curated order + auto-detected functions
+# from fused.__all__ (find_dataset, load_async, register_dataset, run_async, …).
 TOP_LEVEL_FUNCTIONS = [
     "udf",
     "cache",
@@ -45,40 +49,52 @@ TOP_LEVEL_FUNCTIONS = [
     "get_chunks_metadata",
     "get_chunk_from_table",
 ]
+_known_top = set(TOP_LEVEL_FUNCTIONS)
+for _name in sorted(fused.__all__):
+    if _name.startswith("_") or _name in _known_top:
+        continue
+    _member = mod.members.get(_name)
+    if _member is None:
+        continue
+    try:
+        if (
+            _member.kind.value == "function"
+            and _member.docstring
+            and _member.docstring.value.strip()
+        ):
+            TOP_LEVEL_FUNCTIONS.append(_name)
+    except Exception:
+        continue
 
-FUSED_API_FUNCTIONS = [
-    "whoami",
-    "access_token",
-    "auth_scheme",
-    "logout",
-    "delete",
-    "list",
-    "get",
-    "download",
-    "upload",
-    "sign_url",
-    "sign_url_prefix",
-    "resolve",
-    "get_udfs",
-    "get_apps",
-    "job_get_logs",
-    "job_print_logs",
-    "job_tail_logs",
-    "job_get_status",
-    "job_cancel",
-    "job_get_exec_time",
-    "job_wait_for_job",
-    "job_get_results",
-    "job_wait_for_results",
-    "schedule_udf",
-    "schedule_list",
-    "session_token",
-    "team_info",
-    "enable_gcs",
-    "log",
-    "snowflake_connect",
-    "snowflake_query",
-]
+# Mirror generate_reference_docs.py: auto-detect fused.api functions from
+# `__all__` minus a blocklist (keeps integrations like airtable/notion in sync).
+API_BLOCKLIST = {
+    "_session_token",
+    "FusedAPI",
+    "FusedDockerAPI",
+    "DriveFileSystem",
+    "FdFileSystem",
+    "NotebookCredentials",
+}
+_AUTH_SUPPLEMENT = {"access_token", "auth_scheme", "logout"}
+FUSED_API_FUNCTIONS = sorted(
+    _AUTH_SUPPLEMENT
+    | {
+        name for name in _fused_api.__all__
+        if not name.startswith("_")
+        and name not in API_BLOCKLIST
+        and not (name.startswith("Fused") and name.endswith("Connection"))
+        and name in mod_api.members
+        and mod_api[name].kind.value == "function"
+    }
+)
+
+# Auto-detected Fused*Connection classes, each with its public documented methods.
+CONNECTION_CLASSES = sorted(
+    name for name in _fused_api.__all__
+    if name.startswith("Fused") and name.endswith("Connection")
+    and name not in API_BLOCKLIST
+)
 
 FUSED_API_CLASS_METHODS = [
     "create_udf_access_token",
@@ -102,18 +118,17 @@ H3_FUNCTIONS = sorted([
     "run_partition_to_h3",
 ])
 
-FUSED_SNOWFLAKE_METHODS = [
-    "connect",
-    "query",
-    "execute",
-    "list_databases",
-    "list_schemas",
-    "list_tables",
-    "list_stages",
-    "list_stage_files",
-    "read_stage",
-    "write",
-]
+# Per connection class: all public documented methods, discovered dynamically.
+CONNECTION_METHODS = {
+    class_name: sorted(
+        name for name, member in mod_api[class_name].members.items()
+        if not name.startswith("_")
+        and member.kind.value == "function"
+        and member.docstring and member.docstring.value.strip()
+    )
+    for class_name in CONNECTION_CLASSES
+    if class_name in mod_api.members
+}
 
 # Dynamic: all public documented members — picks up new additions automatically
 JOBPOOL_METHODS = sorted(
@@ -211,7 +226,6 @@ for name in TOP_LEVEL_FUNCTIONS:
 # Headings: ## {name}  (bare name, not fused.api.{name})
 
 api_mdx = ROOT / "docs" / "python-sdk" / "api-reference" / "api.mdx"
-mod_api = mod["api"]
 
 for name in FUSED_API_FUNCTIONS:
     if check_in_package(mod_api, name, "fused.api"):
@@ -257,13 +271,12 @@ for name in H3_FUNCTIONS:
     if check_in_package(mod_h3, name, "fused.h3"):
         check_in_mdx(h3_mdx, name, f"fused.h3.{name}", level=2)
 
-# ── FusedSnowflakeConnection methods ──────────────────────────────────────────
-# Headings: ### {name}  (under ## FusedSnowflakeConnection)
+# ── Fused*Connection class methods ────────────────────────────────────────────
+# Headings: ### {name}  (under ## Fused{Name}Connection)
 
-if "FusedSnowflakeConnection" in mod_api.members:
-    for name in FUSED_SNOWFLAKE_METHODS:
-        if check_in_package(mod_api["FusedSnowflakeConnection"], name, "fused.api.FusedSnowflakeConnection"):
-            check_in_mdx(api_mdx, name, f"FusedSnowflakeConnection.{name}", level=3)
+for class_name, methods in CONNECTION_METHODS.items():
+    for name in methods:
+        check_in_mdx(api_mdx, name, f"{class_name}.{name}", level=3)
 
 # ── Report ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Fixes [ITEM-11636] — `Udf.schedule()`, `Udf.get_schedule()`, and `Udf.to_fused()` (and 9 other inherited members) were missing from the generated `Udf` API reference, leaving `#schedule` / `#get_schedule` / `#to_fused` anchors broken.
- **Root cause:** the Udf section of `utils/generate_reference_docs.py` iterated `mod["models"]["Udf"].members`, which in griffe holds only members defined directly on `Udf`. `schedule`/`get_schedule`/`to_fused` etc. are inherited from `BaseUdf`, so they were never rendered.
- **Fix:** discover via `Udf.all_members` (own + inherited), keeping the public + has-docstring filter and generalizing the deprecation-stub exclusion (docstring == `"Deprecated."`) so `original_headers`, `headers`, and `utils` are skipped without hardcoding names.
- Regenerated `docs/python-sdk/api-reference/udf.mdx` now documents 12 inherited members (incl. the three from the ticket).
- Also passes `encoding="utf-8"` to the generator's file writes and the coverage test's read so both run on Windows (cp1252 choked on a docstring emoji).

Scope check: JobPool (base `ABC`), Options, and the curated `fused.api`/`FusedAPI`/Snowflake lists have no missing inherited members. AsyncJobPool already intentionally emits only `*_async` methods and notes it inherits the rest from JobPool — left unchanged.

> Note: `static/llms-*.txt` are not included — regenerating them on Windows introduced unrelated drift and line-ending churn; the deploy pipeline regenerates them.

## Test plan
- [x] `uv run utils/generate_reference_docs.py` — regenerates `udf.mdx` with `schedule`, `get_schedule`, `to_fused` headings
- [x] `npm run build` — the three target anchors no longer appear in the broken-anchor list (1 unrelated `gcs` anchor remains, out of scope)
- [x] `uv run utils/test_api_reference_coverage.py` — 183/183 checks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and doc-generation script changes only; no runtime SDK behavior is modified.
> 
> **Overview**
> Fixes broken API doc anchors by changing how reference MDX is generated, not by hand-editing pages.
> 
> **`Udf` reference:** Member discovery now uses griffe `all_members` instead of `members`, so inherited `BaseUdf` APIs (e.g. `schedule`, `get_schedule`, `to_fused`, access tokens, `shared_url`) appear in `udf.mdx`. Deprecation-only stubs are skipped when the docstring is exactly `"Deprecated."`.
> 
> **Less manual allowlists:** Top-level docs append any documented public function from `fused.__all__` not already in the curated list (`find_dataset`, `load_async`, `register_dataset`, `run_async`, etc.). `fused.api` module functions and every `Fused*Connection` class (Snowflake, Airtable, Notion, …) are built from `fused.api.__all__` with a small blocklist; connection methods are enumerated dynamically instead of a Snowflake-only hardcoded list.
> 
> **Tooling:** `test_api_reference_coverage.py` mirrors the generator rules (including `all_members` and connection classes). Generator output and coverage reads use `encoding="utf-8"` so Windows builds don’t fail on non-ASCII docstrings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eee627e68be965924203bf767e0ca226d1e25fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->