### PR TITLE
docs: add OneDrive and Dropbox integration pages

### DIFF
--- a/docs/workbench/integrations/dropbox.mdx
+++ b/docs/workbench/integrations/dropbox.mdx
@@ -1,0 +1,164 @@
+---
+id: dropbox
+title: Dropbox
+sidebar_label: Dropbox
+sidebar_position: 14
+---
+
+# Dropbox
+
+Read and write files in Dropbox directly from Fused UDFs using OAuth-managed tokens. No API keys are hardcoded — Fused refreshes the token on your behalf. Work with the official [`dropbox`](https://pypi.org/project/dropbox/) SDK client, or read files directly with `dropbox://` paths via `fsspec` (pandas, pyarrow, etc.).
+
+:::note App Folder scope
+The Fused Dropbox app uses Dropbox's **App Folder** permission, so every path is sandboxed to a single dedicated folder in your Dropbox (it appears as `Apps/<AppName>/`). All paths below — both SDK paths like `/report.csv` and `dropbox://report.csv` URLs — are relative to that app folder root; the rest of your Dropbox is not accessible.
+:::
+
+## Setup
+
+### 1. Connect Dropbox
+
+Open **Integrations & Secrets** in Workbench, find the Dropbox section, and click **Connect Dropbox**. You will be redirected to Dropbox to authorize access, then back to Workbench. You can also connect from the CLI with `fused integrations dropbox connect`.
+
+### 2. OAuth scopes
+
+When you connect, the following scopes are requested:
+
+| Scope                 | Description                                         |
+| --------------------- | --------------------------------------------------- |
+| `files.metadata.read` | List folders and read file/folder metadata          |
+| `files.content.read`  | Download file contents                              |
+| `files.content.write` | Upload, move, and delete files                      |
+| `account_info.read`   | Read the account email shown in the integrations UI |
+
+---
+
+### `dropbox://` path format
+
+```
+dropbox://file.csv                    # a file in the app folder root
+dropbox://folder/file.parquet         # a file inside a subfolder
+```
+
+All `dropbox://` paths are relative to your Dropbox **App Folder** root — do not prefix them with `Apps/<AppName>`. The same paths work in the Workbench file explorer once connected.
+
+---
+
+## Examples
+
+### Quick start
+
+`fused.api.dropbox_connect()` returns a `FusedDropboxConnection`; call `.client()` to get an official [`dropbox.Dropbox`](https://dropbox-sdk-python.readthedocs.io/) client. The client is built with your refresh token and the app key, so the SDK refreshes access tokens itself — no app secret is exposed, and it keeps working for long-running jobs.
+
+```python
+@fused.udf
+def udf():
+    import pandas as pd
+    from dropbox.files import WriteMode
+
+    dbx = fused.api.dropbox_connect().client()
+
+    # Upload a file
+    dbx.files_upload(b"hello,world\n", "/example.csv", mode=WriteMode("overwrite"))
+
+    # Download a file
+    metadata, response = dbx.files_download("/example.csv")
+    print(response.content)
+
+    # List the app folder (root is the empty string)
+    result = dbx.files_list_folder("")
+    return pd.DataFrame([{"name": e.name} for e in result.entries])
+```
+
+The `.client()` method requires the `dropbox` package (`pip install dropbox`), which is already available in the Fused execution environment. See the [Dropbox Python SDK reference](https://dropbox-sdk-python.readthedocs.io/) for the full API (`files_*`, `sharing_*`, `users_*`, etc.).
+
+### Read a file with `dropbox://` paths
+
+Fused registers a `dropbox://` `fsspec` filesystem, so any library that accepts an `fsspec` URL can read from your Dropbox app folder directly:
+
+```python
+@fused.udf
+def udf():
+    import pandas as pd
+    return pd.read_csv("dropbox://data/measurements.csv")
+```
+
+```python
+@fused.udf
+def udf():
+    import pandas as pd
+    return pd.read_parquet("dropbox://exports/cities.parquet")
+```
+
+This filesystem is read-only — use the SDK client to write.
+
+### Common operations
+
+```python
+@fused.udf
+def udf():
+    import pandas as pd
+    from dropbox.files import WriteMode
+
+    dbx = fused.api.dropbox_connect().client()
+
+    # List a subfolder (auto-paginate)
+    entries = []
+    res = dbx.files_list_folder("/reports")
+    entries.extend(res.entries)
+    while res.has_more:
+        res = dbx.files_list_folder_continue(res.cursor)
+        entries.extend(res.entries)
+
+    # Create a folder
+    dbx.files_create_folder_v2("/reports/2026")
+
+    # Upload (overwrite if it exists)
+    dbx.files_upload(b"...bytes...", "/reports/2026/q1.csv", mode=WriteMode("overwrite"))
+
+    # Download
+    metadata, response = dbx.files_download("/reports/2026/q1.csv")
+    data = response.content
+
+    # Get a temporary, directly-downloadable link (valid ~4h)
+    link = dbx.files_get_temporary_link("/reports/2026/q1.csv").link
+
+    # Delete
+    dbx.files_delete_v2("/reports/2026/q1.csv")
+
+    return pd.DataFrame([{"name": e.name} for e in entries])
+```
+
+### Read input and write output
+
+```python
+@fused.udf
+def udf():
+    import pandas as pd
+    from dropbox.files import WriteMode
+
+    # Read an input straight from Dropbox via fsspec
+    df = pd.read_csv("dropbox://input/raw.csv")
+
+    out = df.describe().reset_index()
+
+    # Write a result back with the SDK client
+    dbx = fused.api.dropbox_connect().client()
+    dbx.files_upload(
+        out.to_csv(index=False).encode(),
+        "/output/summary.csv",
+        mode=WriteMode("overwrite"),
+    )
+    return out
+```
+
+## CLI
+
+```bash
+fused integrations dropbox connect   # print the OAuth URL (opens a browser in a tty)
+fused integrations dropbox revoke    # disconnect and remove stored tokens
+fused integrations list              # show connection status for all integrations
+```
+
+## Disconnecting
+
+To revoke the integration, go to **Integrations & Secrets**, find the Dropbox section, and click **Disconnect** (or run `fused integrations dropbox revoke`). This removes stored tokens from both the Fused server and Secrets Manager. Files already written to your Dropbox app folder are not affected.

--- a/docs/workbench/integrations/onedrive.mdx
+++ b/docs/workbench/integrations/onedrive.mdx
@@ -1,0 +1,186 @@
+---
+id: onedrive
+title: OneDrive
+sidebar_label: OneDrive
+sidebar_position: 15
+---
+
+# OneDrive
+
+Read and write files in OneDrive directly from Fused UDFs using OAuth-managed tokens. No API keys are hardcoded — Fused refreshes the token on your behalf. There is no official OneDrive Python SDK, so the connection exposes a short-lived [Microsoft Graph](https://learn.microsoft.com/en-us/graph/overview) access token plus thin REST helpers, and you can read files directly with `onedrive://` paths via `fsspec` (pandas, pyarrow, etc.).
+
+:::note Drive scope
+The Fused OneDrive app requests the `Files.ReadWrite` delegated permission, so paths address your OneDrive starting at the drive root. Both helper paths like `reports/q1.csv` and `onedrive://reports/q1.csv` URLs are relative to that root. Personal Microsoft accounts and work/school (Microsoft Entra ID) accounts are both supported.
+:::
+
+## Setup
+
+### 1. Connect OneDrive
+
+Open **Integrations & Secrets** in Workbench, find the OneDrive section, and click **Connect OneDrive**. You will be redirected to Microsoft to authorize access, then back to Workbench. You can also connect from the CLI with `fused integrations onedrive connect`.
+
+### 2. OAuth scopes
+
+When you connect, the following scopes are requested:
+
+| Scope             | Description                                                       |
+| ----------------- | ----------------------------------------------------------------- |
+| `Files.ReadWrite` | List, read, upload, and delete files and folders in your OneDrive |
+| `offline_access`  | Issue a refresh token so long-running jobs keep working           |
+| `User.Read`       | Read the account email shown in the integrations UI               |
+
+---
+
+### `onedrive://` path format
+
+```
+onedrive://file.csv                   # a file in the drive root
+onedrive://folder/file.parquet        # a file inside a subfolder
+```
+
+All `onedrive://` paths are relative to your OneDrive drive root. The same paths work in the Workbench file explorer once connected.
+
+---
+
+## Examples
+
+### Quick start
+
+`fused.api.onedrive_connect()` returns a `FusedOnedriveConnection`. Use the built-in `.list()`, `.get()`, and `.download()` helpers for common tasks, or call `.token()` for a short-lived Microsoft Graph access token to use with any Graph client. The token is minted from your Fused-managed refresh token, so it is refreshed automatically — no secrets are exposed and it keeps working for long-running jobs.
+
+```python
+@fused.udf
+def udf():
+    import pandas as pd
+
+    conn = fused.api.onedrive_connect()
+
+    # List a subfolder
+    for item in conn.list("reports"):
+        print(item["name"], item.get("size"))
+
+    # Download a file's bytes
+    data = conn.download("reports/q1.csv")
+    print(data[:100])
+
+    # List the drive root (folder defaults to "")
+    return pd.DataFrame(conn.list())
+```
+
+### Read a file with `onedrive://` paths
+
+Fused registers an `onedrive://` `fsspec` filesystem, so any library that accepts an `fsspec` URL can read from your OneDrive directly:
+
+```python
+@fused.udf
+def udf():
+    import pandas as pd
+    return pd.read_csv("onedrive://data/measurements.csv")
+```
+
+```python
+@fused.udf
+def udf():
+    import pandas as pd
+    return pd.read_parquet("onedrive://exports/cities.parquet")
+```
+
+This filesystem is read-only — use the Graph helpers below to write.
+
+### Connection API reference
+
+| Method | Description |
+| --- | --- |
+| `fused.api.onedrive_connect()` | Create a OneDrive connection backed by Fused-managed OAuth (Microsoft Graph). |
+| `.token() -> str` | Return a short-lived Microsoft Graph access token for the current user. |
+| `.list(folder="") -> list[dict]` | List the children of a folder (the drive root by default). Returns raw Graph `driveItem` dicts (`name`, `size`, `folder`/`file`, `lastModifiedDateTime`, …); pagination is handled for you. |
+| `.download(path) -> bytes` | Download a file's bytes by its OneDrive path. |
+| `.get(path, **kwargs) -> dict` | `GET` a Graph resource and return the parsed JSON. `path` may be an absolute URL or relative to the Graph v1.0 base. |
+| `.request(method, path, **kwargs)` | Make an arbitrary Microsoft Graph request and return the `requests.Response`. Pass a body with `data=` (bytes) or `json=` (dict). |
+
+```python
+@fused.udf
+def udf():
+    import requests
+
+    token = fused.api.onedrive_connect().token()
+    # use the token with any Microsoft Graph client
+    resp = requests.get(
+        "https://graph.microsoft.com/v1.0/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    return resp.json()
+```
+
+:::note Graph path addressing
+Children of a folder: `me/drive/root:/<path>:/children` (or `me/drive/root/children` at the root). Item metadata: `me/drive/root:/<path>`. File content: `me/drive/root:/<path>:/content`. See the [Microsoft Graph reference](https://learn.microsoft.com/en-us/graph/api/resources/onedrive) for the full API.
+:::
+
+### Common operations
+
+```python
+@fused.udf
+def udf():
+    import pandas as pd
+
+    conn = fused.api.onedrive_connect()
+
+    # List a subfolder (pagination is handled for you)
+    entries = conn.list("reports")
+
+    # Item metadata (size, timestamps, download URL, ...)
+    meta = conn.get("me/drive/root:/reports/q1.csv")
+
+    # Download
+    data = conn.download("reports/q1.csv")
+
+    # Upload / overwrite (simple upload; for very large files use an upload session)
+    conn.request("PUT", "me/drive/root:/reports/q1.csv:/content", data=b"...bytes...")
+
+    # Create a folder
+    conn.request(
+        "POST",
+        "me/drive/root:/reports:/children",
+        json={"name": "2026", "folder": {}, "@microsoft.graph.conflictBehavior": "fail"},
+    )
+
+    # Delete
+    conn.request("DELETE", "me/drive/root:/reports/q1.csv")
+
+    return pd.DataFrame(entries)
+```
+
+### Read input and write output
+
+```python
+@fused.udf
+def udf():
+    import pandas as pd
+
+    # Read an input straight from OneDrive via fsspec
+    df = pd.read_csv("onedrive://input/raw.csv")
+
+    out = df.describe().reset_index()
+
+    # Write a result back with the Graph helper
+    conn = fused.api.onedrive_connect()
+    conn.request(
+        "PUT",
+        "me/drive/root:/output/summary.csv:/content",
+        data=out.to_csv(index=False).encode(),
+    )
+    return out
+```
+
+## CLI
+
+```bash
+fused integrations onedrive connect   # print the OAuth URL (opens a browser in a tty)
+fused integrations onedrive token     # print a short-lived Graph access token (sensitive)
+fused integrations onedrive revoke    # disconnect and remove stored tokens
+fused integrations list               # show connection status for all integrations
+```
+
+## Disconnecting
+
+To revoke the integration, go to **Integrations & Secrets**, find the OneDrive section, and click **Disconnect** (or run `fused integrations onedrive revoke`). This removes stored tokens from both the Fused server and Secrets Manager. Files already in your OneDrive are not affected. (Microsoft has no per-app programmatic token-revoke endpoint; you can also review or remove app access from your Microsoft account security settings.)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -307,6 +307,8 @@ const sidebars: SidebarsConfig = {
         { type: "doc", id: "workbench/integrations/slack", label: "Slack [Experimental]" },
         { type: "doc", id: "workbench/integrations/notion", label: "Notion" },
         { type: "doc", id: "workbench/integrations/gdrive", label: "Google Drive" },
+        { type: "doc", id: "workbench/integrations/onedrive", label: "OneDrive" },
+        { type: "doc", id: "workbench/integrations/dropbox", label: "Dropbox" },
         { type: "doc", id: "workbench/integrations/modal", label: "Modal" },
         { type: "doc", id: "workbench/integrations/huggingface", label: "Hugging Face" },
         { type: "doc", id: "workbench/integrations/daytona", label: "Daytona" },


### PR DESCRIPTION
## Summary

Add integration documentation pages for **OneDrive** and **Dropbox** under `docs/workbench/integrations/`, modeled on the existing Google Drive page.

- `onedrive.mdx` — OAuth setup, scopes, the read-only `onedrive://` fsspec filesystem, `fused.api.onedrive_connect()` helpers (`.list/.get/.download/.token/.request`) via Microsoft Graph, UDF examples, CLI, and disconnecting.
- `dropbox.mdx` — OAuth setup (App Folder scope), the read-only `dropbox://` fsspec filesystem, the official `dropbox` SDK client via `fused.api.dropbox_connect().client()`, UDF examples, CLI, and disconnecting.
- `sidebars.ts` — register both pages in the Integrations category, right after Google Drive.

All code examples are written as Fused UDFs (no `import fused` needed, matching the runtime). Technical content sourced from the authoritative `fused-py` reference docs. Connect screenshots are intentionally omitted until images are captured.

## Verification

- `yarn build:docs` completes successfully; both pages generate at `/workbench/integrations/onedrive` and `/workbench/integrations/dropbox`.
- Verified rendering and sidebar placement in the local dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or auth logic modifications.
> 
> **Overview**
> Adds **OneDrive** and **Dropbox** Workbench integration docs, placed in the Integrations sidebar immediately after Google Drive.
> 
> The new pages document OAuth connect/revoke (Workbench and CLI), requested scopes, and read-only **`onedrive://`** / **`dropbox://`** `fsspec` usage in UDFs. **OneDrive** covers `fused.api.onedrive_connect()` (Graph token plus `.list` / `.download` / `.request` helpers). **Dropbox** covers App Folder path rules and `fused.api.dropbox_connect().client()` with the official SDK for writes. Both include UDF examples, CLI commands, and disconnect behavior—aligned with the existing Google Drive doc style, without connect screenshots yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 756810daa85f24b3d625249f2fcea5e4fd86fa87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->