### PR TITLE
docs: add automated (CI) mode to /changelog command

### DIFF
--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -2,6 +2,19 @@
 
 Generate a new changelog entry for `docs/python-sdk/changelog.mdx`.
 
+## Automated mode (CI)
+
+This command runs in two modes:
+
+- **Interactive mode** — a human runs `/changelog` with no arguments. Follow Step 1 to gather inputs, and Step 5 to open the PR.
+- **Automated mode (CI)** — invoked as `/changelog <version> <date>` (e.g. `/changelog 2.9.0 2026-06-15`) with a `release-notes.md` file present in the repo root. This is how the `changelog.yaml` workflow in `fusedlabs/application` calls it after a release.
+
+When in **Automated mode**:
+1. **Skip Step 1's prompts.** Take the version and date from the arguments, and read the merged-PR list from `release-notes.md` in the repo root (GitHub's auto-generated notes between the previous and current release tag).
+2. Apply Steps 2–4 exactly as written to produce the entry and insert it at the top of `docs/python-sdk/changelog.mdx`.
+3. For each named feature, insert a placeholder comment `{/* TODO: add screenshot/GIF */}` where the media embed goes — screenshots cannot be captured in CI and are added by a human before merge.
+4. **Skip Step 5 entirely.** Do not create a branch, commit, or open a PR — the workflow handles git and opens the PR via `peter-evans/create-pull-request`. Edit `changelog.mdx` and stop.
+
 ## Step 1 — Gather the inputs
 
 Ask the user for:
@@ -84,6 +97,8 @@ See the [{relevant docs page}]({path}) to get started.
 ```
 
 ## Step 5 — Open a PR
+
+> **Automated mode (CI):** skip this step. The `changelog.yaml` workflow opens the PR for you — just leave the edited `changelog.mdx` in the working tree.
 
 1. Create a branch named `changelog_{version_underscored}` (e.g. `changelog_2_6_0`)
 2. Commit with message: `docs: add v{VERSION} changelog entry`


### PR DESCRIPTION
## Summary

Adds an **Automated mode (CI)** path to the `/changelog` slash command so it can be invoked non-interactively from CI after a release.

In automated mode the command:
- Takes the version and date from arguments (`/changelog <version> <date>`) and reads the merged-PR list from `release-notes.md` in the repo root.
- Skips the interactive Step 1 prompts.
- Inserts `{/* TODO: add screenshot/GIF */}` placeholders for named features (screenshots can't be captured in CI).
- Skips Step 5 (git/PR creation) — the calling workflow owns git and opens the PR.

Interactive behavior for humans is unchanged.

## Context

This is the fused-docs half of the automated changelog-on-release pipeline. The companion `changelog.yaml` workflow in `fusedlabs/application` checks out fused-docs, runs `/changelog` in this mode, and opens a draft PR.

This change must land on `main` before the application workflow can use it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a slash-command guide; no runtime or product code.
> 
> **Overview**
> Extends the **`/changelog`** slash-command spec in **`.claude/commands/changelog.md`** with a **CI / automated** path alongside unchanged interactive use.
> 
> **Automated mode** is triggered as `/changelog <version> <date>` with **`release-notes.md`** at the repo root (from the **`changelog.yaml`** workflow in `fusedlabs/application`). It skips Step 1 prompts, uses args + that file for inputs, still runs Steps 2–4 into **`docs/python-sdk/changelog.mdx`**, adds **`{/* TODO: add screenshot/GIF */}`** for feature media, and **does not** run Step 5 (branch/commit/PR). Step 5 now calls out that skip for CI; the workflow opens the draft PR instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 627fab2434a0ce0fa944d060901c05aa1974db1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->