### PR TITLE
docs: add v2.8.1 changelog entry

### DIFF
--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -10,9 +10,9 @@ hide_table_of_contents: true
 
 ## v2.8.1 (2026-06-03)
 
-**Canvas comments**
+**Canvas comments (experimental)**
 
-The [Canvas](/workbench/udf-builder/canvas) now supports comments, so you can leave notes anywhere on the canvas and discuss work in context with your team.
+The [Canvas](/workbench/udf-builder/canvas) now has experimental support for comments, so you can leave notes anywhere on the canvas and discuss work in context with your team.
 
 **Dropbox and OneDrive integrations**
 
@@ -29,7 +29,7 @@ Connect Dropbox and OneDrive as data sources and read files straight into your U
 - [Canvas](/workbench/udf-builder/canvas): revamped edge toolbar with a click-anchored layout, parameters panel, and copy-as-variables
 - [Canvas](/workbench/udf-builder/canvas): Alt+ keyboard shortcuts jump straight to omnisearch actions
 - CLI: new `fused udf search` and `fused canvas validate` commands, plus an `--output-file` option on `fused run`
-- [Widgets](/guide/data-input-outputs/import-connection/widgets): experimental kepler-map JSON UI component for richer map widgets
+- [Experimental Widgets](/guide/data-input-outputs/import-connection/widgets): experimental kepler-map JSON UI component for richer map widgets
 
 **Bug fixes**
 

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -8,6 +8,37 @@ hide_table_of_contents: true
 
 # Changelog
 
+## v2.8.1 (2026-06-03)
+
+**Canvas comments**
+
+The [Canvas](/workbench/udf-builder/canvas) now supports comments, so you can leave notes anywhere on the canvas and discuss work in context with your team.
+
+**Dropbox and OneDrive integrations**
+
+Connect Dropbox and OneDrive as data sources and read files straight into your UDFs, alongside the existing cloud storage integrations.
+
+**New widget components**
+
+[Widgets](/guide/data-input-outputs/import-connection/widgets) gain a file-upload input and a PDF gallery viewer, making it easier to bring documents into a widget and browse them inline.
+
+**Improvements**
+
+- [Canvas](/workbench/udf-builder/canvas): open any node in a fullscreen view for focused editing
+- [Canvas](/workbench/udf-builder/canvas): UDF folders improved — duplicate folders, reorder nodes, and reorganize more reliably
+- [Canvas](/workbench/udf-builder/canvas): revamped edge toolbar with a click-anchored layout, parameters panel, and copy-as-variables
+- [Canvas](/workbench/udf-builder/canvas): Alt+ keyboard shortcuts jump straight to omnisearch actions
+- CLI: new `fused udf search` and `fused canvas validate` commands, plus an `--output-file` option on `fused run`
+- [Widgets](/guide/data-input-outputs/import-connection/widgets): experimental kepler-map JSON UI component for richer map widgets
+
+**Bug fixes**
+
+- Fixed: map results not showing up in some cases
+- Fixed: z-index layer order not preserved when copying, pasting, or duplicating nodes
+- Fixed: chat input Enter key sending messages mid-IME composition
+- Fixed: CSV export column order now matches the realtime usage table
+- Fixed: kernel dropdown not closing and preset search arrow-key navigation
+
 ## v2.8.0 (2026-05-19)
 
 **Canvas MCP**


### PR DESCRIPTION
Auto-generated changelog draft for **fused-py v2.8.1**.

Generated by the `/changelog` command from the auto-generated release notes in `fusedlabs/application`.

### Before merging
- [ ] Review the headline feature pick and the wording
- [ ] Add screenshots / GIFs for the named features (see the comment below)
- [ ] Confirm internal doc links resolve
- [ ] Drop any non–user-facing items that slipped through

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the changelog; no application or SDK code is modified.
> 
> **Overview**
> Adds a **v2.8.1 (2026-06-03)** section to `docs/python-sdk/changelog.mdx`, placed above the existing v2.8.0 entry.
> 
> The new block documents user-facing release notes: experimental Canvas comments, Dropbox/OneDrive integrations, widget file upload and PDF gallery, Canvas improvements (fullscreen nodes, folders, edge toolbar, Alt+ shortcuts), CLI commands (`fused udf search`, `fused canvas validate`, `fused run --output-file`), experimental kepler-map widget component, and a list of bug fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bbb4d9dfafffd150848162bf16845c9dffdaa47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->