### PR TITLE
Add non-blocking broken-link checker for docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,11 @@ repos:
         files: '\.mdx?$'
         exclude: 'docs/python-sdk/api-reference/'
         pass_filenames: true
+
+      - id: check-doc-links
+        name: Broken internal links & assets (docs)
+        language: system
+        entry: node scripts/check-doc-links.js --warn
+        files: '(^docs/.*\.mdx?$|^docusaurus\.config\.ts$|^static/)'
+        pass_filenames: false
+        verbose: true # always print the report, even though it never blocks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,11 +69,19 @@ Detailed references for common tasks are in `.claude/commands/` — readable dir
 
 ```bash
 npm run build                              # full SSG build — required before any PR
+npm run check-links                        # fast check for broken internal page/asset links
 uv run utils/test_api_reference_coverage.py   # API reference coverage gate
 uv run utils/test_doc_snippets.py          # syntax-check all Python blocks in docs
 ```
 
 Before pushing any branch touching `docs/python-sdk/` or `utils/generate_reference_docs.py`, run both the build and the coverage gate. Run `test_doc_snippets.py` after adding or editing any Python code block.
+
+## Broken links
+
+Two complementary, **non-blocking** checks surface broken links — neither fails a PR:
+
+- **Internal page & asset links** — `npm run check-links` (script: `scripts/check-doc-links.js`) resolves every internal link in `docs/` against the real Docusaurus URL space (slug/`id` rules, folder-index collapse, redirects, blog, generated `widget-api` pages, and `static/` assets) in ~1s with no network. A non-blocking pre-commit hook runs it automatically (`--warn` mode: prints the report, never blocks the commit). To use the hook, enable pre-commit once: `pip install pre-commit && pre-commit install`. Run `npm run check-links` directly for a one-off check (exits non-zero on findings).
+- **Anchors (`#fragment`) & cross-page links** — the build (`onBrokenLinks: "throw"`, `onBrokenMarkdownLinks: "throw"` in `docusaurus.config.ts`) hard-fails on broken page links, while `onBrokenAnchors: "warn"` prints broken anchors as warnings without failing. Anchors can't be checked from source (many headings are emitted by MDX components), so the build is the only accurate anchor check — scan its output for `broken anchors` warnings.
 
 ## Python code block conventions
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -6,14 +6,14 @@ const config: Config = {
   title: "Fused",
   tagline: "Code to map. Instantly.",
   favicon: "img/favicon.png",
-  
+
   // Custom fields for version management
   customFields: {
     fusedPyVersion: '1.20.1',
   },
 
   trailingSlash: undefined,
-  
+
   // Production URL configuration
   url: process.env.DEPLOYMENT_URL || "https://docs.fused.io",
   baseUrl: process.env.BASE_URL || "/",
@@ -25,6 +25,9 @@ const config: Config = {
 
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "throw",
+  // Surface broken anchors as build warnings without failing the build —
+  // they're low-severity and shouldn't block a PR.
+  onBrokenAnchors: "warn",
 
   // Mermaid diagrams
   markdown: {
@@ -89,7 +92,7 @@ const config: Config = {
         content: 'Complete documentation for Fused: the Analytics platform where AI, real-time Python execution, and data work together. Build Analytics at the speed of thought',
       },
     ],
-    
+
     tableOfContents: {
       minHeadingLevel: 2,
       maxHeadingLevel: 3,
@@ -243,18 +246,18 @@ const config: Config = {
           { to: "/examples/creating-charts", from: ["/tutorials/Analytics%20&%20Dashboard/interactive-graphs", "/tutorials/Analytics & Dashboard/interactive-graphs", "/guide/working-with-udfs/building-outputs/charts", "/examples/building-outputs/charts", "/examples/interactive-charts", "/examples/vibe-chart-building"] },
           { to: "/guide/data-input-outputs/import-connection/ai-data-connection", from: ["/tutorials/Analytics%20&%20Dashboard/let-anyone-talk-to-your-data", "/tutorials/Analytics & Dashboard/let-anyone-talk-to-your-data", "/guide/data-input-outputs/export-api/mcp-servers"] },
           { to: "/examples/creating-charts", from: ["/tutorials/Analytics%20&%20Dashboard/stack-overflow-surveys", "/tutorials/Analytics & Dashboard/stack-overflow-surveys"] },
-          
+
           // Data Science & AI tutorials
           { to: "/examples/zonal-stats", from: ["/tutorials/Data%20Science%20&%20AI/discover_data", "/tutorials/Data Science & AI/discover_data", "/examples/data-exploration"] },
           { to: "/examples/web-scraping", from: ["/tutorials/Data%20Science%20&%20AI/scraping", "/tutorials/Data Science & AI/scraping"] },
           { to: "/examples/pdf-scraping", from: ["/tutorials/Data%20Science%20&%20AI/pdf_scraping", "/tutorials/Data Science & AI/pdf_scraping"] },
           { to: "/examples/site-selection-analysis", from: ["/tutorials/Data%20Science%20&%20AI/competitor_analysis", "/tutorials/Data Science & AI/competitor_analysis", "/examples/competitor-analysis"] },
-          
+
           // Engineering & ETL tutorials
           { to: "/guide/data-input-outputs/import-connection/cloud-storage", from: ["/tutorials/Engineering%20&%20ETL/connect-your-data-to-fused", "/tutorials/Engineering & ETL/connect-your-data-to-fused"] },
           { to: "/guide/data-input-outputs/import-connection/cloud-storage", from: ["/tutorials/Engineering%20&%20ETL/handling-large-remote-files", "/tutorials/Engineering & ETL/handling-large-remote-files"] },
           { to: "/guide/data-input-outputs/export-api/tokens-endpoints", from: ["/tutorials/Engineering%20&%20ETL/turn-your-data-into-an-api", "/tutorials/Engineering & ETL/turn-your-data-into-an-api"] },
-          
+
           // Geospatial tutorials - H3
           { to: "/guide/h3-analytics/aggregations", from: ["/tutorials/Geospatial%20with%20Fused/h3-tiling", "/tutorials/Geospatial with Fused/h3-tiling"] },
           { to: "/guide/h3-analytics/aggregations", from: ["/tutorials/Geospatial%20with%20Fused/h3-tiling/when-to-use-h3", "/tutorials/Geospatial with Fused/h3-tiling/when-to-use-h3"] },
@@ -264,7 +267,7 @@ const config: Config = {
           { to: "/guide/h3-analytics/aggregations", from: ["/tutorials/Geospatial%20with%20Fused/h3-tiling/analysis-with-h3/aggregating-h3-data", "/tutorials/Geospatial with Fused/h3-tiling/analysis-with-h3/aggregating-h3-data"] },
           { to: "/guide/h3-analytics/joining", from: ["/tutorials/Geospatial%20with%20Fused/h3-tiling/analysis-with-h3/joining-h3-data", "/tutorials/Geospatial with Fused/h3-tiling/analysis-with-h3/joining-h3-data"] },
           { to: "/examples/zonal-stats", from: ["/tutorials/Geospatial%20with%20Fused/h3-tiling/analysis-with-h3/zonal-statistics", "/tutorials/Geospatial with Fused/h3-tiling/analysis-with-h3/zonal-statistics"] },
-          
+
           // Geospatial tutorials - Read/Write/Ingestion
           { to: "/guide/data-input-outputs/read-write/geospatial/geospatial-reading", from: ["/tutorials/Geospatial%20with%20Fused/read-data", "/tutorials/Geospatial with Fused/read-data"] },
           { to: "/guide/data-input-outputs/read-write/geospatial/geospatial-writing", from: ["/tutorials/Geospatial%20with%20Fused/write-data", "/tutorials/Geospatial with Fused/write-data"] },
@@ -272,24 +275,24 @@ const config: Config = {
           { to: "/guide/data-input-outputs/read-write/geospatial/ingestion", from: ["/tutorials/Geospatial%20with%20Fused/geospatial-data-ingestion/why-ingestion", "/tutorials/Geospatial with Fused/geospatial-data-ingestion/why-ingestion"] },
           { to: "/guide/data-input-outputs/read-write/geospatial/ingestion", from: ["/tutorials/Geospatial%20with%20Fused/geospatial-data-ingestion/ingest-your-data", "/tutorials/Geospatial with Fused/geospatial-data-ingestion/ingest-your-data"] },
           { to: "/guide/data-input-outputs/read-write/geospatial/ingestion", from: ["/tutorials/Geospatial%20with%20Fused/geospatial-data-ingestion/geospatial-file-formats", "/tutorials/Geospatial with Fused/geospatial-data-ingestion/geospatial-file-formats"] },
-          
+
           // Geospatial tutorials - Other
           { to: "/guide/working-with-udfs/udf-best-practices/geospatial-single-vs-tile", from: ["/tutorials/Geospatial%20with%20Fused/filetile", "/tutorials/Geospatial with Fused/filetile", "/guide/working-with-udfs/geospatial/single-vs-tile"] },
           { to: "/guide/data-input-outputs/export-api/geospatial-export", from: ["/tutorials/Geospatial%20with%20Fused/other-integrations", "/tutorials/Geospatial with Fused/other-integrations"] },
           { to: "/guide/data-input-outputs/import-connection/geospatial/gee", from: ["/tutorials/Geospatial%20with%20Fused/gee_bigquery", "/tutorials/Geospatial with Fused/gee_bigquery"] },
           { to: "/examples/canvas-gallery", from: ["/tutorials/Geospatial%20with%20Fused/canvas-catalog", "/tutorials/Geospatial with Fused/canvas-catalog", "/examples/canvas-examples"] },
-          
+
           // Geospatial use cases
           { to: "/examples/ais-dark-vessels", from: ["/tutorials/Geospatial%20with%20Fused/use-cases/dark-vessel-detection", "/tutorials/Geospatial with Fused/use-cases/dark-vessel-detection", "/examples/dark-vessel-detection"] },
           { to: "/examples/climate-dashboard", from: ["/tutorials/Geospatial%20with%20Fused/use-cases/Climate%20Dashboard", "/tutorials/Geospatial with Fused/use-cases/Climate Dashboard"] },
           { to: "/examples/maxar-satellite-imagery", from: ["/tutorials/Geospatial%20with%20Fused/use-cases/exploring_maxar_data", "/tutorials/Geospatial with Fused/use-cases/exploring_maxar_data", "/examples/satellite-imagery"] },
           { to: "/examples/zonal-stats", from: ["/tutorials/Geospatial%20with%20Fused/use-cases/zonal-stats", "/tutorials/Geospatial with Fused/use-cases/zonal-stats"] },
           { to: "/examples/creating-charts", from: ["/tutorials/Geospatial%20with%20Fused/use-cases/vibe-coded-timeseries", "/tutorials/Geospatial with Fused/use-cases/vibe-coded-timeseries"] },
-          
+
           // 2min with Fused / Quickstart
           { to: "/guide/getting-started/first-udf-basics", from: ["/tutorials/2min-with-fused", "/quickstart"] },
           { to: "/guide/getting-started/first-udf-basics", from: ["/tutorials/load-and-export-data", "/tutorials/load_and_save_data"] },
-          
+
           // Core concepts redirects
           { to: "/guide/working-with-udfs/udf-best-practices/realtime", from: ["/core-concepts/run-udfs/run-small-udfs", "/core-concepts/run-udfs", "/core-concepts/async", "/guide/working-with-udfs/execution/realtime", "/guide/getting-started/udf-best-practices/realtime"] },
           { to: "/guide/working-with-udfs/udf-best-practices/scaling-out", from: ["/core-concepts/run-udfs/run_large", "/core-concepts/run-udfs/run-large", "/guide/working-with-udfs/execution/batch-jobs", "/guide/getting-started/udf-best-practices/batch-jobs", "/guide/working-with-udfs/udf-best-practices/batch-jobs", "/guide/working-with-udfs/execution/parallel", "/guide/getting-started/udf-best-practices/parallel", "/guide/working-with-udfs/udf-best-practices/parallel"] },
@@ -300,18 +303,18 @@ const config: Config = {
           { to: "/guide/advanced-setup/dependencies", from: ["/core-concepts/run-udfs/dependencies"] },
           { to: "/guide/getting-started/workbench-intro", from: ["/core-concepts/best-practices/workbench-best-practices"] },
           { to: "/guide/getting-started/first-udf-basics", from: ["/core-concepts/why"] },
-          
+
           // Old workbench paths
           { to: "/workbench/udf-explorer", from: ["/workbench/udf-catalog"] },
           { to: "/workbench/udf-builder/code-editor", from: ["/workbench/udf-editor"] },
-          
+
           // Jan 2026 docs migration redirects
           { to: "/guide/working-with-udfs/run-udfs-as-api", from: ["/guide/data-input-outputs/export-api/dynamic-file-api", "/guide/working-with-udfs/calling-udfs-as-api"] },
           { to: "/guide/working-with-udfs/fused-run", from: ["/guide/working-with-udfs/run-udfs-in-python"] },
           { to: "/guide/working-with-udfs/fused-submit", from: ["/guide/working-with-udfs/run-udfs-in-parallel"] },
           { to: "/examples/sharing-canvas-dashboards", from: ["/guide/working-with-udfs/building-outputs/dashboards", "/examples/building-outputs/dashboards"] },
           { to: "/guide/working-with-udfs/udf-best-practices/geospatial-single-vs-tile", from: ["/guide/working-with-udfs/udf-best-practices/geospatial/single-vs-tile"] },
-          
+
           // API Reference flattening redirects
           { to: "/python-sdk/overview", from: ["/python-sdk/top-level-functions"] },
           { to: "/guide/advanced-setup/local-installation", from: ["/python-sdk/index", "/python-sdk/authentication"] },
@@ -346,7 +349,7 @@ const config: Config = {
         },
       ],
     ] : []),
-    
+
 
   ],
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "generate-llms-python-sdk": "node scripts/generate-llms-txt.js --python-sdk",
     "validate-llms": "node scripts/validate-llms-links.js",
     "test-llms-http": "node scripts/test-llms-links-http.js",
+    "check-links": "node scripts/check-doc-links.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/scripts/check-doc-links.js
+++ b/scripts/check-doc-links.js
@@ -91,6 +91,23 @@ function registerWidgetApi() {
   }
 }
 
+// _category_.json files with `link.type: "generated-index"` create a route at
+// the category's folder URL (or link.slug) that isn't backed by a doc file.
+function registerCategoryIndexes() {
+  for (const file of walk(DOCS_DIR, ['_category_.json'])) {
+    let cfg;
+    try {
+      cfg = JSON.parse(fs.readFileSync(file, 'utf8'));
+    } catch {
+      continue;
+    }
+    if (cfg.link?.type !== 'generated-index') continue;
+    const dir = path.relative(DOCS_DIR, path.dirname(file)).replace(/\\/g, '/');
+    const url = typeof cfg.link.slug === 'string' ? cfg.link.slug : '/' + dir;
+    validPaths.add(normalize(url));
+  }
+}
+
 function registerRedirects() {
   const config = fs.readFileSync(CONFIG_FILE, 'utf8');
   for (const m of config.matchAll(/from:\s*(\[[^\]]*\]|["'][^"']*["'])/g)) {
@@ -128,6 +145,7 @@ function main() {
   registerDocs();
   registerBlog();
   registerWidgetApi();
+  registerCategoryIndexes();
   registerRedirects();
 
   const broken = [];

--- a/scripts/check-doc-links.js
+++ b/scripts/check-doc-links.js
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// Fast, network-free check for broken internal page links and missing image/
+// asset references across docs/ — meant as a pre-commit gate and a quick local
+// command (`npm run check-links`).
+//
+// Why only page + asset links (not anchors or external URLs)?
+//   - Broken #anchors and broken page links are already caught authoritatively
+//     by `npm run build` (onBrokenLinks / onBrokenAnchors: "throw"), which
+//     resolves against the fully-rendered site. Anchors in particular can't be
+//     checked from source — many headings are emitted by MDX components.
+//   - This script trades that completeness for speed: it resolves every internal
+//     link against the real Docusaurus URL space (slug/id rules, folder-index
+//     collapse, redirects, blog, the generated widget-api pages, static assets)
+//     in well under a second, so it can run on every commit. The build remains
+//     the comprehensive gate.
+
+const fs = require('fs');
+const path = require('path');
+const matter = require('gray-matter');
+
+const ROOT = path.resolve(__dirname, '..');
+const DOCS_DIR = path.join(ROOT, 'docs');
+const BLOG_DIR = path.join(ROOT, 'blog');
+const STATIC_DIR = path.join(ROOT, 'static');
+const WIDGET_SCHEMA_DIR = path.join(STATIC_DIR, 'widget-schema');
+const CONFIG_FILE = path.join(ROOT, 'docusaurus.config.ts');
+
+// Routes that exist but aren't backed by a doc/blog/static file.
+const EXTRA_VALID_PATHS = ['/', '/search', '/blog'];
+
+function walk(dir, exts) {
+  const out = [];
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full, exts));
+    else if (exts.some((e) => entry.name.endsWith(e))) out.push(full);
+  }
+  return out;
+}
+
+function normalize(p) {
+  let s = decodeURIComponent(p);
+  if (s.length > 1) s = s.replace(/\/+$/, '');
+  return s;
+}
+
+// Derive a doc's Docusaurus URL from its path + frontmatter:
+//   - an absolute frontmatter `slug` wins outright
+//   - a frontmatter `id` replaces the filename as the last segment
+//   - index files, and a file named after its folder, map to the folder URL
+function fileToUrl(relPath, data) {
+  if (typeof data.slug === 'string' && data.slug.startsWith('/')) return data.slug;
+  const parts = relPath.replace(/\\/g, '/').split('/');
+  const file = parts.pop().replace(/\.mdx?$/, '');
+  const last = typeof data.id === 'string' ? data.id : file;
+  if (last.toLowerCase() !== 'index' && last !== parts[parts.length - 1]) parts.push(last);
+  return '/' + parts.join('/');
+}
+
+const validPaths = new Set(EXTRA_VALID_PATHS.map(normalize));
+
+function registerDocs() {
+  for (const file of walk(DOCS_DIR, ['.md', '.mdx'])) {
+    if (path.basename(file).startsWith('_')) continue; // partials
+    const { data } = matter(fs.readFileSync(file, 'utf8'));
+    if (data.draft === true) continue; // not built in production
+    validPaths.add(normalize(fileToUrl(path.relative(DOCS_DIR, file), data)));
+  }
+}
+
+function registerBlog() {
+  for (const file of walk(BLOG_DIR, ['.md', '.mdx'])) {
+    if (path.basename(file).startsWith('_')) continue;
+    const { data } = matter(fs.readFileSync(file, 'utf8'));
+    if (data.draft === true) continue;
+    let slug = typeof data.slug === 'string'
+      ? data.slug
+      : path.basename(file).replace(/\.mdx?$/, '').replace(/^\d{4}-\d{2}-\d{2}-/, '');
+    if (!slug.startsWith('/')) slug = '/blog/' + slug.replace(/^\//, '');
+    validPaths.add(normalize(slug));
+  }
+}
+
+// docusaurus-plugin-widget-api generates docs/widget-api/<slug>.mdx from these
+// schema files at build time — valid routes, but not committed source files.
+function registerWidgetApi() {
+  if (!fs.existsSync(WIDGET_SCHEMA_DIR)) return;
+  for (const f of fs.readdirSync(WIDGET_SCHEMA_DIR)) {
+    if (f.endsWith('.json')) validPaths.add('/widget-api/' + f.replace(/\.json$/, ''));
+  }
+}
+
+function registerRedirects() {
+  const config = fs.readFileSync(CONFIG_FILE, 'utf8');
+  for (const m of config.matchAll(/from:\s*(\[[^\]]*\]|["'][^"']*["'])/g)) {
+    const froms = m[1].startsWith('[')
+      ? [...m[1].matchAll(/["']([^"']+)["']/g)].map((x) => x[1])
+      : [m[1].slice(1, -1)];
+    for (const f of froms) validPaths.add(normalize(f));
+  }
+}
+
+function staticAssetExists(urlPath) {
+  return fs.existsSync(path.join(STATIC_DIR, decodeURIComponent(urlPath.replace(/^\//, ''))));
+}
+
+function isAsset(p) {
+  return /\.[a-z0-9]{2,5}$/i.test(p);
+}
+
+// Internal markdown and JSX links, with code fences stripped and templated
+// (${...} / {...}) targets ignored.
+function extractLinks(file) {
+  const { content } = matter(fs.readFileSync(file, 'utf8'));
+  const body = content
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/~~~[\s\S]*?~~~/g, '')
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, '') // JSX comments
+    .replace(/<!--[\s\S]*?-->/g, ''); // HTML comments
+  const links = [];
+  for (const m of body.matchAll(/\]\((\/[^)\s]*)\)/g)) links.push(m[1]);
+  for (const m of body.matchAll(/\b(?:to|href)=["'](\/[^"']*)["']/g)) links.push(m[1]);
+  return links.filter((l) => !l.includes('${') && !l.includes('{'));
+}
+
+function main() {
+  registerDocs();
+  registerBlog();
+  registerWidgetApi();
+  registerRedirects();
+
+  const broken = [];
+  let checked = 0;
+
+  for (const file of walk(DOCS_DIR, ['.md', '.mdx'])) {
+    if (path.basename(file).startsWith('_')) continue;
+    const rel = path.relative(ROOT, file).replace(/\\/g, '/');
+    for (const link of extractLinks(file)) {
+      checked++;
+      const targetPath = link.split('#')[0]; // anchors are checked by the build
+      if (targetPath === '') continue; // pure same-page anchor
+      if (validPaths.has(normalize(targetPath))) continue;
+      if (staticAssetExists(targetPath)) continue;
+      broken.push({
+        file: rel,
+        link,
+        reason: isAsset(targetPath) ? 'missing static asset' : 'no such page',
+      });
+    }
+  }
+
+  console.log(`Checked ${checked} internal links across ${validPaths.size} routes.\n`);
+
+  if (broken.length === 0) {
+    console.log('All internal page and asset links resolve.');
+    return;
+  }
+
+  const byFile = new Map();
+  for (const b of broken) {
+    if (!byFile.has(b.file)) byFile.set(b.file, []);
+    byFile.get(b.file).push(b);
+  }
+  // --warn surfaces findings without failing (for the non-blocking pre-commit
+  // hook); without it the command exits non-zero so it can gate when wanted.
+  const warnOnly = process.argv.includes('--warn');
+  const log = warnOnly ? console.warn : console.error;
+  log(`Found ${broken.length} broken link(s):\n`);
+  for (const [f, items] of [...byFile].sort()) {
+    log(f);
+    for (const it of items) log(`  ${it.link}  (${it.reason})`);
+    log('');
+  }
+  if (warnOnly) {
+    console.warn('Not blocking the commit — please fix these when you can.');
+  } else {
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/scripts/check-doc-links.js
+++ b/scripts/check-doc-links.js
@@ -1,200 +1,137 @@
 #!/usr/bin/env node
-// Fast, network-free check for broken internal page links and missing image/
-// asset references across docs/ — meant as a pre-commit gate and a quick local
-// command (`npm run check-links`).
+// Flags broken internal page/asset links in docs/ against Docusaurus's URL space
+// (slug/id rules, folder-index collapse, redirects, blog, widget-api pages,
+// static assets). Fast and network-free.
 //
-// Why only page + asset links (not anchors or external URLs)?
-//   - Broken #anchors and broken page links are already caught authoritatively
-//     by `npm run build` (onBrokenLinks / onBrokenAnchors: "throw"), which
-//     resolves against the fully-rendered site. Anchors in particular can't be
-//     checked from source — many headings are emitted by MDX components.
-//   - This script trades that completeness for speed: it resolves every internal
-//     link against the real Docusaurus URL space (slug/id rules, folder-index
-//     collapse, redirects, blog, the generated widget-api pages, static assets)
-//     in well under a second, so it can run on every commit. The build remains
-//     the comprehensive gate.
+// Run as `npm run check-links` (exits non-zero on findings) or as a non-blocking
+// pre-commit hook with `--warn` (prints findings, always exits 0). Anchors and
+// external links are left to the build (onBrokenLinks / onBrokenAnchors).
 
 const fs = require('fs');
 const path = require('path');
 const matter = require('gray-matter');
 
 const ROOT = path.resolve(__dirname, '..');
-const DOCS_DIR = path.join(ROOT, 'docs');
-const BLOG_DIR = path.join(ROOT, 'blog');
-const STATIC_DIR = path.join(ROOT, 'static');
-const WIDGET_SCHEMA_DIR = path.join(STATIC_DIR, 'widget-schema');
-const CONFIG_FILE = path.join(ROOT, 'docusaurus.config.ts');
+const DOCS = path.join(ROOT, 'docs');
+const STATIC = path.join(ROOT, 'static');
+const WARN = process.argv.includes('--warn');
 
-// Routes that exist but aren't backed by a doc/blog/static file.
-const EXTRA_VALID_PATHS = ['/', '/search', '/blog'];
+const decode = (s) => { try { return decodeURIComponent(s); } catch { return s; } };
+const norm = (p) => { const s = decode(p); return s.length > 1 ? s.replace(/\/+$/, '') : s; };
+const data = (file) => matter(fs.readFileSync(file, 'utf8')).data;
 
-function walk(dir, exts) {
-  const out = [];
-  if (!fs.existsSync(dir)) return out;
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) out.push(...walk(full, exts));
-    else if (exts.some((e) => entry.name.endsWith(e))) out.push(full);
-  }
-  return out;
+// Recursively collect files under `dir` whose basename satisfies `match`.
+function find(dir, match) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const full = path.join(dir, e.name);
+    return e.isDirectory() ? find(full, match) : match(e.name) ? [full] : [];
+  });
 }
 
-function normalize(p) {
-  let s = decodeURIComponent(p);
-  if (s.length > 1) s = s.replace(/\/+$/, '');
-  return s;
-}
+const isPage = (n) => /\.mdx?$/.test(n) && !n.startsWith('_');
 
-// Derive a doc's Docusaurus URL from its path + frontmatter:
-//   - an absolute frontmatter `slug` wins outright
-//   - a frontmatter `id` replaces the filename as the last segment
-//   - index files, and a file named after its folder, map to the folder URL
-function fileToUrl(relPath, data) {
-  if (typeof data.slug === 'string' && data.slug.startsWith('/')) return data.slug;
-  const parts = relPath.replace(/\\/g, '/').split('/');
-  const file = parts.pop().replace(/\.mdx?$/, '');
-  const last = typeof data.id === 'string' ? data.id : file;
+// A doc's URL: absolute `slug` wins; else folder path + (`id` or filename), with
+// index files and a file named after its folder collapsing to the folder URL.
+function docUrl(rel, fm) {
+  if (typeof fm.slug === 'string' && fm.slug.startsWith('/')) return fm.slug;
+  const parts = rel.replace(/\\/g, '/').split('/');
+  const filename = parts.pop().replace(/\.mdx?$/, '');
+  const last = typeof fm.id === 'string' ? fm.id : filename;
   if (last.toLowerCase() !== 'index' && last !== parts[parts.length - 1]) parts.push(last);
   return '/' + parts.join('/');
 }
 
-const validPaths = new Set(EXTRA_VALID_PATHS.map(normalize));
+// Build the set of valid routes.
+function buildRoutes() {
+  const routes = new Set(['/', '/search', '/blog'].map(norm));
 
-function registerDocs() {
-  for (const file of walk(DOCS_DIR, ['.md', '.mdx'])) {
-    if (path.basename(file).startsWith('_')) continue; // partials
-    const { data } = matter(fs.readFileSync(file, 'utf8'));
-    if (data.draft === true) continue; // not built in production
-    validPaths.add(normalize(fileToUrl(path.relative(DOCS_DIR, file), data)));
+  for (const file of find(DOCS, isPage)) {
+    const fm = data(file);
+    if (fm.draft !== true) routes.add(norm(docUrl(path.relative(DOCS, file), fm)));
   }
-}
 
-function registerBlog() {
-  for (const file of walk(BLOG_DIR, ['.md', '.mdx'])) {
-    if (path.basename(file).startsWith('_')) continue;
-    const { data } = matter(fs.readFileSync(file, 'utf8'));
-    if (data.draft === true) continue;
-    let slug = typeof data.slug === 'string'
-      ? data.slug
+  for (const file of find(path.join(ROOT, 'blog'), isPage)) {
+    const fm = data(file);
+    if (fm.draft === true) continue;
+    let slug = typeof fm.slug === 'string'
+      ? fm.slug
       : path.basename(file).replace(/\.mdx?$/, '').replace(/^\d{4}-\d{2}-\d{2}-/, '');
-    if (!slug.startsWith('/')) slug = '/blog/' + slug.replace(/^\//, '');
-    validPaths.add(normalize(slug));
+    routes.add(norm(slug.startsWith('/') ? slug : '/blog/' + slug));
   }
-}
 
-// docusaurus-plugin-widget-api generates docs/widget-api/<slug>.mdx from these
-// schema files at build time — valid routes, but not committed source files.
-function registerWidgetApi() {
-  if (!fs.existsSync(WIDGET_SCHEMA_DIR)) return;
-  for (const f of fs.readdirSync(WIDGET_SCHEMA_DIR)) {
-    if (f.endsWith('.json')) validPaths.add('/widget-api/' + f.replace(/\.json$/, ''));
-  }
-}
+  // widget-api pages are generated from these schemas at build time.
+  for (const file of find(path.join(STATIC, 'widget-schema'), (n) => n.endsWith('.json')))
+    routes.add('/widget-api/' + path.basename(file, '.json'));
 
-// _category_.json files with `link.type: "generated-index"` create a route at
-// the category's folder URL (or link.slug) that isn't backed by a doc file.
-function registerCategoryIndexes() {
-  for (const file of walk(DOCS_DIR, ['_category_.json'])) {
+  // generated-index categories serve a route at their folder URL (or link.slug).
+  for (const file of find(DOCS, (n) => n === '_category_.json')) {
     let cfg;
-    try {
-      cfg = JSON.parse(fs.readFileSync(file, 'utf8'));
-    } catch {
-      continue;
+    try { cfg = JSON.parse(fs.readFileSync(file, 'utf8')); } catch { continue; }
+    if (cfg.link && cfg.link.type === 'generated-index') {
+      const dir = path.relative(DOCS, path.dirname(file)).replace(/\\/g, '/');
+      routes.add(norm(typeof cfg.link.slug === 'string' ? cfg.link.slug : '/' + dir));
     }
-    if (cfg.link?.type !== 'generated-index') continue;
-    const dir = path.relative(DOCS_DIR, path.dirname(file)).replace(/\\/g, '/');
-    const url = typeof cfg.link.slug === 'string' ? cfg.link.slug : '/' + dir;
-    validPaths.add(normalize(url));
   }
+
+  // redirect `from` paths are valid routes too.
+  const config = fs.readFileSync(path.join(ROOT, 'docusaurus.config.ts'), 'utf8');
+  for (const m of config.matchAll(/from:\s*(\[[^\]]*\]|["'][^"']*["'])/g))
+    for (const q of m[1].match(/["']([^"']+)["']/g) || []) routes.add(norm(q.slice(1, -1)));
+
+  return routes;
 }
 
-function registerRedirects() {
-  const config = fs.readFileSync(CONFIG_FILE, 'utf8');
-  for (const m of config.matchAll(/from:\s*(\[[^\]]*\]|["'][^"']*["'])/g)) {
-    const froms = m[1].startsWith('[')
-      ? [...m[1].matchAll(/["']([^"']+)["']/g)].map((x) => x[1])
-      : [m[1].slice(1, -1)];
-    for (const f of froms) validPaths.add(normalize(f));
-  }
+const assetExists = (p) => fs.existsSync(path.join(STATIC, decode(p).replace(/^\//, '')));
+
+// Internal markdown and JSX (href/to/src) links, ignoring code, comments, and
+// templated targets.
+function linksIn(file) {
+  const body = matter(fs.readFileSync(file, 'utf8')).content
+    .replace(/```[\s\S]*?```|~~~[\s\S]*?~~~/g, '') // fenced code
+    .replace(/`[^`\n]*`/g, '') // inline code
+    .replace(/\{\/\*[\s\S]*?\*\/\}|<!--[\s\S]*?-->/g, ''); // comments
+  const out = [];
+  for (const m of body.matchAll(/\]\((\/[^)\s]*)\)/g)) out.push(m[1]);
+  for (const m of body.matchAll(/\b(?:to|href|src)=["'](\/[^"']*)["']/g)) out.push(m[1]);
+  return out.filter((l) => !l.includes('{'));
 }
 
-function staticAssetExists(urlPath) {
-  return fs.existsSync(path.join(STATIC_DIR, decodeURIComponent(urlPath.replace(/^\//, ''))));
-}
-
-function isAsset(p) {
-  return /\.[a-z0-9]{2,5}$/i.test(p);
-}
-
-// Internal markdown and JSX links, with code fences stripped and templated
-// (${...} / {...}) targets ignored.
-function extractLinks(file) {
-  const { content } = matter(fs.readFileSync(file, 'utf8'));
-  const body = content
-    .replace(/```[\s\S]*?```/g, '')
-    .replace(/~~~[\s\S]*?~~~/g, '')
-    .replace(/\{\/\*[\s\S]*?\*\/\}/g, '') // JSX comments
-    .replace(/<!--[\s\S]*?-->/g, ''); // HTML comments
-  const links = [];
-  for (const m of body.matchAll(/\]\((\/[^)\s]*)\)/g)) links.push(m[1]);
-  for (const m of body.matchAll(/\b(?:to|href|src)=["'](\/[^"']*)["']/g)) links.push(m[1]);
-  return links.filter((l) => !l.includes('${') && !l.includes('{'));
-}
-
-function main() {
-  registerDocs();
-  registerBlog();
-  registerWidgetApi();
-  registerCategoryIndexes();
-  registerRedirects();
-
+function run() {
+  const routes = buildRoutes();
   const broken = [];
-  let checked = 0;
 
-  for (const file of walk(DOCS_DIR, ['.md', '.mdx'])) {
-    if (path.basename(file).startsWith('_')) continue;
+  for (const file of find(DOCS, isPage)) {
     const rel = path.relative(ROOT, file).replace(/\\/g, '/');
-    for (const link of extractLinks(file)) {
-      checked++;
-      const targetPath = link.split('#')[0]; // anchors are checked by the build
-      if (targetPath === '') continue; // pure same-page anchor
-      if (validPaths.has(normalize(targetPath))) continue;
-      if (staticAssetExists(targetPath)) continue;
-      broken.push({
-        file: rel,
-        link,
-        reason: isAsset(targetPath) ? 'missing static asset' : 'no such page',
-      });
+    for (const link of linksIn(file)) {
+      const target = link.split('#')[0]; // anchors are validated by the build
+      if (!target || routes.has(norm(target)) || assetExists(target)) continue;
+      const reason = /\.[a-z0-9]{2,5}$/i.test(target) ? 'missing static asset' : 'no such page';
+      broken.push({ rel, link, reason });
     }
   }
 
-  console.log(`Checked ${checked} internal links across ${validPaths.size} routes.\n`);
-
+  console.log(`Checked internal links across ${routes.size} routes.\n`);
   if (broken.length === 0) {
     console.log('All internal page and asset links resolve.');
     return;
   }
 
-  const byFile = new Map();
-  for (const b of broken) {
-    if (!byFile.has(b.file)) byFile.set(b.file, []);
-    byFile.get(b.file).push(b);
+  const log = WARN ? console.warn : console.error;
+  log(`Found ${broken.length} broken link(s):`);
+  let current = '';
+  for (const b of broken.sort((a, b) => a.rel.localeCompare(b.rel))) {
+    if (b.rel !== current) log(`\n${(current = b.rel)}`);
+    log(`  ${b.link}  (${b.reason})`);
   }
-  // --warn surfaces findings without failing (for the non-blocking pre-commit
-  // hook); without it the command exits non-zero so it can gate when wanted.
-  const warnOnly = process.argv.includes('--warn');
-  const log = warnOnly ? console.warn : console.error;
-  log(`Found ${broken.length} broken link(s):\n`);
-  for (const [f, items] of [...byFile].sort()) {
-    log(f);
-    for (const it of items) log(`  ${it.link}  (${it.reason})`);
-    log('');
-  }
-  if (warnOnly) {
-    console.warn('Not blocking the commit — please fix these when you can.');
-  } else {
-    process.exitCode = 1;
-  }
+  if (WARN) console.warn('\nNot blocking the commit — please fix these when you can.');
+  else process.exitCode = 1;
 }
 
-main();
+// Never let an unexpected error block a commit when running as the --warn hook.
+try {
+  run();
+} catch (err) {
+  console.warn(`check-doc-links skipped (error: ${err.message})`);
+  if (!WARN) process.exitCode = 1;
+}

--- a/scripts/check-doc-links.js
+++ b/scripts/check-doc-links.js
@@ -120,7 +120,7 @@ function extractLinks(file) {
     .replace(/<!--[\s\S]*?-->/g, ''); // HTML comments
   const links = [];
   for (const m of body.matchAll(/\]\((\/[^)\s]*)\)/g)) links.push(m[1]);
-  for (const m of body.matchAll(/\b(?:to|href)=["'](\/[^"']*)["']/g)) links.push(m[1]);
+  for (const m of body.matchAll(/\b(?:to|href|src)=["'](\/[^"']*)["']/g)) links.push(m[1]);
   return links.filter((l) => !l.includes('${') && !l.includes('{'));
 }
 


### PR DESCRIPTION
## What

Adds a fast, **non-blocking** way to surface broken links in the docs locally — the goal is to *tell* the author about broken links, not to block them.

## Why

The Docusaurus build already hard-fails on broken internal **page** links (`onBrokenLinks: "throw"`), but that only runs in CI and takes minutes. There was no quick local signal, and broken **anchors** weren't surfaced at all (`onBrokenAnchors` was unset → defaulted to silent).

## Changes

- **`scripts/check-doc-links.js`** — fast (~1s), network-free checker. Resolves every internal page/asset link in `docs/` against the real Docusaurus URL space: slug/`id` rules, folder-index collapse, redirects, blog, the generated `widget-api` pages, and `static/` assets. Validated to **zero false positives** against a full production build.
- **`npm run check-links`** — one-off manual run (exits non-zero on findings, so it *can* gate if ever wanted).
- **Non-blocking pre-commit hook** (`check-doc-links --warn`, `verbose: true`) — prints the report on every commit but **never blocks** it. Enable once with `pip install pre-commit && pre-commit install`.
- **`onBrokenAnchors: "warn"`** in `docusaurus.config.ts` — the build now prints broken anchors as warnings without failing. (Anchors can't be resolved from source since many headings are emitted by MDX components, so the build is the only accurate anchor check.)
- **`CLAUDE.md`** — new "Broken links" section documenting both checks.

## Behavior

On commit with a broken link present:

```
Broken internal links & assets (docs)....................................Passed
Found 2 broken link(s):
docs/examples/foo.mdx
  /guide/this-page-does-not-exist  (no such page)
  /img/does-not-exist.png  (missing static asset)
Not blocking the commit — please fix these when you can.
```

The commit still goes through. No CI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs tooling and non-blocking hooks only; production link enforcement via `onBrokenLinks: "throw"` is unchanged.
> 
> **Overview**
> Adds a **fast local check** for broken internal doc links and static assets, wired into developer workflow without blocking commits or PRs.
> 
> **`scripts/check-doc-links.js`** builds Docusaurus’s URL space (docs slug/`id`, blog, redirects from config, generated `widget-api` routes, `static/` files) and scans MDX/MD for internal `href`/`to`/`src` and markdown links. **`npm run check-links`** runs it and exits non-zero on findings. A **local pre-commit hook** runs the same script with **`--warn`** so the report always prints but commits never fail.
> 
> **`onBrokenAnchors: "warn"`** in `docusaurus.config.ts` surfaces broken hash anchors at build time without failing the build (page links still throw). **`CLAUDE.md`** documents the two-tier link strategy (script vs build).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc7152e557a97b1645ba9c4dbbd0e984ddb06218. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->