### PR TITLE
feat: add Beehiiv newsletter embed to ShortsFooter

### DIFF
--- a/src/components/ShortsFooter/index.tsx
+++ b/src/components/ShortsFooter/index.tsx
@@ -1,9 +1,27 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import styles from "./styles.module.css";
 
-// Set to true to show sections when ready
-const SHOW_NEWSLETTER = false;
+const BEEHIIV_FORM_ID = "4d460bb7-ac79-4cef-a7ee-c014bc5f62eb";
+
+const SHOW_NEWSLETTER = true;
 const SHOW_CONNECT_AGENT = false;
+
+function BeehiivForm(): JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const script = document.createElement("script");
+    script.src = "https://subscribe-forms.beehiiv.com/v3/loader.js";
+    script.async = true;
+    script.setAttribute("data-beehiiv-form", BEEHIIV_FORM_ID);
+    container.appendChild(script);
+    return () => { container.innerHTML = ""; };
+  }, []);
+
+  return <div ref={containerRef} className={styles.beehiivEmbed} />;
+}
 
 export default function ShortsFooter(): JSX.Element {
   return (
@@ -14,12 +32,9 @@ export default function ShortsFooter(): JSX.Element {
         <div className={styles.subscribeSection}>
           <h3 className={styles.subscribeHeading}>Get new shorts in your inbox</h3>
           <p className={styles.subscribeSubtext}>
-            Short dispatches from Fused as we build toward zero-code data workflows.
+            Short posts on building Fused without writing a single line of code.
           </p>
-          {/* BEEHIIV_EMBED_HERE */}
-          <div className={styles.embedPlaceholder}>
-            Newsletter embed — paste Beehiiv code here
-          </div>
+          <BeehiivForm />
         </div>
       )}
 

--- a/src/components/ShortsFooter/styles.module.css
+++ b/src/components/ShortsFooter/styles.module.css
@@ -23,12 +23,9 @@
   font-size: 0.95rem;
 }
 
-.embedPlaceholder {
-  border: 1px dashed var(--ifm-toc-border-color);
-  border-radius: 6px;
-  padding: 1rem 1.5rem;
-  color: var(--ifm-color-secondary-darkest);
-  font-size: 0.875rem;
+.beehiivEmbed {
+  display: flex;
+  justify-content: center;
 }
 
 .connectSection {

--- a/src/theme/BlogListPage/index.tsx
+++ b/src/theme/BlogListPage/index.tsx
@@ -130,20 +130,17 @@ function ShortsListPage(props: Props): JSX.Element {
             );
           })}
         </ul>
+        <BlogListPaginator metadata={metadata} />
       </div>
     </BlogLayout>
   );
 }
 
-export default function BlogListPage(props: Props): JSX.Element {
+function MainBlogListPage(props: Props): JSX.Element {
   const { metadata, items } = props;
   const {
     siteConfig: { title: siteTitle },
   } = useDocusaurusContext();
-
-  if (metadata.permalink.startsWith('/shorts')) {
-    return <ShortsListPage {...props} />;
-  }
 
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<CategoryKey>('all');
@@ -231,4 +228,11 @@ export default function BlogListPage(props: Props): JSX.Element {
       </BlogLayout>
     </>
   );
+}
+
+export default function BlogListPage(props: Props): JSX.Element {
+  if (props.metadata.permalink.startsWith('/shorts')) {
+    return <ShortsListPage {...props} />;
+  }
+  return <MainBlogListPage {...props} />;
 }


### PR DESCRIPTION
## Summary

- Wires up Beehiiv inline subscribe form in `ShortsFooter` using a `useEffect`-based script loader
- Enables newsletter section (`SHOW_NEWSLETTER = true`) — visible on all shorts posts
- Centers the form and removes the old placeholder div

## Test plan

- [ ] Visit `/shorts/zero-coding-001` and `/shorts/zero-coding-002` — Beehiiv form renders inline under "Get new shorts in your inbox"
- [ ] Form is centered
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Third-party script on marketing shorts pages and a small blog routing refactor; no auth or data-path changes.
> 
> **Overview**
> **Shorts footer:** Turns on the newsletter block and replaces the dashed placeholder with a **`BeehiivForm`** that loads Beehiiv’s subscribe script in a `useEffect` (cleanup clears the container). Copy is tweaked; styles swap the placeholder for a centered **`.beehiivEmbed`**.
> 
> **Shorts index:** Refactors **`BlogListPage`** so `/shorts` routes render **`ShortsListPage`** via a thin default export, and adds **`BlogListPaginator`** to the shorts notes list so pagination matches the main blog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0957dfa139a008552950db9022976253fa614a67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->