### PR TITLE
feat: add LLM share button to docs and blog pages

### DIFF
--- a/src/components/LLMShareButton/index.tsx
+++ b/src/components/LLMShareButton/index.tsx
@@ -51,7 +51,7 @@ function LLMShareButtonInner(): JSX.Element {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
-  const url = window.location.href;
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     function onClickOutside(e: MouseEvent) {
@@ -60,23 +60,32 @@ function LLMShareButtonInner(): JSX.Element {
       }
     }
     document.addEventListener("mousedown", onClickOutside);
-    return () => document.removeEventListener("mousedown", onClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", onClickOutside);
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
   }, []);
 
   function handleCopy() {
-    navigator.clipboard.writeText(url);
-    setCopied(true);
-    setOpen(false);
-    setTimeout(() => setCopied(false), 2000);
+    // Read URL at click time to avoid stale value on SPA navigation
+    const url = window.location.href;
+    navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      setOpen(false);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), 2000);
+    });
   }
 
   function handleClaude() {
-    window.open(`https://claude.ai/new?q=${encodeURIComponent(PROMPT(url))}`, "_blank");
+    const url = window.location.href;
+    window.open(`https://claude.ai/new?q=${encodeURIComponent(PROMPT(url))}`, "_blank", "noopener,noreferrer");
     setOpen(false);
   }
 
   function handleChatGPT() {
-    window.open(`https://chatgpt.com/?q=${encodeURIComponent(PROMPT(url))}`, "_blank");
+    const url = window.location.href;
+    window.open(`https://chatgpt.com/?q=${encodeURIComponent(PROMPT(url))}`, "_blank", "noopener,noreferrer");
     setOpen(false);
   }
 

--- a/src/components/LLMShareButton/index.tsx
+++ b/src/components/LLMShareButton/index.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useRef, useState } from "react";
+import BrowserOnly from "@docusaurus/BrowserOnly";
+import styles from "./styles.module.css";
+
+const PROMPT = (url: string) =>
+  `Read from ${url} so I can ask questions about it.`;
+
+function CopyIcon() {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <rect x="5" y="5" width="8" height="9" rx="1.5" stroke="currentColor" strokeWidth="1.4"/>
+      <path d="M11 4V3.5A1.5 1.5 0 0 0 9.5 2h-6A1.5 1.5 0 0 0 2 3.5v7A1.5 1.5 0 0 0 3.5 12H4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
+    </svg>
+  );
+}
+
+function ClaudeIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="m4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z" />
+    </svg>
+  );
+}
+
+function ChatGPTIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
+    </svg>
+  );
+}
+
+function ExternalLinkIcon() {
+  return (
+    <svg viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" className={styles.externalIcon} aria-hidden="true">
+      <path d="M10 10H2V2H5V1H1V11H11V7H10V10Z" fill="currentColor"/>
+      <path d="M11 1H7V2H9.29L4.64 6.65L5.35 7.36L10 2.71V5H11V1Z" fill="currentColor"/>
+    </svg>
+  );
+}
+
+function ChevronDown() {
+  return (
+    <svg viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" className={styles.chevron} aria-hidden="true">
+      <path d="M2 4l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  );
+}
+
+function LLMShareButtonInner(): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const url = window.location.href;
+
+  useEffect(() => {
+    function onClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onClickOutside);
+    return () => document.removeEventListener("mousedown", onClickOutside);
+  }, []);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(url);
+    setCopied(true);
+    setOpen(false);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  function handleClaude() {
+    window.open(`https://claude.ai/new?q=${encodeURIComponent(PROMPT(url))}`, "_blank");
+    setOpen(false);
+  }
+
+  function handleChatGPT() {
+    window.open(`https://chatgpt.com/?q=${encodeURIComponent(PROMPT(url))}`, "_blank");
+    setOpen(false);
+  }
+
+  return (
+    <div ref={ref} className={styles.wrapper}>
+      <button className={styles.trigger} onClick={() => setOpen(!open)}>
+        <span className={styles.triggerIcon}><CopyIcon /></span>
+        {copied ? "Copied!" : "Copy page"}
+        <ChevronDown />
+      </button>
+      {open && (
+        <div className={styles.dropdown}>
+          <button className={styles.item} onClick={handleCopy}>
+            <span className={styles.itemIcon}><CopyIcon /></span>
+            <span className={styles.itemText}>
+              <span className={styles.itemTitle}>Copy page</span>
+              <span className={styles.itemSubtitle}>Copy page URL for LLMs</span>
+            </span>
+          </button>
+          <button className={styles.item} onClick={handleChatGPT}>
+            <span className={styles.itemIcon}><ChatGPTIcon /></span>
+            <span className={styles.itemText}>
+              <span className={styles.itemTitle}>Open in ChatGPT <ExternalLinkIcon /></span>
+              <span className={styles.itemSubtitle}>Ask questions about this page</span>
+            </span>
+          </button>
+          <button className={styles.item} onClick={handleClaude}>
+            <span className={styles.itemIcon}><ClaudeIcon /></span>
+            <span className={styles.itemText}>
+              <span className={styles.itemTitle}>Open in Claude <ExternalLinkIcon /></span>
+              <span className={styles.itemSubtitle}>Ask questions about this page</span>
+            </span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function LLMShareButton(): JSX.Element {
+  return (
+    <BrowserOnly fallback={null}>{() => <LLMShareButtonInner />}</BrowserOnly>
+  );
+}

--- a/src/components/LLMShareButton/styles.module.css
+++ b/src/components/LLMShareButton/styles.module.css
@@ -1,0 +1,126 @@
+.wrapper {
+  position: relative;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+/* Trigger button */
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  padding: 5px 10px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  color: var(--ifm-color-emphasis-700);
+  transition: border-color 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.trigger:hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+}
+
+.triggerIcon {
+  display: flex;
+  align-items: center;
+  width: 14px;
+  height: 14px;
+  opacity: 0.7;
+}
+
+.triggerIcon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.chevron {
+  width: 10px;
+  height: 10px;
+  opacity: 0.6;
+}
+
+/* Dropdown */
+.dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+  min-width: 240px;
+  z-index: 200;
+  overflow: hidden;
+}
+
+/* Dropdown items */
+.item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--ifm-color-emphasis-100);
+  padding: 10px 14px;
+  cursor: pointer;
+  color: var(--ifm-font-color-base);
+}
+
+.item:last-child {
+  border-bottom: none;
+}
+
+.item:hover {
+  background: var(--ifm-color-emphasis-100);
+}
+
+.itemIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  margin-top: 1px;
+  opacity: 0.75;
+}
+
+.itemIcon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.itemText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.itemTitle {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--ifm-font-color-base);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.itemSubtitle {
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-600);
+  line-height: 1.3;
+}
+
+.externalIcon {
+  width: 11px;
+  height: 11px;
+  opacity: 0.5;
+  flex-shrink: 0;
+}

--- a/src/components/ShortsFooter/index.tsx
+++ b/src/components/ShortsFooter/index.tsx
@@ -1,9 +1,27 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import styles from "./styles.module.css";
 
-// Set to true to show sections when ready
-const SHOW_NEWSLETTER = false;
+const BEEHIIV_FORM_ID = "4d460bb7-ac79-4cef-a7ee-c014bc5f62eb";
+
+const SHOW_NEWSLETTER = true;
 const SHOW_CONNECT_AGENT = false;
+
+function BeehiivForm(): JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const script = document.createElement("script");
+    script.src = "https://subscribe-forms.beehiiv.com/v3/loader.js";
+    script.async = true;
+    script.setAttribute("data-beehiiv-form", BEEHIIV_FORM_ID);
+    container.appendChild(script);
+    return () => { container.innerHTML = ""; };
+  }, []);
+
+  return <div ref={containerRef} className={styles.beehiivEmbed} />;
+}
 
 export default function ShortsFooter(): JSX.Element {
   return (
@@ -14,12 +32,9 @@ export default function ShortsFooter(): JSX.Element {
         <div className={styles.subscribeSection}>
           <h3 className={styles.subscribeHeading}>Get new shorts in your inbox</h3>
           <p className={styles.subscribeSubtext}>
-            Short dispatches from Fused as we build toward zero-code data workflows.
+            Short posts on building Fused without writing a single line of code.
           </p>
-          {/* BEEHIIV_EMBED_HERE */}
-          <div className={styles.embedPlaceholder}>
-            Newsletter embed — paste Beehiiv code here
-          </div>
+          <BeehiivForm />
         </div>
       )}
 

--- a/src/components/ShortsFooter/styles.module.css
+++ b/src/components/ShortsFooter/styles.module.css
@@ -23,12 +23,9 @@
   font-size: 0.95rem;
 }
 
-.embedPlaceholder {
-  border: 1px dashed var(--ifm-toc-border-color);
-  border-radius: 6px;
-  padding: 1rem 1.5rem;
-  color: var(--ifm-color-secondary-darkest);
-  font-size: 0.875rem;
+.beehiivEmbed {
+  display: flex;
+  justify-content: center;
 }
 
 .connectSection {

--- a/src/theme/BlogLayout/index.tsx
+++ b/src/theme/BlogLayout/index.tsx
@@ -1,7 +1,5 @@
 import React from "react";
-import clsx from "clsx";
 import Layout from "@theme/Layout";
-import BlogSidebar from "@theme/BlogSidebar";
 import Link from "@docusaurus/Link";
 import { useLocation } from "@docusaurus/router";
 import LLMShareButton from "@site/src/components/LLMShareButton";

--- a/src/theme/BlogLayout/index.tsx
+++ b/src/theme/BlogLayout/index.tsx
@@ -3,20 +3,28 @@ import clsx from "clsx";
 import Layout from "@theme/Layout";
 import BlogSidebar from "@theme/BlogSidebar";
 import Link from "@docusaurus/Link";
+import { useLocation } from "@docusaurus/router";
+import LLMShareButton from "@site/src/components/LLMShareButton";
 
 import type { Props } from "@theme/BlogLayout";
 
 export default function BlogLayout(props: Props): JSX.Element {
   const { sidebar, toc, children, ...layoutProps } = props;
-  const hasSidebar = sidebar && sidebar.items.length > 0;
+  const { pathname } = useLocation();
+
+  // Don't show on list pages (/blog, /shorts, /blog/page/N, /shorts/page/N)
+  const isListPage = /^\/(blog|shorts)(\/page\/\d+)?\/?$/.test(pathname);
 
   return (
     <Layout {...layoutProps}>
       <div className="container margin-vert--lg">
         <div className="row ">
-          <main
-            className="col"
-          >
+          <main className="col">
+            {!isListPage && (
+              <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "0.5rem" }}>
+                <LLMShareButton />
+              </div>
+            )}
             {children}
           </main>
 

--- a/src/theme/BlogListPage/index.tsx
+++ b/src/theme/BlogListPage/index.tsx
@@ -130,20 +130,17 @@ function ShortsListPage(props: Props): JSX.Element {
             );
           })}
         </ul>
+        <BlogListPaginator metadata={metadata} />
       </div>
     </BlogLayout>
   );
 }
 
-export default function BlogListPage(props: Props): JSX.Element {
+function MainBlogListPage(props: Props): JSX.Element {
   const { metadata, items } = props;
   const {
     siteConfig: { title: siteTitle },
   } = useDocusaurusContext();
-
-  if (metadata.permalink.startsWith('/shorts')) {
-    return <ShortsListPage {...props} />;
-  }
 
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<CategoryKey>('all');
@@ -231,4 +228,11 @@ export default function BlogListPage(props: Props): JSX.Element {
       </BlogLayout>
     </>
   );
+}
+
+export default function BlogListPage(props: Props): JSX.Element {
+  if (props.metadata.permalink.startsWith('/shorts')) {
+    return <ShortsListPage {...props} />;
+  }
+  return <MainBlogListPage {...props} />;
 }

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import clsx from "clsx";
+import { useWindowSize } from "@docusaurus/theme-common";
+import { useDoc } from "@docusaurus/plugin-content-docs/client";
+import DocItemPaginator from "@theme/DocItem/Paginator";
+import DocVersionBanner from "@theme/DocVersionBanner";
+import DocVersionBadge from "@theme/DocVersionBadge";
+import DocItemFooter from "@theme/DocItem/Footer";
+import DocItemTOCMobile from "@theme/DocItem/TOC/Mobile";
+import DocItemTOCDesktop from "@theme/DocItem/TOC/Desktop";
+import DocItemContent from "@theme/DocItem/Content";
+import DocBreadcrumbs from "@theme/DocBreadcrumbs";
+import ContentVisibility from "@theme/ContentVisibility";
+import LLMShareButton from "@site/src/components/LLMShareButton";
+import styles from "./styles.module.css";
+
+function useDocTOC() {
+  const { frontMatter, toc } = useDoc();
+  const windowSize = useWindowSize();
+  const hidden = frontMatter.hide_table_of_contents;
+  const canRender = !hidden && toc.length > 0;
+  const mobile = canRender ? <DocItemTOCMobile /> : undefined;
+  const desktop =
+    canRender && (windowSize === "desktop" || windowSize === "ssr") ? (
+      <DocItemTOCDesktop />
+    ) : undefined;
+  return { hidden, mobile, desktop };
+}
+
+export default function DocItemLayout({ children }) {
+  const docTOC = useDocTOC();
+  const { metadata } = useDoc();
+  return (
+    <div className="row">
+      <div className={clsx("col", !docTOC.hidden && styles.docItemCol)}>
+        <ContentVisibility metadata={metadata} />
+        <DocVersionBanner />
+        <div className={styles.docItemContainer}>
+          <article>
+            <DocBreadcrumbs />
+            <DocVersionBadge />
+            {docTOC.mobile}
+            <div className={styles.llmButtonFloat}>
+              <LLMShareButton />
+            </div>
+            <DocItemContent>{children}</DocItemContent>
+            <DocItemFooter />
+          </article>
+          <DocItemPaginator />
+        </div>
+      </div>
+      {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
+    </div>
+  );
+}

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -1,0 +1,16 @@
+.docItemContainer header + *,
+.docItemContainer article > *:first-child {
+  margin-top: 0;
+}
+
+.llmButtonFloat {
+  float: right;
+  margin-left: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+@media (min-width: 997px) {
+  .docItemCol {
+    max-width: 75% !important;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a **"Copy page ▾"** dropdown to every docs page and blog/shorts post
- Three options: copy the page URL, open in Claude, open in ChatGPT (both with real brand logos)
- Placement matches Modal's design: floating right, inline with the page h1 title
- Hidden on the `/blog` and `/shorts` list pages — only shows on individual posts/docs

## Test plan

- [ ] Verify button appears on a docs page (e.g. `/guide/getting-started/first-udf-basics/`) right-aligned next to the page title
- [ ] Verify button appears on a blog/shorts post but NOT on `/blog` or `/shorts` list pages
- [ ] Click "Copy page" — URL copies to clipboard
- [ ] Click "Open in Claude" — opens `https://claude.ai/new?q=Read from <url>...`
- [ ] Click "Open in ChatGPT" — opens `https://chatgpt.com/?q=Read from <url>...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only Docusaurus UI (clipboard, external links, third-party Beehiiv script); no auth or backend changes.
> 
> **Overview**
> Adds a **Copy page** dropdown (`LLMShareButton`) on individual **docs** and **blog/shorts** pages: copy the current URL, or open ChatGPT/Claude with a prefilled “read this URL” prompt. It is wired into swizzled `DocItem/Layout` (floated near content) and `BlogLayout` (top-right), and hidden on `/blog` and `/shorts` list routes via pathname checks.
> 
> **Shorts** footer turns on the newsletter section and replaces the placeholder with a **Beehiiv** embed loaded from their subscribe script. **Blog list** routing is split so `/shorts` uses `ShortsListPage` (now includes `BlogListPaginator`); the main blog list logic lives in `MainBlogListPage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34c5f0242efca7b6e67fca05ac5b24a9fa60c076. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->