### PR TITLE
Add /refresh-workbench-screenshot Claude Code command

### DIFF
--- a/.claude/commands/refresh-workbench-screenshot.md
+++ b/.claude/commands/refresh-workbench-screenshot.md
@@ -14,8 +14,10 @@ images live under `<repo>/static`.
 
 ## Steps
 1. **Resolve & read all media.** Resolve `$ARGUMENTS` to a **single** `.mdx` under
-   `docs/workbench/` (plus any linked guide with the real steps). If it is ambiguous or
-   names a section with several pages (e.g. `integrations`), **ask the user which exact
+   `docs/workbench/` — match the filename **or** the page's `id:`/URL slug (they often
+   differ, e.g. `udf-explorer` → `udf-catalog.mdx`); grep frontmatter `id:` when the
+   filename doesn't match. If it is ambiguous, names a section with several pages (e.g.
+   `integrations`), or you can't confidently pin the file, **ask the user which exact
    page** instead of guessing. List the page's media (`![]` images, `<LazyReactPlayer>`
    `.mp4`). Read the prose and every image. For a video: `curl -s -o v.mp4 <url>` then
    `ffmpeg -i v.mp4 -vf fps=2 f_%04d.png` and read the frames. A doc's own media can
@@ -25,17 +27,19 @@ images live under `<repo>/static`.
    record where it actually is, or that it's absent.
 3. **Compare.** Table: aspect → docs say → live shows → verdict.
 4. **Decide.** Mismatch/missing → do **not** refresh; file the ticket (below). Full match
-   → refresh the screenshot (below). Never silently edit docs or capture a stale state.
+   → refresh **every** referenced screenshot that's now stale (below). Never silently
+   edit docs or capture a stale state.
 
-## Refresh a screenshot
+## Refresh screenshots
 The extension's `screenshot save_to_disk` doesn't produce a usable file, but its GIF
-export does. So: reach the UI state, then `gif_creator` start_recording → screenshot →
-export `download:true` (GIF lands in the browser's Downloads). Extract frames
+export does. **Repeat for each stale image the page references** (pages often have
+several): reach its UI state, then `gif_creator` start_recording → screenshot → export
+`download:true` (GIF lands in the browser's Downloads). Extract frames
 `ffmpeg -y -i <downloads>/<file>.gif f_%04d.png` and take the last. Write it to the
-destination **derived from the page's own image reference**: take the `/img/...` path
-in the MDX `![](...)` tag and write to `<repo>/static` + that exact path. Do **not**
-assume `/img/workbench/` — pages use other prefixes too. If the target path or prefix is
-unclear, ask the user for the appropriate destination. Then `git status` the path; don't
+destination **derived from that image's own reference**: take the `/img/...` path in its
+MDX `![](...)` tag and write to `<repo>/static` + that exact path. Do **not** assume
+`/img/workbench/` — pages use other prefixes too. If a target path or prefix is unclear,
+ask the user for the appropriate destination. Then `git status` the path; don't
 commit unless asked. (Backup, optional: a local Playwright tool attached to a debug
 Chrome over CDP gives pixel-precise stills — only if set up.)
 

--- a/.claude/commands/refresh-workbench-screenshot.md
+++ b/.claude/commands/refresh-workbench-screenshot.md
@@ -21,7 +21,8 @@ Fused CLI (`fused whoami`). Repo root: `git rev-parse --show-toplevel`; assets l
 2. **Explore live.** Follow the documented steps on the live workbench; if an option isn't
    where the doc says, look elsewhere (sidebar, avatar menu, tabs) — record where it
    actually is, or that it's absent.
-3. **Compare.** Table: aspect → docs say → live shows → verdict.
+3. **Compare.** Table: aspect → docs say → live shows → verdict. Also mark each
+   referenced image **current or stale** by comparing it against its live state.
 4. **Decide.** Mismatch/missing → don't refresh; file the ticket. Full match → refresh
    **every** stale asset. Never silently edit docs or capture a stale state.
 

--- a/.claude/commands/refresh-workbench-screenshot.md
+++ b/.claude/commands/refresh-workbench-screenshot.md
@@ -1,0 +1,49 @@
+---
+description: Check a Workbench doc page's workflow against the live UI, file a 3-section drift ticket with a GIF, and refresh its screenshot only if docs and live match.
+argument-hint: <page> (e.g. "profile", "integrations")
+---
+
+# Refresh workbench screenshot
+
+Primary tool: **Claude for Chrome** (`mcp__Claude_in_Chrome__*`) driving the user's real,
+logged-in browser. Target page: **$ARGUMENTS**.
+
+Setup (check once; install if missing): `git`, `ffmpeg`, `curl`, and the Fused CLI
+(`fused whoami` must succeed). Find the repo with `git rev-parse --show-toplevel`; doc
+images live under `<repo>/static`.
+
+## Steps
+1. **Resolve & read all media.** Map `$ARGUMENTS` to a page in `docs/workbench/` (plus any
+   linked guide holding the real steps). List its media (`![]` images, `<LazyReactPlayer>`
+   `.mp4`). Read the prose and every image. For a video: `curl -s -o v.mp4 <url>` then
+   `ffmpeg -i v.mp4 -vf fps=2 f_%02d.png` and read the frames. A doc's own media can
+   contradict its prose — note that.
+2. **Explore live.** Follow the documented steps on the live workbench. If an option
+   isn't where the doc says, look elsewhere (sidebar, in-canvas avatar menu, tabs);
+   record where it actually is, or that it's absent.
+3. **Compare.** Table: aspect → docs say → live shows → verdict.
+4. **Decide.** Mismatch/missing → do **not** refresh; file the ticket (below). Full match
+   → refresh the screenshot (below). Never silently edit docs or capture a stale state.
+
+## Refresh a screenshot
+The extension's `screenshot save_to_disk` doesn't produce a usable file, but its GIF
+export does. So: reach the UI state, then `gif_creator` start_recording → screenshot →
+export `download:true` (GIF lands in the browser's Downloads). Extract the final frame:
+`ffmpeg -y -i <downloads>/<file>.gif f_%03d.png` and copy the last frame to the repo path
+`<repo>/static/img/workbench/.../<name>.png`. Then `git status` the path; don't commit
+unless asked. (Backup, optional: a local Playwright tool attached to a debug Chrome over
+CDP gives pixel-precise stills — only if set up.)
+
+## File the drift ticket — Notion, exactly 3 sections
+1. **Page targeted** — doc page + its media.
+2. **Docs vs Live UI** — the comparison table.
+3. **What to resolve** — concrete fixes, open questions, whether a screenshot needs refresh.
+
+Create it in your team's `Engineering Tasks` data source (find via Notion search); set
+`BUG`. Attach a **GIF** of the workflow as evidence — record with `gif_creator`, then
+store it durably in Fused and reference the stable path (don't embed signed URLs, they
+expire):
+`fused files upload <gif> "fd://<handle>/claude/<name>.gif"`
+Put that `fd://` path in the ticket with the read-back command
+`fused files download "fd://<handle>/claude/<name>.gif" .` — get `<handle>` from
+`fused whoami`.

--- a/.claude/commands/refresh-workbench-screenshot.md
+++ b/.claude/commands/refresh-workbench-screenshot.md
@@ -1,6 +1,6 @@
 ---
 description: Check a Workbench doc page's workflow against the live UI, file a 3-section drift ticket with a GIF, and refresh its screenshot only if docs and live match.
-argument-hint: <page> (e.g. "profile", "integrations")
+argument-hint: <page> — a single doc page slug (e.g. "profile", "integrations/s3"), not a section
 ---
 
 # Refresh workbench screenshot
@@ -13,10 +13,12 @@ Setup (check once; install if missing): `git`, `ffmpeg`, `curl`, and the Fused C
 images live under `<repo>/static`.
 
 ## Steps
-1. **Resolve & read all media.** Map `$ARGUMENTS` to a page in `docs/workbench/` (plus any
-   linked guide holding the real steps). List its media (`![]` images, `<LazyReactPlayer>`
+1. **Resolve & read all media.** Resolve `$ARGUMENTS` to a **single** `.mdx` under
+   `docs/workbench/` (plus any linked guide with the real steps). If it is ambiguous or
+   names a section with several pages (e.g. `integrations`), **ask the user which exact
+   page** instead of guessing. List the page's media (`![]` images, `<LazyReactPlayer>`
    `.mp4`). Read the prose and every image. For a video: `curl -s -o v.mp4 <url>` then
-   `ffmpeg -i v.mp4 -vf fps=2 f_%02d.png` and read the frames. A doc's own media can
+   `ffmpeg -i v.mp4 -vf fps=2 f_%04d.png` and read the frames. A doc's own media can
    contradict its prose — note that.
 2. **Explore live.** Follow the documented steps on the live workbench. If an option
    isn't where the doc says, look elsewhere (sidebar, in-canvas avatar menu, tabs);
@@ -28,11 +30,14 @@ images live under `<repo>/static`.
 ## Refresh a screenshot
 The extension's `screenshot save_to_disk` doesn't produce a usable file, but its GIF
 export does. So: reach the UI state, then `gif_creator` start_recording → screenshot →
-export `download:true` (GIF lands in the browser's Downloads). Extract the final frame:
-`ffmpeg -y -i <downloads>/<file>.gif f_%03d.png` and copy the last frame to the repo path
-`<repo>/static/img/workbench/.../<name>.png`. Then `git status` the path; don't commit
-unless asked. (Backup, optional: a local Playwright tool attached to a debug Chrome over
-CDP gives pixel-precise stills — only if set up.)
+export `download:true` (GIF lands in the browser's Downloads). Extract frames
+`ffmpeg -y -i <downloads>/<file>.gif f_%04d.png` and take the last. Write it to the
+destination **derived from the page's own image reference**: take the `/img/...` path
+in the MDX `![](...)` tag and write to `<repo>/static` + that exact path. Do **not**
+assume `/img/workbench/` — pages use other prefixes too. If the target path or prefix is
+unclear, ask the user for the appropriate destination. Then `git status` the path; don't
+commit unless asked. (Backup, optional: a local Playwright tool attached to a debug
+Chrome over CDP gives pixel-precise stills — only if set up.)
 
 ## File the drift ticket — Notion, exactly 3 sections
 1. **Page targeted** — doc page + its media.

--- a/.claude/commands/refresh-workbench-screenshot.md
+++ b/.claude/commands/refresh-workbench-screenshot.md
@@ -1,58 +1,47 @@
 ---
-description: Check a Workbench doc page's workflow against the live UI, file a 3-section drift ticket with a GIF, and refresh its screenshot only if docs and live match.
+description: Check a Workbench doc page's workflow against the live UI, file a 3-section drift ticket with a GIF, and refresh its screenshots only if docs and live match.
 argument-hint: <page> — a single doc page slug (e.g. "profile", "integrations/s3"), not a section
 ---
 
 # Refresh workbench screenshot
 
-Primary tool: **Claude for Chrome** (`mcp__Claude_in_Chrome__*`) driving the user's real,
-logged-in browser. Target page: **$ARGUMENTS**.
-
-Setup (check once; install if missing): `git`, `ffmpeg`, `curl`, and the Fused CLI
-(`fused whoami` must succeed). Find the repo with `git rev-parse --show-toplevel`; doc
-images live under `<repo>/static`.
+Primary tool: **Claude for Chrome** (`mcp__Claude_in_Chrome__*`) on the user's real,
+logged-in browser. Target: **$ARGUMENTS**. Setup (check once): `git`, `ffmpeg`, `curl`,
+Fused CLI (`fused whoami`). Repo root: `git rev-parse --show-toplevel`; assets live under
+`<repo>/static`.
 
 ## Steps
-1. **Resolve & read all media.** Resolve `$ARGUMENTS` to a **single** `.mdx` under
-   `docs/workbench/` — match the filename **or** the page's `id:`/URL slug (they often
-   differ, e.g. `udf-explorer` → `udf-catalog.mdx`); grep frontmatter `id:` when the
-   filename doesn't match. If it is ambiguous, names a section with several pages (e.g.
-   `integrations`), or you can't confidently pin the file, **ask the user which exact
-   page** instead of guessing. List the page's media (`![]` images, `<LazyReactPlayer>`
-   `.mp4`). Read the prose and every image. For a video: `curl -s -o v.mp4 <url>` then
-   `ffmpeg -i v.mp4 -vf fps=2 f_%04d.png` and read the frames. A doc's own media can
-   contradict its prose — note that.
-2. **Explore live.** Follow the documented steps on the live workbench. If an option
-   isn't where the doc says, look elsewhere (sidebar, in-canvas avatar menu, tabs);
-   record where it actually is, or that it's absent.
+1. **Resolve & read.** Map `$ARGUMENTS` to one `.mdx` in `docs/workbench/` by filename
+   **or** frontmatter `id:`/URL slug (they differ, e.g. `udf-explorer` → `udf-catalog.mdx`).
+   If ambiguous, a section (e.g. `integrations`), or unresolvable, **ask the user**. Read
+   the prose and **every media asset** — `![]`, `ClickZoomImage`, `<img src>`,
+   `<LazyReactPlayer>`, `<video>/<source>`. Per video, download to a **unique** name and
+   extract frames (`curl -s -o v1.mp4 <url>; ffmpeg -i v1.mp4 -vf fps=2 v1_%04d.png`), then
+   read them. Note where a page's own media contradicts its prose.
+2. **Explore live.** Follow the documented steps on the live workbench; if an option isn't
+   where the doc says, look elsewhere (sidebar, avatar menu, tabs) — record where it
+   actually is, or that it's absent.
 3. **Compare.** Table: aspect → docs say → live shows → verdict.
-4. **Decide.** Mismatch/missing → do **not** refresh; file the ticket (below). Full match
-   → refresh **every** referenced screenshot that's now stale (below). Never silently
-   edit docs or capture a stale state.
+4. **Decide.** Mismatch/missing → don't refresh; file the ticket. Full match → refresh
+   **every** stale asset. Never silently edit docs or capture a stale state.
 
 ## Refresh screenshots
-The extension's `screenshot save_to_disk` doesn't produce a usable file, but its GIF
-export does. **Repeat for each stale image the page references** (pages often have
-several): reach its UI state, then `gif_creator` start_recording → screenshot → export
-`download:true` (GIF lands in the browser's Downloads). Extract frames
-`ffmpeg -y -i <downloads>/<file>.gif f_%04d.png` and take the last. Write it to the
-destination **derived from that image's own reference**: take the `/img/...` path in its
-MDX `![](...)` tag and write to `<repo>/static` + that exact path. Do **not** assume
-`/img/workbench/` — pages use other prefixes too. If a target path or prefix is unclear,
-ask the user for the appropriate destination. Then `git status` the path; don't
-commit unless asked. (Backup, optional: a local Playwright tool attached to a debug
-Chrome over CDP gives pixel-precise stills — only if set up.)
+(`screenshot save_to_disk` yields no usable file; the GIF export does.) For **each** stale
+asset: reach its UI state → `gif_creator` start_recording → screenshot → export
+`download:true` (lands in Downloads) → `ffmpeg -y -i <gif> f_%04d.png`, take the last
+frame → write it to `<repo>/static` + the asset's own `/img/...` path (from its `![]`/`src`
+tag — don't assume `/img/workbench/`). Ask the user if a path is unclear. `git status` the
+paths; don't commit unless asked. (Backup: a local Playwright tool attached to a debug
+Chrome over CDP for pixel-precise stills — only if set up.)
 
-## File the drift ticket — Notion, exactly 3 sections
-1. **Page targeted** — doc page + its media.
+## Ticket — Notion, exactly 3 sections
+1. **Page targeted** — page + its media.
 2. **Docs vs Live UI** — the comparison table.
-3. **What to resolve** — concrete fixes, open questions, whether a screenshot needs refresh.
+3. **What to resolve** — fixes, open questions, which assets need refreshing.
 
-Create it in your team's `Engineering Tasks` data source (find via Notion search); set
-`BUG`. Attach a **GIF** of the workflow as evidence — record with `gif_creator`, then
-store it durably in Fused and reference the stable path (don't embed signed URLs, they
-expire):
-`fused files upload <gif> "fd://<handle>/claude/<name>.gif"`
-Put that `fd://` path in the ticket with the read-back command
-`fused files download "fd://<handle>/claude/<name>.gif" .` — get `<handle>` from
-`fused whoami`.
+Create in your team's `Engineering Tasks` data source (find via search); set `BUG`. Attach
+a workflow **GIF** as evidence: record with `gif_creator`, upload to Fused, reference the
+stable path (don't embed signed URLs — they expire):
+`fused files upload <gif> "fd://<handle>/claude/<name>.gif"` — put that `fd://` path in the
+ticket with `fused files download "fd://<handle>/claude/<name>.gif" .` (`<handle>` from
+`fused whoami`).


### PR DESCRIPTION
Adds a portable Claude Code slash command (`.claude/commands/refresh-workbench-screenshot.md`) for keeping Workbench docs screenshots in sync with the live app.

## What it does
Given a Workbench doc page, it:
1. Reads the page's documented workflow and **all** its media (prose, images, and any walkthrough video — frames extracted with ffmpeg).
2. Drives the **live** Workbench with Claude for Chrome, following the documented steps and exploring alternate entry points.
3. Compares docs vs live UI (aspect → docs say → live shows → verdict).
4. On a mismatch, files a 3-section drift ticket (page / docs-vs-live / resolution) with a GIF as evidence; on a full match, refreshes the screenshot.

## Notes
- **Primary tool: Claude for Chrome** (drives your real, logged-in browser). A local Playwright capture is mentioned only as an optional backup.
- **Portable** — no hardcoded paths or accounts: it discovers the repo root via `git rev-parse --show-toplevel`, the Fused handle via `fused whoami`, and the team's engineering tracker via search. A one-line setup check lists the prerequisites (`git`, `ffmpeg`, `curl`, `fused`).
- Doc-only addition; no app/code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition of an agent workflow file; no application, auth, or runtime code changes.
> 
> **Overview**
> Adds a new Claude Code slash command **`/refresh-workbench-screenshot`** (`.claude/commands/refresh-workbench-screenshot.md`) for Workbench documentation maintenance.
> 
> The command takes a single doc page slug, resolves it to `docs/workbench/*.mdx`, and walks through **read docs + media** (including video frame extraction), **replay the workflow in live Workbench** via Claude for Chrome, **compare** docs vs UI, then either file a **3-section Notion drift ticket** (with GIF evidence on Fused) or **refresh stale screenshots** under `static/` using GIF export + ffmpeg. It documents portable setup (`git`, `ffmpeg`, `curl`, `fused whoami`) and forbids refreshing or silently editing docs when UI and prose don't match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79eae75328a49f9d24d76f84b74fa0ddaff28525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->