### PR TITLE
chore: sync widget schemas (application@9317c70e5436b581e5165bded55a223504d04654)

### DIFF
--- a/static/widget-schema/ai-chat.json
+++ b/static/widget-schema/ai-chat.json
@@ -23,6 +23,6 @@
         "type": "string"
       }
     },
-    "description": "Always-on AI chat for asking questions about UDFs connected to this JSON UI node."
+    "description": "Always-on AI chat for asking questions about UDFs connected to this JSON UI node.\n\n## Example\n\n```json\n{\n  \"type\": \"ai-chat\",\n  \"props\": {\n    \"title\": \"Ask about this data\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/bar-chart.json
+++ b/static/widget-schema/bar-chart.json
@@ -85,6 +85,6 @@
     "required": [
       "sql"
     ],
-    "description": "A bar chart powered by DuckDB SQL queries against UDF outputs. Query must return 'label' and 'value' columns. Uses {{udf_name}} placeholders to reference UDF DataFrames."
+    "description": "A bar chart powered by DuckDB SQL queries against UDF outputs. Query must return 'label' and 'value' columns. Uses {{udf_name}} placeholders to reference UDF DataFrames.\n\n## Example\n\n```json\n{\n  \"type\": \"bar-chart\",\n  \"props\": {\n    \"sql\": \"SELECT neighborhood AS label, COUNT(*) AS value FROM {{listings}} GROUP BY 1 ORDER BY 2 DESC LIMIT 10\",\n    \"title\": \"Listings by Neighborhood\"\n  }\n}\n```\n\n## Example — horizontal\n\n```json\n{\n  \"type\": \"bar-chart\",\n  \"props\": {\n    \"sql\": \"SELECT city AS label, population AS value FROM {{cities}} ORDER BY 2 DESC\",\n    \"horizontal\": true,\n    \"showValues\": true\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/button.json
+++ b/static/widget-schema/button.json
@@ -49,6 +49,6 @@
         "type": "boolean"
       }
     },
-    "description": "A clickable button for triggering actions. If param is provided, broadcasts click count to that canvas parameter."
+    "description": "A clickable button for triggering actions. If `param` is provided, broadcasts a click signal to that canvas parameter.\n\n## Example\n\n```json\n{\n  \"type\": \"button\",\n  \"props\": {\n    \"label\": \"Submit\",\n    \"variant\": \"default\",\n    \"param\": \"submit_count\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/camera-input.json
+++ b/static/widget-schema/camera-input.json
@@ -78,6 +78,6 @@
         "type": "string"
       }
     },
-    "description": "A camera input that captures a photo as a data URL string and can optionally sync with canvas parameters or a form."
+    "description": "A camera input that captures a photo as a data URL string and can optionally sync with canvas parameters or a form.\n\n## Example\n\n```json\n{\n  \"type\": \"camera-input\",\n  \"props\": {\n    \"label\": \"Photo\",\n    \"param\": \"photo_data_url\",\n    \"facingMode\": \"environment\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/code-editor.json
+++ b/static/widget-schema/code-editor.json
@@ -48,6 +48,6 @@
         "type": "string"
       }
     },
-    "description": "Code editor with multi-language syntax highlighting. Syncs content with a canvas parameter."
+    "description": "Code editor with multi-language syntax highlighting. Syncs content with a canvas parameter.\n\n## Example — SQL\n\n```json\n{\n  \"type\": \"code-editor\",\n  \"props\": {\n    \"param\": \"my_query\",\n    \"language\": \"sql\",\n    \"defaultValue\": \"SELECT * FROM {{my_udf}} LIMIT 10\"\n  }\n}\n```\n\n## Example — Python\n\n```json\n{\n  \"type\": \"code-editor\",\n  \"props\": {\n    \"param\": \"code\",\n    \"language\": \"python\",\n    \"defaultValue\": \"import pandas as pd\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/color-input.json
+++ b/static/widget-schema/color-input.json
@@ -46,6 +46,6 @@
         "type": "string"
       }
     },
-    "description": "A color input that can optionally sync string color values with canvas parameters. Hex strings are recommended for chart and CSS interoperability."
+    "description": "A color input that can optionally sync string color values with canvas parameters. Hex strings are recommended for chart and CSS interoperability.\n\n## Example\n\n```json\n{\n  \"type\": \"color-input\",\n  \"props\": {\n    \"label\": \"Highlight color\",\n    \"param\": \"highlight_color\",\n    \"defaultValue\": \"#2563eb\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/datetime-input.json
+++ b/static/widget-schema/datetime-input.json
@@ -51,6 +51,6 @@
         "type": "string"
       }
     },
-    "description": "A date, time, or local datetime input that can optionally sync string values with canvas parameters. Values are stored without timezone conversion."
+    "description": "A date, time, or local datetime input that can optionally sync string values with canvas parameters. Values are stored without timezone conversion.\n\n## Example\n\n```json\n{\n  \"type\": \"datetime-input\",\n  \"props\": {\n    \"label\": \"Start date\",\n    \"param\": \"start_date\",\n    \"mode\": \"date\",\n    \"defaultValue\": \"2026-01-01\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/div.json
+++ b/static/widget-schema/div.json
@@ -11,6 +11,6 @@
         "type": "string"
       }
     },
-    "description": "A generic container for grouping elements. Can contain any child components. Defaults to a flex column."
+    "description": "A generic container for grouping elements. Can contain any child components. Defaults to a flex column.\n\n## Example\n\n```json\n{\n  \"type\": \"div\",\n  \"props\": { \"style\": \"display: flex; gap: 8px; padding: 16px\" },\n  \"children\": [\n    { \"type\": \"text-input\", \"props\": { \"label\": \"Name\", \"param\": \"name\" } },\n    { \"type\": \"button\", \"props\": { \"label\": \"Submit\", \"param\": \"submit\" } }\n  ]\n}\n```"
   }
 }

--- a/static/widget-schema/donut-chart.json
+++ b/static/widget-schema/donut-chart.json
@@ -52,6 +52,6 @@
     "required": [
       "sql"
     ],
-    "description": "A donut chart powered by DuckDB SQL. Query must return label and value columns."
+    "description": "A donut chart powered by DuckDB SQL. Query must return label and value columns.\n\n## Example\n\n```json\n{\n  \"type\": \"donut-chart\",\n  \"props\": {\n    \"sql\": \"SELECT room_type AS label, COUNT(*) AS value FROM {{listings}} GROUP BY 1\",\n    \"title\": \"Listings by Room Type\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/dropdown.json
+++ b/static/widget-schema/dropdown.json
@@ -98,6 +98,6 @@
         "type": "boolean"
       }
     },
-    "description": "A dropdown that syncs with canvas parameters. Prefer sql (DuckDB query with {{udf_name}} placeholders returning 'value' and 'label' columns) for dynamic options from UDF DataFrames. Fall back to options array for static choices."
+    "description": "A dropdown that syncs with canvas parameters. Prefer `sql` (a DuckDB query with `{{udf_name}}` placeholders returning `value` and `label` columns) for dynamic options from UDF DataFrames. Fall back to the `options` array for static choices.\n\n## Example — SQL (dynamic)\n\n```json\n{\n  \"type\": \"dropdown\",\n  \"props\": {\n    \"label\": \"Select City\",\n    \"param\": \"city\",\n    \"sql\": \"SELECT DISTINCT city AS value, city AS label FROM {{my_udf}} ORDER BY city\"\n  }\n}\n```\n\n## Example — static options\n\n```json\n{\n  \"type\": \"dropdown\",\n  \"props\": {\n    \"label\": \"Select Country\",\n    \"param\": \"country\",\n    \"options\": [\n      { \"value\": \"us\", \"label\": \"United States\" },\n      { \"value\": \"uk\", \"label\": \"United Kingdom\" }\n    ]\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/form.json
+++ b/static/widget-schema/form.json
@@ -44,6 +44,6 @@
         "type": "string"
       }
     },
-    "description": "A form container that collects child input values and submits on button click. If form 'param' is provided, all child values are broadcast as one object to that parameter. If omitted, each child field parameter is broadcast individually. Children should use 'param' prop to register with the form. It supports input components such as text-input, text-area, number-input, datetime-input, camera-input, color-input, dropdown, slider, and text."
+    "description": "A form container that collects child input values and submits them on button click. If `param` is provided, all child values are broadcast as one JSON object to that parameter. If omitted, each child field is broadcast individually. Children use their own `param` prop to register with the form. Supported child types: text-input, text-area, number-input, datetime-input, camera-input, color-input, dropdown, slider, and text.\n\n## Example\n\n```json\n{\n  \"type\": \"form\",\n  \"props\": {\n    \"param\": \"form_data\",\n    \"submitLabel\": \"Submit\"\n  },\n  \"children\": [\n    { \"type\": \"text-input\", \"props\": { \"label\": \"Name\", \"param\": \"user_name\" } },\n    {\n      \"type\": \"dropdown\",\n      \"props\": {\n        \"label\": \"City\",\n        \"param\": \"city\",\n        \"sql\": \"SELECT DISTINCT city AS value, city AS label FROM {{my_udf}} ORDER BY city\"\n      }\n    }\n  ]\n}\n```"
   }
 }

--- a/static/widget-schema/fused-map.json
+++ b/static/widget-schema/fused-map.json
@@ -234,6 +234,6 @@
         "type": "string"
       }
     },
-    "description": "Interactive map with Mapbox GL (mvt, raster, geojson) and deck.gl (h3, heatmap, arc, scatterplot) layers."
+    "description": "Interactive map with Mapbox GL (mvt, raster, geojson) and deck.gl (h3, heatmap, arc, scatterplot) layers.\n\n## Example — MVT tile layer\n\n```json\n{\n  \"type\": \"fused-map\",\n  \"props\": {\n    \"layers\": [{\n      \"id\": \"counties\",\n      \"type\": \"mvt\",\n      \"tileUrl\": \"https://tiles.fused.io/public/my_tileset/{z}/{x}/{y}\",\n      \"style\": { \"fillColor\": [100, 150, 200], \"opacity\": 0.6 }\n    }]\n  }\n}\n```\n\n## Example — SQL with lat/lng points\n\n```json\n{\n  \"type\": \"fused-map\",\n  \"props\": {\n    \"layers\": [{\n      \"id\": \"sites\",\n      \"type\": \"geojson\",\n      \"sql\": \"SELECT name, lat, lng FROM {{my_udf}}\",\n      \"style\": { \"fillColor\": [255, 80, 0], \"pointRadius\": 8 }\n    }]\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/gallery-input.json
+++ b/static/widget-schema/gallery-input.json
@@ -109,6 +109,6 @@
         "type": "string"
       }
     },
-    "description": "An image-card gallery input with horizontal, vertical, or grid layout that syncs with canvas parameters. Prefer sql (DuckDB query with {{udf_name}} placeholders returning value, title, and image columns) for dynamic options from UDF DataFrames. Fall back to options array for static choices."
+    "description": "An image-card gallery input with horizontal, vertical, or grid layout that syncs with canvas parameters. Prefer sql (DuckDB query with {{udf_name}} placeholders returning value, title, and image columns) for dynamic options from UDF DataFrames. Fall back to options array for static choices.\n\n## Example — SQL\n\n```json\n{\n  \"type\": \"gallery-input\",\n  \"props\": {\n    \"label\": \"Select a dataset\",\n    \"param\": \"dataset\",\n    \"sql\": \"SELECT id AS value, name AS title, thumbnail AS image FROM {{datasets}}\"\n  }\n}\n```\n\n## Example — static options\n\n```json\n{\n  \"type\": \"gallery-input\",\n  \"props\": {\n    \"label\": \"Select style\",\n    \"param\": \"map_style\",\n    \"options\": [\n      { \"value\": \"dark\", \"title\": \"Dark\", \"image\": \"https://example.com/dark.png\" },\n      { \"value\": \"light\", \"title\": \"Light\", \"image\": \"https://example.com/light.png\" }\n    ]\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/heatmap-chart.json
+++ b/static/widget-schema/heatmap-chart.json
@@ -55,6 +55,6 @@
     "required": [
       "sql"
     ],
-    "description": "A matrix heatmap powered by DuckDB SQL. Query must return x, y, and value columns."
+    "description": "A matrix heatmap powered by DuckDB SQL. Query must return x, y, and value columns.\n\n## Example\n\n```json\n{\n  \"type\": \"heatmap-chart\",\n  \"props\": {\n    \"sql\": \"SELECT day_of_week AS x, hour AS y, COUNT(*) AS value FROM {{events}} GROUP BY 1, 2\",\n    \"title\": \"Events by Day and Hour\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/html.json
+++ b/static/widget-schema/html.json
@@ -16,6 +16,6 @@
         "type": "string"
       }
     },
-    "description": "Sandboxed HTML with $param_name and {{udf_name}} substitution. Exposes fusedCanvas.setParam(name, value) / .clearParam(name) for canvas communication."
+    "description": "Sandboxed HTML with $param_name and {{udf_name}} substitution. Exposes fusedCanvas.setParam(name, value) / .clearParam(name) for canvas communication.\n\n## Example\n\n```json\n{\n  \"type\": \"html\",\n  \"props\": {\n    \"value\": \"<h2>Hello, $user_name!</h2><p>Selected city: <b>$city</b></p>\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/iframe.json
+++ b/static/widget-schema/iframe.json
@@ -26,6 +26,6 @@
     "required": [
       "src"
     ],
-    "description": "Embeds a web page or HTML-returning UDF in an iframe. Use for dashboards, docs, or any site that permits framing."
+    "description": "Embeds a web page or HTML-returning UDF in an iframe. Use for dashboards, docs, or any site that permits framing.\n\n## Example\n\n```json\n{\n  \"type\": \"iframe\",\n  \"props\": {\n    \"src\": \"https://docs.fused.io\",\n    \"title\": \"Fused documentation\",\n    \"style\": \"border-radius: 8px; height: 500px\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/image.json
+++ b/static/widget-schema/image.json
@@ -1,6 +1,6 @@
 {
   "type": "image",
-  "description": "Display an image from a URL or base64 data URL.",
+  "description": "Display an image from a URL, base64 data URL, or signable storage path.",
   "hasChildren": false,
   "propsSchema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -8,7 +8,7 @@
     "properties": {
       "src": {
         "type": "string",
-        "description": "Image URL or base64 data URL"
+        "description": "Image URL, base64 data URL, or signable storage path (e.g., \"s3://bucket/image.png\")"
       },
       "alt": {
         "description": "Accessible description of the image",
@@ -34,6 +34,6 @@
     "required": [
       "src"
     ],
-    "description": "Displays an image from a URL or base64 data URL. Useful for showing pasted images, charts, or any visual asset."
+    "description": "Displays an image from a URL, base64 data URL, or signable storage path. Useful for showing pasted images, charts, or any visual asset.\n\n## Example\n\n```json\n{\n  \"type\": \"image\",\n  \"props\": {\n    \"src\": \"https://example.com/map.png\",\n    \"alt\": \"Map preview\",\n    \"objectFit\": \"contain\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/kepler-map.json
+++ b/static/widget-schema/kepler-map.json
@@ -1,0 +1,28 @@
+{
+  "type": "kepler-map",
+  "description": "Embed the Kepler.gl viewer for a workspace UDF. Use {{udf_1}} to bind the connected UDF via a slot, or supply a plain UDF name as a fallback.",
+  "hasChildren": false,
+  "propsSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "udf": {
+        "type": "string",
+        "minLength": 1,
+        "description": "UDF slot placeholder (e.g. {{udf_1}}) or plain UDF name whose results should be displayed in Kepler.gl."
+      },
+      "title": {
+        "description": "Accessible title for the embedded Kepler.gl map",
+        "type": "string"
+      },
+      "style": {
+        "description": "Inline CSS styles as a plain CSS string (e.g., \"min-height: 480px; border-radius: 8px\")",
+        "type": "string"
+      }
+    },
+    "required": [
+      "udf"
+    ],
+    "description": "Embeds the Kepler.gl viewer for a UDF in the workspace. Accepts a {{udf_N}} slot placeholder or a plain UDF name. Uses a parquet share URL when the canvas is shared; falls back to a temporary GeoJSON upload otherwise."
+  }
+}

--- a/static/widget-schema/line-chart.json
+++ b/static/widget-schema/line-chart.json
@@ -119,6 +119,6 @@
     "required": [
       "sql"
     ],
-    "description": "A line/area chart for time series data, powered by DuckDB SQL queries. Query must return 'label' and 'value' columns. Add a 'series' column for multiple lines."
+    "description": "A line/area chart for time series data, powered by DuckDB SQL queries. Query must return 'label' and 'value' columns. Add a 'series' column for multiple lines.\n\n## Example\n\n```json\n{\n  \"type\": \"line-chart\",\n  \"props\": {\n    \"sql\": \"SELECT date AS label, revenue AS value FROM {{sales}} ORDER BY 1\",\n    \"title\": \"Revenue Over Time\"\n  }\n}\n```\n\n## Example — multi-series\n\n```json\n{\n  \"type\": \"line-chart\",\n  \"props\": {\n    \"sql\": \"SELECT date AS label, count AS value, category AS series FROM {{events}} ORDER BY 1, 3\",\n    \"title\": \"Events by Category\",\n    \"showArea\": true,\n    \"curveType\": \"smooth\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/map-bounds.json
+++ b/static/widget-schema/map-bounds.json
@@ -52,6 +52,6 @@
         "type": "string"
       }
     },
-    "description": "Interactive Mapbox map that syncs viewport bounds [west, south, east, north] with a canvas parameter. Supports auto-send on pan/zoom or manual send via button."
+    "description": "Interactive Mapbox map that syncs viewport bounds [west, south, east, north] with a canvas parameter. Supports auto-send on pan/zoom or manual send via button.\n\n## Example\n\n```json\n{\n  \"type\": \"map-bounds\",\n  \"props\": {\n    \"param\": \"viewport\",\n    \"centerLng\": -74,\n    \"centerLat\": 40.7,\n    \"zoom\": 12,\n    \"autoSend\": true\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/map-h3.json
+++ b/static/widget-schema/map-h3.json
@@ -140,6 +140,6 @@
         "type": "string"
       }
     },
-    "description": "Interactive map that emits the H3 hex cell at the map center. Resolution can be fixed or auto-derived from zoom."
+    "description": "Interactive map that emits the H3 hex cell at the map center. Resolution can be fixed or auto-derived from zoom.\n\n## Example — auto-resolution, send on move\n\n```json\n{\n  \"type\": \"map-h3\",\n  \"props\": {\n    \"param\": \"hex_id\",\n    \"autoSend\": true,\n    \"sendOnMove\": true\n  }\n}\n```\n\n## Example — fixed resolution\n\n```json\n{\n  \"type\": \"map-h3\",\n  \"props\": {\n    \"param\": \"hex_id\",\n    \"h3Res\": 7,\n    \"centerLng\": -74,\n    \"centerLat\": 40.7\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/map.json
+++ b/static/widget-schema/map.json
@@ -57,6 +57,10 @@
                     "type": "string"
                   },
                   "additionalProperties": {}
+                },
+                "tile": {
+                  "description": "Connect as tile mode. By default layers connect as viewport (fetches data for the current map view as a single request).",
+                  "type": "boolean"
                 }
               },
               "required": [
@@ -80,11 +84,16 @@
           "satellite",
           "blank"
         ]
+      },
+      "autoFit": {
+        "default": true,
+        "description": "Automatically fit the map viewport to the loaded data bounds. When true, the map zooms to show all data after each UDF execution.",
+        "type": "boolean"
       }
     },
     "required": [
       "layers"
     ],
-    "description": "Interactive Mapbox map that syncs viewport bounds [west, south, east, north] with a canvas parameter. Supports auto-send on pan/zoom or manual send via button."
+    "description": "Interactive Mapbox map that renders live UDF layers. Pass UDF names as strings or layer config objects in the layers array.\n\n## Example\n\n```json\n{\n  \"type\": \"map\",\n  \"props\": {\n    \"layers\": [\"my_udf\"],\n    \"centerLng\": -74,\n    \"centerLat\": 40.7,\n    \"zoom\": 12\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/metric.json
+++ b/static/widget-schema/metric.json
@@ -51,6 +51,6 @@
         "type": "string"
       }
     },
-    "description": "Metric card for dashboards. Shows a single large formatted value from SQL, $param substitution in value, or a static value."
+    "description": "Metric card for dashboards. Shows a single large formatted value from SQL, $param substitution in value, or a static value.\n\n## Example — SQL\n\n```json\n{\n  \"type\": \"metric\",\n  \"props\": {\n    \"sql\": \"SELECT COUNT(*) FROM {{my_udf}}\",\n    \"label\": \"Total Records\",\n    \"format\": \"compact\"\n  }\n}\n```\n\n## Example — static / param\n\n```json\n{\n  \"type\": \"metric\",\n  \"props\": {\n    \"value\": \"$record_count\",\n    \"label\": \"Records\",\n    \"suffix\": \" rows\",\n    \"format\": \"comma\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/number-input.json
+++ b/static/widget-schema/number-input.json
@@ -46,6 +46,6 @@
         "type": "string"
       }
     },
-    "description": "A numeric input that can optionally sync valid number values with canvas parameters. If param is provided, syncs with that parameter or form; otherwise works as a regular number input."
+    "description": "A numeric input that can optionally sync valid number values with canvas parameters. If param is provided, syncs with that parameter or form; otherwise works as a regular number input.\n\n## Example\n\n```json\n{\n  \"type\": \"number-input\",\n  \"props\": {\n    \"label\": \"Max price\",\n    \"param\": \"max_price\",\n    \"min\": 0,\n    \"max\": 1000,\n    \"step\": 50,\n    \"defaultValue\": 500\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/scatter-chart.json
+++ b/static/widget-schema/scatter-chart.json
@@ -98,6 +98,6 @@
     "required": [
       "sql"
     ],
-    "description": "A scatter chart powered by DuckDB SQL. Query must return x and y numeric columns."
+    "description": "A scatter chart powered by DuckDB SQL. Query must return x and y numeric columns.\n\n## Example\n\n```json\n{\n  \"type\": \"scatter-chart\",\n  \"props\": {\n    \"sql\": \"SELECT price AS x, rating AS y FROM {{listings}}\",\n    \"title\": \"Price vs. Rating\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/slider.json
+++ b/static/widget-schema/slider.json
@@ -38,6 +38,7 @@
         "description": "Inline CSS styles as a plain CSS string (e.g., \"color: red; font-size: 16px\")",
         "type": "string"
       }
-    }
+    },
+    "description": "A slider that syncs with canvas parameters. Works standalone or nested inside a `form`. Broadcasts value changes on a debounced basis.\n\n## Example\n\n```json\n{\n  \"type\": \"slider\",\n  \"props\": {\n    \"label\": \"Max price\",\n    \"param\": \"max_price\",\n    \"min\": 0,\n    \"max\": 1000,\n    \"step\": 50,\n    \"defaultValue\": 500\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/sql-runner.json
+++ b/static/widget-schema/sql-runner.json
@@ -27,6 +27,6 @@
       "sql",
       "name"
     ],
-    "description": "Runs a DuckDB query and exposes its result as a named SQL source to descendant components."
+    "description": "Runs a DuckDB query and exposes its result as a named SQL source to descendant components. Children reference the result via {{name}}.\n\n## Example\n\n```json\n{\n  \"type\": \"sql-runner\",\n  \"props\": {\n    \"name\": \"filtered_data\",\n    \"sql\": \"SELECT * FROM {{my_udf}} WHERE price < $max_price\",\n    \"maxRows\": 10000\n  },\n  \"children\": [\n    { \"type\": \"bar-chart\", \"props\": { \"sql\": \"SELECT category AS label, COUNT(*) AS value FROM {{filtered_data}} GROUP BY 1\" } }\n  ]\n}\n```"
   }
 }

--- a/static/widget-schema/sql-table.json
+++ b/static/widget-schema/sql-table.json
@@ -76,6 +76,6 @@
     "required": [
       "sql"
     ],
-    "description": "Renders the results of a DuckDB SQL query in a table similar to the UDF node Data Table. Supports {{udf_name}} placeholders and $param_name canvas parameters. Optional AI chat can author the SQL for you."
+    "description": "Renders the results of a DuckDB SQL query in a table similar to the UDF node Data Table. Supports {{udf_name}} placeholders and $param_name canvas parameters. Optional AI chat can author the SQL for you.\n\n## Example\n\n```json\n{\n  \"type\": \"sql-table\",\n  \"props\": {\n    \"sql\": \"SELECT * FROM {{my_udf}} WHERE city = $city LIMIT 100\",\n    \"title\": \"Results\",\n    \"sortable\": true,\n    \"maxRows\": 500\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/stacked-area-chart.json
+++ b/static/widget-schema/stacked-area-chart.json
@@ -94,6 +94,6 @@
     "required": [
       "sql"
     ],
-    "description": "A stacked area chart powered by DuckDB SQL. Query should return label, series, and value."
+    "description": "A stacked area chart powered by DuckDB SQL. Query should return label, series, and value.\n\n## Example\n\n```json\n{\n  \"type\": \"stacked-area-chart\",\n  \"props\": {\n    \"sql\": \"SELECT month AS label, revenue AS value, category AS series FROM {{sales}} ORDER BY 1\",\n    \"title\": \"Revenue by Category\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/stacked-bar-chart.json
+++ b/static/widget-schema/stacked-bar-chart.json
@@ -66,6 +66,6 @@
     "required": [
       "sql"
     ],
-    "description": "A stacked bar chart powered by DuckDB SQL. Query should return label, series, and value."
+    "description": "A stacked bar chart powered by DuckDB SQL. Query should return label, series, and value.\n\n## Example\n\n```json\n{\n  \"type\": \"stacked-bar-chart\",\n  \"props\": {\n    \"sql\": \"SELECT quarter AS label, revenue AS value, region AS series FROM {{sales}} ORDER BY 1\",\n    \"title\": \"Revenue by Region\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/text-area.json
+++ b/static/widget-schema/text-area.json
@@ -62,6 +62,6 @@
         "type": "string"
       }
     },
-    "description": "A multi-line text input that can optionally sync with canvas parameters. If param is provided, syncs with that parameter or form; otherwise works as a regular text area."
+    "description": "A multi-line text input that can optionally sync with canvas parameters. If param is provided, syncs with that parameter or form; otherwise works as a regular text area.\n\n## Example\n\n```json\n{\n  \"type\": \"text-area\",\n  \"props\": {\n    \"label\": \"Notes\",\n    \"param\": \"notes\",\n    \"placeholder\": \"Enter notes...\",\n    \"rows\": 4\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/text-input.json
+++ b/static/widget-schema/text-input.json
@@ -51,6 +51,6 @@
         "type": "string"
       }
     },
-    "description": "A text input field that can optionally sync with canvas parameters. If param is provided, syncs with that parameter or form; otherwise works as a regular input."
+    "description": "A text input field that can optionally sync with canvas parameters. If param is provided, syncs with that parameter or form; otherwise works as a regular input.\n\n## Example\n\n```json\n{\n  \"type\": \"text-input\",\n  \"props\": {\n    \"label\": \"Search\",\n    \"param\": \"search_query\",\n    \"placeholder\": \"Enter search term...\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/text.json
+++ b/static/widget-schema/text.json
@@ -35,6 +35,6 @@
         "type": "string"
       }
     },
-    "description": "Displays text values. Can show static values, dynamic values from message parameters, or results from DuckDB SQL queries. Priority: sql > value."
+    "description": "Displays text values. Can show static values, dynamic values from message parameters, or results from DuckDB SQL queries. Priority: sql > value.\n\n## Example — static / param\n\n```json\n{\n  \"type\": \"text\",\n  \"props\": {\n    \"value\": \"Selected city: $city\",\n    \"variant\": \"h3\"\n  }\n}\n```\n\n## Example — SQL\n\n```json\n{\n  \"type\": \"text\",\n  \"props\": {\n    \"sql\": \"SELECT COUNT(*) || ' records' FROM {{my_udf}}\",\n    \"variant\": \"muted\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/transformer.json
+++ b/static/widget-schema/transformer.json
@@ -26,6 +26,6 @@
       "param",
       "method"
     ],
-    "description": "Non-visual component that runs JavaScript in a sandboxed iframe and broadcasts the return value to a canvas param. Use $param_name to inject canvas param values and {{udf_name}} to inject UDF result rows. UDF data is substituted as a JSON object of column arrays, e.g. {\"col1\":[\"a\",\"b\"],\"col2\":[1,2]}. The method string should be a self-invoking arrow function, e.g. \"()=>{ return $input; }\"."
+    "description": "Non-visual component that runs JavaScript in a sandboxed iframe and broadcasts the return value to a canvas param. Use $param_name to inject canvas param values and {{udf_name}} to inject UDF result rows. UDF data is substituted as a JSON object of column arrays. The method string must be a no-argument arrow function that explicitly returns a value.\n\n## Example\n\n```json\n{\n  \"type\": \"transformer\",\n  \"props\": {\n    \"param\": \"price_tier\",\n    \"method\": \"() => { const p = Number($max_price); if (p <= 100) return 'Budget'; if (p <= 300) return 'Mid-range'; return 'Luxury'; }\"\n  }\n}\n```"
   }
 }

--- a/static/widget-schema/video.json
+++ b/static/widget-schema/video.json
@@ -1,0 +1,68 @@
+{
+  "type": "video",
+  "description": "Display a video from a URL, base64 data URL, or signable storage path.",
+  "hasChildren": false,
+  "propsSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "src": {
+        "type": "string",
+        "description": "Video URL, base64 data URL, or signable storage path (e.g., \"s3://bucket/clip.mp4\")"
+      },
+      "alt": {
+        "description": "Accessible description of the video",
+        "type": "string"
+      },
+      "objectFit": {
+        "default": "contain",
+        "description": "How the video fits its container",
+        "type": "string",
+        "enum": [
+          "contain",
+          "cover",
+          "fill",
+          "none",
+          "scale-down"
+        ]
+      },
+      "controls": {
+        "default": true,
+        "description": "Whether to show native playback controls",
+        "type": "boolean"
+      },
+      "autoPlay": {
+        "default": false,
+        "description": "Whether the video starts playing automatically",
+        "type": "boolean"
+      },
+      "loop": {
+        "default": false,
+        "description": "Whether the video loops after ending",
+        "type": "boolean"
+      },
+      "muted": {
+        "default": false,
+        "description": "Whether the video is muted (required for autoplay in most browsers)",
+        "type": "boolean"
+      },
+      "playsInline": {
+        "default": true,
+        "description": "Whether the video should play inline on mobile devices",
+        "type": "boolean"
+      },
+      "poster": {
+        "description": "Poster image URL shown before playback starts",
+        "type": "string"
+      },
+      "style": {
+        "description": "Inline CSS styles as a plain CSS string (e.g., \"border-radius: 8px\")",
+        "type": "string"
+      }
+    },
+    "required": [
+      "src"
+    ],
+    "description": "Displays a video from a URL, base64 data URL, or signable storage path."
+  }
+}

--- a/static/widget-schema/widget-builder.json
+++ b/static/widget-schema/widget-builder.json
@@ -86,6 +86,6 @@
     "required": [
       "defaultValue"
     ],
-    "description": "Renders a widget definition received via a canvas param or inline. Use \"$param_name\" to render whatever a dropdown (or other sender) broadcasts. Set showEditor to enable a live JSON editor panel."
+    "description": "Renders a widget definition received via a canvas param or inline. Use \"$param_name\" to render whatever a dropdown (or other sender) broadcasts. Set showEditor to enable a live JSON editor panel.\n\n## Example — from param\n\n```json\n{\n  \"type\": \"widget-builder\",\n  \"props\": {\n    \"defaultValue\": \"$widget_definition\",\n    \"showEditor\": true\n  }\n}\n```\n\n## Example — inline definition\n\n```json\n{\n  \"type\": \"widget-builder\",\n  \"props\": {\n    \"defaultValue\": {\n      \"type\": \"metric\",\n      \"props\": { \"sql\": \"SELECT COUNT(*) FROM {{my_udf}}\", \"label\": \"Total rows\" }\n    },\n    \"showEditor\": false\n  }\n}\n```"
   }
 }


### PR DESCRIPTION
Auto-generated widget schema sync.

Source: [`fusedlabs/application@9317c70e5436b581e5165bded55a223504d04654`](https://github.com/fusedlabs/application/commit/9317c70e5436b581e5165bded55a223504d04654)

This PR is opened automatically whenever widget component definitions change
in `fusedlabs/application`. Merge after reviewing the diff in
`static/widget-schema/`.

To trigger manually: re-run the
[Sync widget schemas to fused-docs](https://github.com/fusedlabs/application/actions/workflows/sync-widget-schemas.yml)
workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only JSON under static/widget-schema; no application runtime changes in this repo.
> 
> **Overview**
> Syncs **widget JSON schemas** in `static/widget-schema/` from `fusedlabs/application` so docs, LLM context, and `/widget-api` pages stay aligned with the app.
> 
> **New widget types:** `kepler-map` (Kepler.gl for a UDF via `{{udf_N}}` or name) and `video` (URL, data URL, or signable storage path with playback props).
> 
> **Schema updates:** `map` gains layer `tile` mode and `autoFit`, and its description now targets live UDF layers instead of bounds-sync wording. `image` documents signable paths (e.g. `s3://…`) alongside URLs and base64.
> 
> **Docs pass:** Most existing schemas get longer `propsSchema.description` text with **## Example** JSON blocks; a few props are clarified (`button` param behavior, `transformer` `method` shape). `slider.json` fixes a small JSON structure issue and adds a schema-level description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 834da87dea608ec7aa4d8acaf00970a46151080f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->