### PR TITLE
fix(widget-api): remove duplicate h1 heading on widget pages

### DIFF
--- a/src/components/WidgetSchemaPage.tsx
+++ b/src/components/WidgetSchemaPage.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import type { WidgetSchemaFile } from "@site/src/components/WidgetSchemaDocs";
 import WidgetSchemaDocs from "@site/src/components/WidgetSchemaDocs";
-import { widgetLabel } from "@site/src/lib/widget-api-labels";
 
 const schemaContext = require.context(
   "../../static/widget-schema",
@@ -19,12 +18,5 @@ type Props = {
 
 export default function WidgetSchemaPage({ slug }: Props): React.ReactElement {
   const schema = loadSchema(slug);
-  const title = widgetLabel(slug);
-
-  return (
-    <>
-      <h1>{title}</h1>
-      <WidgetSchemaDocs schema={schema} />
-    </>
-  );
+  return <WidgetSchemaDocs schema={schema} />;
 }


### PR DESCRIPTION
Docusaurus renders the page title from frontmatter as an h1 automatically. WidgetSchemaPage was also rendering its own h1, causing every widget API page to show the title twice. Fix: remove the manual h1 and the now-unused widgetLabel import.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change on docs pages with no auth, data, or API behavior impact.
> 
> **Overview**
> Fixes **duplicate page titles** on widget API schema pages by stopping `WidgetSchemaPage` from rendering its own `<h1>`.
> 
> Docusaurus already injects the title from frontmatter as the main heading, so the component now only loads the schema and renders **`WidgetSchemaDocs`**, and drops the unused **`widgetLabel`** import that fed the extra heading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df18cbc860d986f22fcc7013f8b02afb95c46f77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->