### PR TITLE
docs(widgets): add raster layer example to map widget

### DIFF
--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -495,6 +495,54 @@ def udf(
 }
 ```
 
+#### Raster layers
+
+A `map` layer can also render a **raster**. Return an image array from a tiled UDF and style it with a `rasterLayer` ([`BitmapLayer`](https://deck.gl/docs/api-reference/layers/bitmap-layer)) `vizConfig` — `tileLayer` fetches the tiles, `rasterLayer` paints the array. Paste this into a UDF node named `bay_area_seismic_raster`:
+
+<details>
+<summary><code>bay_area_seismic_raster</code></summary>
+
+```python
+@fused.udf
+def udf(
+    bounds: fused.types.Bounds = [-122.6, 37.2, -121.7, 38.0],
+    path: str = "s3://fused-asset/demos/seismic_data/v2023_1_pga_475_rock_3min.tif",
+):
+    common = fused.load("https://github.com/fusedio/udfs/tree/fbf5682/public/common/")
+    tile = common.get_tiles(bounds, zoom=common.estimate_zoom(bounds))
+    arr = common.read_tiff(tile, input_tiff_path=path)
+    return common.arr_to_plasma(arr.filled(0), min_max=(0, 1.5))
+```
+
+</details>
+
+```json
+{
+  "type": "map",
+  "props": {
+    "label": "SF Bay Area seismic hazard (raster)",
+    "centerLng": -122.2,
+    "centerLat": 37.6,
+    "zoom": 8.5,
+    "mapStyle": "dark",
+    "layers": [
+      {
+        "udf": "{{bay_area_seismic_raster}}",
+        "tile": true,
+        "vizConfig": {
+          "tileLayer": { "@@type": "TileLayer", "minZoom": 0, "maxZoom": 19, "tileSize": 256 },
+          "rasterLayer": { "@@type": "BitmapLayer", "opacity": 0.8, "pickable": true }
+        }
+      }
+    ]
+  }
+}
+```
+
+:::tip
+`layers` is an array — stack as many as you like, e.g. tiled building footprints beneath a direct polygon overlay. The [Map widget canvas](https://www.fused.io/canvas/fc_fused/map_widget_canvas) has live examples of combined layers and raster tilesets (`fused-map` `raster`).
+:::
+
 ### `fused-map` — SQL layers and tilesets
 
 `fused-map` adds Mapbox layer types and accepts more data shapes than `map`. The example below runs SQL over a **plain DataFrame** and plots its lat/lng columns. Paste this into a UDF node named `sf_listings`:

--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -497,7 +497,7 @@ def udf(
 
 #### Raster layers
 
-A `map` layer can also render a **raster**. Return an image array from a tiled UDF and style it with a `rasterLayer` ([`BitmapLayer`](https://deck.gl/docs/api-reference/layers/bitmap-layer)) `vizConfig` — `tileLayer` fetches the tiles, `rasterLayer` paints the array. Paste this into a UDF node named `bay_area_seismic_raster`:
+A `map` widget can also render a **raster**. Return an image array from a tiled UDF and style it with a `rasterLayer` ([`BitmapLayer`](https://deck.gl/docs/api-reference/layers/bitmap-layer)) `vizConfig` — `tileLayer` fetches the tiles, `rasterLayer` paints the array. Paste this into a UDF node named `bay_area_seismic_raster`:
 
 <details>
 <summary><code>bay_area_seismic_raster</code></summary>


### PR DESCRIPTION
Adds raster coverage to the **Map widgets** section of the import-connection widgets guide, kept short and glanceable to match the existing examples.

## What changed
- New **Raster layers** subsection under the `map` widget — one complete example: a tiled UDF (`bay_area_seismic_raster`) returning an image array, styled with a `rasterLayer` (deck.gl `BitmapLayer`) alongside `tileLayer`.
- A short tip noting `layers` is an array (combine multiple layers — e.g. tiled footprints under a direct polygon overlay) and pointing to the [Map widget canvas](https://www.fused.io/canvas/fc_fused/map_widget_canvas) for the combined-layer and `fused-map` raster examples.

These mirror sections already live on the map widget canvas.

## Testing
- `uv run utils/test_doc_snippets.py docs/.../widgets.mdx` — 8 Python blocks syntax-valid
- `npm run build` — full SSG build succeeds, 0 broken links
- Raster UDF runs via `fused run` and returns a colorized array; widget JSON passes `fused json-ui validate`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the widgets guide; no runtime or API behavior changes.
> 
> **Overview**
> Adds a **Raster layers** subsection to the `map` widget docs in `widgets.mdx`, alongside the existing vector and tiled-vector examples.
> 
> The new content documents tiled rasters: a sample UDF (`bay_area_seismic_raster`) that reads a GeoTIFF and returns a colorized array, plus matching `map` widget JSON using `tileLayer` with `rasterLayer` (`BitmapLayer`). A short tip clarifies that `layers` can be stacked and links to the Map widget canvas for combined-layer and `fused-map` raster demos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f34a00a69e660a034b5f51647fe9e7ac44492ab3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->