### PR TITLE
docs(gdrive): note that users must grant the parent folder, not just …

### DIFF
--- a/docs/workbench/integrations/gdrive.mdx
+++ b/docs/workbench/integrations/gdrive.mdx
@@ -27,6 +27,13 @@ Complete the Google OAuth consent screen. Once connected, the panel shows your a
 
 Fused uses the `drive.file` scope — it can only access files and folders you explicitly grant through the **Choose files and folders** picker in Workbench. Files added to Drive after the initial grant will not appear until re-granted via the Picker.
 
+:::warning Grant the folder, not just files inside it
+
+The `drive.file` scope is per-object: granting a file does **not** grant the folder that contains it. A file granted on its own is still readable directly by its `gdrive://<file_id>/<name>` path, but it will **not** appear when you browse or `fused.api.list()` its parent folder — a folder you have not granted cannot be listed.
+
+To browse into a folder and see its files in Workbench, grant the **folder** through the **Choose files and folders** picker — not only the individual files within it.
+:::
+
 ---
 
 ### `gdrive://` path format


### PR DESCRIPTION
…a file

Under the drive.file scope, granting a single file does not grant its containing folder. Such a file stays readable by its direct gdrive:// path but won't appear when browsing/listing its parent folder, which is confusing. Add a warning telling users to grant the folder in the Picker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Adds a **warning** callout in the Google Drive integration docs (step 2, Picker setup) explaining how **`drive.file`** behaves per object.
> 
> Users who grant only individual files can still read them via direct **`gdrive://<file_id>/<name>`** paths, but those files **won’t show up** when browsing or calling **`fused.api.list()`** on the parent folder unless the **folder itself** was granted in **Choose files and folders**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f9c9a549d70dd2edbfcfec80c4a1747caceae39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->