### PR TITLE
update job logs page

### DIFF
--- a/docs/workbench/jobs.mdx
+++ b/docs/workbench/jobs.mdx
@@ -12,4 +12,4 @@ sidebar_position: 2
 Each job includes detailed information such as Logs, Metrics, Code, and Status History, allowing you to monitor and review execution results.
 
 
-<LazyReactPlayer url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/jobs.mp4" />
+<LazyReactPlayer url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/jobs2.mp4" />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only URL change for an embedded video; no application or security impact.
> 
> **Overview**
> Updates the **Job logs** docs walkthrough video to use the new `jobs2.mp4` asset instead of `jobs.mp4` on the existing `LazyReactPlayer` embed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f2005545648b8983944941a6c12e886740f19b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->