### PR TITLE
docs(widgets): document single-value UDF accessor syntax

### DIFF
--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -215,6 +215,8 @@ SELECT product AS label, revenue AS value FROM {{udf_1?product=$name}}
 
 The `text-input` widget publishes its value under `param: "name"`. The bar chart reads it as `$name` and passes it to `udf_1` on every keystroke.
 
+You can also pull a **single value** out of a UDF's output inline (outside SQL — for example in a `text` widget's `value`) with `{{ udf_name.column[row] }}`, optionally passing parameters — e.g. `{{ udf_1.col_name[0]?param=100 }}` runs `udf_1` and resolves to one cell of the returned table.
+
 <ClickZoomImage src="/img/widgets/parameterize-udf-widget.png" alt="Input widget filtering bar chart by passing $name into udf_1 at query time" />
 
 ## AI driven Widget

--- a/docs/guide/data-input-outputs/import-connection/widgets.mdx
+++ b/docs/guide/data-input-outputs/import-connection/widgets.mdx
@@ -215,7 +215,7 @@ SELECT product AS label, revenue AS value FROM {{udf_1?product=$name}}
 
 The `text-input` widget publishes its value under `param: "name"`. The bar chart reads it as `$name` and passes it to `udf_1` on every keystroke.
 
-You can also pull a **single value** out of a UDF's output inline (outside SQL — for example in a `text` widget's `value`) with `{{ udf_name.column[row] }}`, optionally passing parameters — e.g. `{{ udf_1.col_name[0]?param=100 }}` runs `udf_1` and resolves to one cell of the returned table.
+You can also reference a UDF's output **inline** — outside SQL, for example in a [`text`](/widget-api/text) widget's `value`. Use `{{ udf_name.column_name }}` to pull any column from the UDF's output, and add `[row]` to select a specific element by its row index (any row, not just the first). Append `?param=value` to run the UDF with that parameter before reading from it. For example, `{{ udf_1.col_name[0]?param=100 }}` runs `udf_1` with `param=100`, then resolves to the first value of its `col_name` column.
 
 <ClickZoomImage src="/img/widgets/parameterize-udf-widget.png" alt="Input widget filtering bar chart by passing $name into udf_1 at query time" />
 


### PR DESCRIPTION
## What

Adds a line to the **Passing parameters to a UDF in SQL** section of the Widgets guide documenting the inline single-value accessor: `{{ udf_name.column[row] }}` (with optional `?param=`). This pulls one cell out of a UDF output — e.g. in a `text` widget's `value` — and wasn't documented before.

Closes the docs task in ITEM-11425.

## Testing

- `fused run "" udf.py --value=100` on a dummy UDF returned `col_name[0] = 1000`, confirming param-passing + column/row extraction at the data layer.
- The application's `inline-substitution` parser and its unit tests explicitly cover `{{udf_1.col_name[0]?param=100}}` (and `["col"]`, `[$dynamicCol]`, `[$index]` variants), resolving to the expected column/row with the param applied.
- The `text` widget schema documents `{{udf_name}}` placeholder support in `value`.

No new links or code blocks, so no build/link surface changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Documents **inline UDF output references** in the Widgets guide’s “Passing parameters to a UDF in SQL” section, complementing the existing SQL `{{udf?param=}}` and `$param` patterns.
> 
> The new paragraph explains using `{{ udf_name.column_name }}` with optional `[row]` indexing and `?param=value` (e.g. `{{ udf_1.col_name[0]?param=100 }}`) in non-SQL props such as a [`text`](/widget-api/text) widget’s `value`, so a single cell from a parameterized UDF run can drive widget content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a04d29faaaa1798ada15ec26b2eeb8046d1301b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->