### PR TITLE
docs: explain 'serverless' in plain language on intro pages

### DIFF
--- a/docs/guide/overview.mdx
+++ b/docs/guide/overview.mdx
@@ -8,7 +8,7 @@ slug: /guide/guide-overview
 
 # What is Fused?
 
-Fused is the glue between your data and the tools that consume it: write Python functions that run serverlessly at scale, and expose them as secure HTTP endpoints. No containers, no infrastructure config, no waiting.
+Fused is the glue between your data and the tools that consume it: write Python functions that run serverlessly — on our cloud, with no servers for you to set up or manage — and expose them as secure HTTP endpoints. No containers, no infrastructure config, no waiting.
 
 <img src="/img/what-is-fused/overview-diagram.png" alt="Fused Overview" style={{width: '75%', display: 'block', margin: '20px auto'}} />
 
@@ -24,7 +24,7 @@ We ship an opinionated and tested set of dependencies that covers most modern da
 
 ## Scalable serverless engine
 
-Python alone isn't enough. Scaling up compute on demand normally means deploying a new Docker container. Fused lets you create **User Defined Functions (UDFs)**: simple, self-contained Python functions that run on our serverless compute infrastructure. All you need is a `@fused.udf` decorator:
+Python alone isn't enough. Scaling up compute on demand normally means deploying a new Docker container. Fused lets you create **User Defined Functions (UDFs)**: simple, self-contained Python functions that run on our cloud. **Serverless** just means you never provision, configure, or pay for an idle machine — Fused spins up exactly the compute each run needs, then shuts it down. All you need is a `@fused.udf` decorator:
 
 ```python
 @fused.udf

--- a/docs/guide/working-with-udfs/why-fused.mdx
+++ b/docs/guide/working-with-udfs/why-fused.mdx
@@ -68,7 +68,7 @@ Look, we know that many Analytics projects start in a notebook on a laptop.
 ## Efficiently Scaling
 
 Because Fused is built for scale:
-- ☁️ [Serverless computing](/guide/working-with-udfs/udf-best-practices/realtime): Only pay for the processing you actually use
+- ☁️ [Serverless computing](/guide/working-with-udfs/udf-best-practices/realtime): No servers to provision or keep running — Fused spins up compute when your code runs and shuts it down when it's done, so you only pay for the processing you actually use
 - ⚡️ [Caching](/guide/working-with-udfs/udf-best-practices/caching) makes recurring calls faster & cheaper
 
 ## Get started using UDFs right now


### PR DESCRIPTION
@
## What

The word **serverless** is the first thing a newcomer reads on the "What is Fused?" page, but it was never explained. This adds a plain-language gloss the first time the term appears, so readers who dont already know the concept arent lost.

## Changes

- **`guide/overview.mdx`** (opening sentence): glosses "serverlessly" inline — *"on our cloud, with no servers for you to set up or manage."*
- **`guide/overview.mdx`** ("Scalable serverless engine" section): defines the term plainly — *"Serverless just means you never provision, configure, or pay for an idle machine — Fused spins up exactly the compute each run needs, then shuts it down."*
- **`working-with-udfs/why-fused.mdx`**: expands the bullet to say what "only pay for what you use" actually means — *"No servers to provision or keep running."*

Wording only; no structural or code changes.
@

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation copy edits only; no runtime, security, or application behavior changes.
> 
> **Overview**
> Adds **plain-language explanations** of *serverless* on newcomer-facing docs so readers are not left guessing what the term means.
> 
> On **`guide/overview.mdx`**, the opening line now clarifies that functions run **on Fused’s cloud with no servers to set up or manage**, and the **Scalable serverless engine** section spells out that serverless means **no provisioning idle machines** — compute spins up per run and shuts down afterward.
> 
> On **`why-fused.mdx`**, the serverless bullet under **Efficiently Scaling** is expanded to say **no servers to provision or keep running**, tying that to pay-for-what-you-use wording.
> 
> **Wording only** — no structural, API, or code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2d5b54333a3026f9f8c340472ff050c558d5356. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->