### PR TITLE
chore: sync widget schemas (application@5ac53f531b505977edd57dcd0dd197ba56dc054b)

### DIFF
--- a/static/widget-schema/map.json
+++ b/static/widget-schema/map.json
@@ -87,7 +87,7 @@
       },
       "autoFit": {
         "default": true,
-        "description": "Automatically fit the map viewport to the loaded data bounds. When true, the map zooms to show all data after each UDF execution.",
+        "description": "Automatically fit the map viewport to the loaded data bounds. When true, the map zooms once to frame the union of all layers' data after they first load, then leaves the viewport under user control (it does not re-fit on later pans or re-runs). When false, the map opens at centerLng/centerLat/zoom.",
         "type": "boolean"
       }
     },


### PR DESCRIPTION
Auto-generated widget schema sync.

Source: [`fusedlabs/application@5ac53f531b505977edd57dcd0dd197ba56dc054b`](https://github.com/fusedlabs/application/commit/5ac53f531b505977edd57dcd0dd197ba56dc054b)

This PR is opened automatically whenever widget component definitions change
in `fusedlabs/application`. Merge after reviewing the diff in
`static/widget-schema/`.

To trigger manually: re-run the
[Sync widget schemas to fused-docs](https://github.com/fusedlabs/application/actions/workflows/sync-widget-schemas.yml)
workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in synced widget schema; no runtime or API behavior in this repo.
> 
> **Overview**
> Syncs the **`map`** widget schema from `fusedlabs/application` with a documentation-only update to **`autoFit`**.
> 
> The **`autoFit`** property description now states that when enabled the map **fits once** to the union of all layers’ bounds after their **first load**, then **does not** re-fit on pans or later UDF re-runs; when disabled it documents that the map uses **`centerLng` / `centerLat` / `zoom`** instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c1861f72dc3d066a17e1b63cec7164f558a3ead. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->