### PR TITLE
update secrets mgmt page

### DIFF
--- a/docs/guide/advanced-setup/environment-variables.mdx
+++ b/docs/guide/advanced-setup/environment-variables.mdx
@@ -17,7 +17,10 @@ Open the **Integrations & secrets** modal in Workbench:
 - From the **home** sidebar, click **Integrations & secrets** under your user section.
 - From inside a **canvas**, open the overflow menu and select **Integrations & secrets**.
 
-The modal has separate **Team secrets** and **Personal secrets** sections. In either section, click **Add new secret** to store a key-value pair.
+The modal is organized into **Personal integrations** and **Team integrations**.
+
+Each integration contains expandable rows for secrets (e.g. Google Drive, Dropbox, Notion).  
+To manage secrets, first expand the relevant integration row, then click **Add new secret** inside the expanded section.
 
 ## Team secrets — `fused.secrets`
 

--- a/docs/workbench/profile.mdx
+++ b/docs/workbench/profile.mdx
@@ -5,9 +5,9 @@ tags: [profile, usage, account]
 sidebar_position: 4
 ---
 
-The Profile page in Workbench lets you edit your username, view account information, monitor usage, and manage your S3 bucket policy. Navigate to it from the Workbench sidebar under your **Account > Profile**.
+The Profile page in Workbench lets you edit your username, view account information, monitor usage, and manage your S3 bucket policy. Navigate to the Profile page from the Workbench by clicking your avatar in the top-right corner and selecting **Profile**.
 
-The Profile page has three tabs: **Usage**, **Debug**, and **S3 Policy**.
+The Profile page has two tabs: **Usage** and **Debug**.
 
 <LazyReactPlayer url="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/docs_rewrite/profile.mp4" />
 
@@ -29,12 +29,6 @@ For details on plans and pricing, see the [Fused pricing page](https://www.fused
 ## Billing
 
 You can upgrade your subscription tier directly from the Profile page. Upgrading gives you dedicated compute resources and higher usage limits. See [Free Tier](/workbench/free-tier) for details on what's included in the free plan, or visit the [pricing page](https://www.fused.io/pricing) to compare plans.
-
-## S3 Policy
-
-The **S3 Policy** tab generates a bucket policy that grants Fused access to your S3 bucket. Copy the generated policy and apply it to your bucket in the AWS console.
-
-For more on connecting S3 buckets, see [Connect your own bucket](/workbench/file-explorer/#connect-your-own-bucket).
 
 ## Debug
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security logic impact; other docs may still reference the removed S3 Policy tab on Profile.
> 
> **Overview**
> Updates Workbench docs to match the current **Integrations & secrets** and **Profile** UI.
> 
> The secrets guide now describes **Personal integrations** / **Team integrations** with expandable per-integration rows (e.g. Google Drive, Dropbox, Notion) and instructs users to expand a row before **Add new secret**, instead of flat Team/Personal secret sections.
> 
> The Profile page doc changes navigation to the **avatar → Profile** path, states there are only **Usage** and **Debug** tabs, and **removes** the entire **S3 Policy** tab section and its link to connecting your own bucket.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a337c14ba81e7a34cf486fa7fbf606864cc5a778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->