### PR TITLE
docs(examples): point POI dashboard canvas links to fused.io

### DIFF
--- a/docs/examples/poi-site-selection-dashboard.mdx
+++ b/docs/examples/poi-site-selection-dashboard.mdx
@@ -9,13 +9,13 @@ This example builds an interactive site selection dashboard that answers: **"Wha
 
 We'll chain together multiple UDFs on a [Canvas](/workbench/udf-builder/canvas) to geocode an address, compute a travel-time boundary (isochrone), pull Points of Interest from [Overture Maps](https://overturemaps.org/) and median income from the [US Census](https://www.census.gov/programs-surveys/acs), aggregate everything into H3 hexagons, and display the results on a map with interactive [Widgets](/guide/data-input-outputs/import-connection/widgets).
 
-[![POI Site Selection Dashboard](https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/poi-dashboard-hero.gif)](https://unstable.fused.io/workbench/max/Dashboard_Overture_Census_Isochrone)
+[![POI Site Selection Dashboard](https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/poi-dashboard-hero.gif)](https://www.fused.io/canvas/fc_fused/Dashboard_Overture_Census_Isochrone)
 
-*Interactive dashboard showing POI density, isochrones, and income distribution for San Francisco. [Try it out](https://unstable.fused.io/workbench/max/Dashboard_Overture_Census_Isochrone) ->*
+*Interactive dashboard showing POI density, isochrones, and income distribution for San Francisco. [Try it out](https://www.fused.io/canvas/fc_fused/Dashboard_Overture_Census_Isochrone) ->*
 
 ## How to run
 
-Open the [Canvas](https://unstable.fused.io/workbench/max/Dashboard_Overture_Census_Isochrone), fill in the **Travel Settings** form (address, travel mode, POI category, travel time), and click **Submit**. The dashboard re-runs and shows a map with hexagons colored by POI density, the isochrone boundary, and the geocoded location for the address you entered, along with a bar chart of income distribution across the area.
+Open the [Canvas](https://www.fused.io/canvas/fc_fused/Dashboard_Overture_Census_Isochrone), fill in the **Travel Settings** form (address, travel mode, POI category, travel time), and click **Submit**. The dashboard re-runs and shows a map with hexagons colored by POI density, the isochrone boundary, and the geocoded location for the address you entered, along with a bar chart of income distribution across the area.
 
 ## What we're building
 
@@ -486,7 +486,7 @@ def udf(
 
 ### Live map preview
 
-Interact with the POI map below — hexagons are colored by POI density, with the isochrone boundary and geocoded point overlaid. [Try it out](https://unstable.fused.io/workbench/max/Dashboard_Overture_Census_Isochrone) ->
+Interact with the POI map below — hexagons are colored by POI density, with the isochrone boundary and geocoded point overlaid. [Try it out](https://www.fused.io/canvas/fc_fused/Dashboard_Overture_Census_Isochrone) ->
 
 <iframe
   src="https://unstable.udf.ai/fc_4fUqKOCoKL0gIX4YwgCk7z/selected_poi_map.html"

--- a/docs/examples/poi-site-selection-dashboard.mdx
+++ b/docs/examples/poi-site-selection-dashboard.mdx
@@ -9,7 +9,7 @@ This example builds an interactive site selection dashboard that answers: **"Wha
 
 We'll chain together multiple UDFs on a [Canvas](/workbench/udf-builder/canvas) to geocode an address, compute a travel-time boundary (isochrone), pull Points of Interest from [Overture Maps](https://overturemaps.org/) and median income from the [US Census](https://www.census.gov/programs-surveys/acs), aggregate everything into H3 hexagons, and display the results on a map with interactive [Widgets](/guide/data-input-outputs/import-connection/widgets).
 
-[![POI Site Selection Dashboard](https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/poi-dashboard-hero.gif)](https://www.fused.io/canvas/fc_fused/Dashboard_Overture_Census_Isochrone)
+<ClickZoomImage src="https://fused-magic.s3.us-west-2.amazonaws.com/workbench-walkthrough-videos/poi-dashboard-hero.gif" alt="POI Site Selection Dashboard" />
 
 *Interactive dashboard showing POI density, isochrones, and income distribution for San Francisco. [Try it out](https://www.fused.io/canvas/fc_fused/Dashboard_Overture_Census_Isochrone) ->*
 


### PR DESCRIPTION
Addresses ITEM-11001 — both asks from the ticket:

1. **Point canvas links to the public canvas.** Updated all four references in `docs/examples/poi-site-selection-dashboard.mdx` from `https://unstable.fused.io/workbench/max/Dashboard_Overture_Census_Isochrone` to `https://www.fused.io/canvas/fc_fused/Dashboard_Overture_Census_Isochrone`.

2. **Make the hero image zoomable.** Replaced the plain markdown hero image with the `<ClickZoomImage>` component (consistent with other docs pages). The canvas link is preserved via the "Try it out" caption directly below.

Verified with `npm run build` (passes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL and markup updates with no runtime or security impact.
> 
> **Overview**
> **POI Site Selection** example doc now points readers at the public canvas on `www.fused.io` instead of the old `unstable.fused.io/workbench/max/...` URL in the hero caption, **How to run**, and live map **Try it out** links.
> 
> The hero GIF is rendered with **`<ClickZoomImage>`** instead of a markdown-linked image. The embedded map **iframe** (`unstable.udf.ai`) is unchanged. A stray leading `-` on the **How to run** paragraph is removed so it renders as normal prose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ae4b02544d8e6037b40b7052f8671823d5775ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->