### PR TITLE
docs: update API reference for fused-py v2.8.0.4

### DIFF
--- a/docs/cli/canvas.mdx
+++ b/docs/cli/canvas.mdx
@@ -24,7 +24,7 @@ fused canvas [SUBCOMMAND] [OPTIONS]
 | `push` | Import a local canvas directory into a canvas. |
 | `rename` | Rename a canvas. |
 | `serve-mcp` | Serve a shared canvas OpenAPI as a local MCP server. |
-| `share` | Share a canvas and return its shareable URL. |
+| `share` | Share a canvas and return updated metadata. |
 | `unshare` | Unshare a canvas and return updated metadata. |
 | `validate` | Validate a canvas directory without running any UDFs. |
 
@@ -161,7 +161,7 @@ fused canvas serve-mcp CANVAS_REF [OPTIONS]
 
 ## `fused canvas share`
 
-Share a canvas and return its shareable URL.
+Share a canvas and return updated metadata.
 
 ```
 fused canvas share CANVAS_REF [OPTIONS]
@@ -172,7 +172,7 @@ fused canvas share CANVAS_REF [OPTIONS]
 | Flag | Description |
 |---|---|
 | `--client-id TEXT` | Override realtime client ID for share token generation. |
-| `--new-token` | Generate a new share token instead of reusing the existing one. This immediately invalidates the previous token, so any already-distributed link or embed stops working. |
+| `--new-token` | Generate a new share token instead of reusing an existing one. |
 | `--id` | Treat the provided reference as a canvas ID. |
 
 

--- a/docs/python-sdk/api-reference/api.mdx
+++ b/docs/python-sdk/api-reference/api.mdx
@@ -92,6 +92,18 @@ auth_scheme() -> str
 
 ---
 
+## daytona_connect
+
+```python
+daytona_connect() -> Daytona
+```
+
+Return an authenticated Daytona client for cloud development environments.
+
+The API key is read from `fused.secrets["DAYTONA_API_KEY"]`.
+
+---
+
 ## delete
 
 ```python
@@ -102,7 +114,7 @@ Delete the files at the path.
 
 **Parameters:**
 
-- **path** (`str`) – Directory or file to delete, like `fd://my-old-table/`
+- **path** (`str`) – Directory or file to delete, like `s3://fused-users/fused/aman/my-old-table/`
 - **max_deletion_depth** (`int | Literal['unlimited']`) – If set (defaults to 3), the maximum depth the operation will recurse to.
   This option is to help avoid accidentally deleting more data that intended.
   Pass `"unlimited"` for unlimited.
@@ -110,7 +122,7 @@ Delete the files at the path.
 **Examples:**
 
 ```python
-fused.api.delete("fd://bucket-name/deprecated_table/")
+fused.api.delete("s3://fused-users/fused/aman/deprecated_table/")
 ```
 
 ---
@@ -125,8 +137,23 @@ Download the contents at the path to disk.
 
 **Parameters:**
 
-- **path** (`str`) – URL to a file, like `fd://bucket-name/file.parquet`
+- **path** (`str`) – URL to a file, like `s3://fused-users/fused/aman/file.parquet`
 - **local_path** (`str | Path`) – Path to a local file.
+
+---
+
+## dropbox_connect
+
+```python
+dropbox_connect() -> FusedDropboxConnection
+```
+
+Create a Dropbox connection using Fused-managed OAuth.
+
+**Returns:**
+
+- **A** (`[FusedDropboxConnection](#fused.api._dropbox.FusedDropboxConnection)`) – class:`FusedDropboxConnection`. Call `.client()` for the official
+- `[FusedDropboxConnection](#fused.api._dropbox.FusedDropboxConnection)` – `dropbox.Dropbox` SDK client (requires `pip install dropbox`).
 
 ---
 
@@ -150,7 +177,7 @@ Download the contents at the path to memory.
 
 **Parameters:**
 
-- **path** (`str`) – URL to a file, like `fd://bucket-name/file.parquet`
+- **path** (`str`) – URL to a file, like `s3://fused-users/fused/aman/file.parquet`
 
 **Returns:**
 
@@ -159,7 +186,7 @@ Download the contents at the path to memory.
 **Examples:**
 
 ```python
-fused.api.get("fd://bucket-name/file.parquet")
+fused.api.get("s3://fused-users/fused/aman/file.parquet")
 ```
 
 ---
@@ -446,7 +473,7 @@ List the files at the path.
 
 **Parameters:**
 
-- **path** (`str`) – Parent directory URL, like `fd://bucket-name/`
+- **path** (`str`) – Parent directory URL, like `s3://fused-users/fused/aman/`
 - **details** (`bool`) – If True, return additional metadata about each record.
 
 **Returns:**
@@ -456,7 +483,7 @@ List the files at the path.
 **Examples:**
 
 ```python
-fused.api.list("fd://bucket-name/")
+fused.api.list("s3://fused-users/fused/aman/")
 ```
 
 ---
@@ -570,6 +597,33 @@ Create a Notion connection using Fused-managed OAuth.
 
 ---
 
+## onedrive_connect
+
+```python
+onedrive_connect() -> FusedOnedriveConnection
+```
+
+Create a OneDrive connection using Fused-managed OAuth (Microsoft Graph).
+
+**Returns:**
+
+- **A** (`[FusedOnedriveConnection](#fused.api._onedrive.FusedOnedriveConnection)`) – class:`FusedOnedriveConnection`. Call `.token()` for a short-lived Microsoft
+- `[FusedOnedriveConnection](#fused.api._onedrive.FusedOnedriveConnection)` – Graph access token, or use `.list()` / `.get()` / `.download()` helpers.
+
+---
+
+## openai_connect
+
+```python
+openai_connect() -> openai.OpenAI
+```
+
+Return an authenticated OpenAI client for GPT model inference.
+
+The API key is read from `fused.secrets["OPENAI_API_KEY"]`.
+
+---
+
 ## resolve
 
 ```python
@@ -666,7 +720,7 @@ This function may not check that the file represented by the path exists.
 
 **Parameters:**
 
-- **path** (`str`) – URL to a file, like `fd://bucket-name/file.parquet`
+- **path** (`str`) – URL to a file, like `s3://fused-users/fused/aman/file.parquet`
 
 **Returns:**
 
@@ -675,7 +729,7 @@ This function may not check that the file represented by the path exists.
 **Examples:**
 
 ```python
-fused.api.sign_url("fd://bucket-name/table_directory/file.parquet")
+fused.api.sign_url("s3://fused-users/fused/aman/table_directory/file.parquet")
 ```
 
 ---
@@ -690,7 +744,7 @@ Create signed URLs to access all blobs under the path.
 
 **Parameters:**
 
-- **path** (`str`) – URL to a prefix, like `fd://bucket-name/some_directory/`
+- **path** (`str`) – URL to a prefix, like `s3://fused-users/fused/aman/some_directory/`
 
 **Returns:**
 
@@ -699,7 +753,7 @@ Create signed URLs to access all blobs under the path.
 **Examples:**
 
 ```python
-fused.api.sign_url_prefix("fd://bucket-name/table_directory/")
+fused.api.sign_url_prefix("s3://fused-users/fused/aman/table_directory/")
 ```
 
 ---
@@ -795,7 +849,7 @@ Upload local file to S3.
   (which will get uploaded as Parquet file), or the contents to upload.
   Any string will be treated as a Path, if you wish to upload the contents of
   the string, first encode it: `s.encode("utf-8")`
-- **remote_path** (`str`) – URL to upload to, like `fd://new-file.txt`
+- **remote_path** (`str`) – URL to upload to, like `s3://fused-users/fused/aman/new-file.txt`
 - **timeout** (`float | None`) – Optional timeout in seconds for the upload (will default to `OPTIONS.request_timeout` if not specified).
 
 **Examples:**
@@ -803,7 +857,7 @@ Upload local file to S3.
 To upload a local json file to your Fused-managed S3 bucket:
 
 ```py
-fused.api.upload("my_file.json", "fd://my_bucket/my_file.json")
+fused.api.upload("my_file.json", "s3://fused-users/fused/aman/my_file.json")
 ```
 
 ---
@@ -1255,6 +1309,35 @@ Update one or more records (PATCH -- partial update).
 
 ---
 
+## Dropbox
+
+## FusedDropboxConnection
+
+## fused.api.FusedDropboxConnection
+
+Dropbox integration using Fused-managed OAuth tokens (PKCE refresh).
+
+---
+
+### client
+
+```python
+client() -> dropbox.Dropbox
+```
+
+Return an official `dropbox.Dropbox` client using Fused-managed OAuth.
+
+The client is constructed with the refresh token and app key, so the SDK
+refreshes access tokens itself (PKCE; no app secret required).
+
+Requires the `dropbox` package::
+
+```
+pip install dropbox
+```
+
+---
+
 ## Notion
 
 ## FusedNotionConnection
@@ -1446,6 +1529,72 @@ Update a page's properties or trash/restore it.
 - **page_id** (`str`) – Notion page ID.
 - **properties** (`dict[str, Any] | None`) – Property values to update.
 - **in_trash** (`bool | None`) – Set `True` to move to trash, `False` to restore.
+
+---
+
+## Onedrive
+
+## FusedOnedriveConnection
+
+## fused.api.FusedOnedriveConnection
+
+OneDrive connection using Fused-managed OAuth tokens (Microsoft Graph).
+
+---
+
+### download
+
+```python
+download(path: str) -> bytes
+```
+
+Download a file's bytes by its OneDrive path.
+
+---
+
+### get
+
+```python
+get(path: str, **kwargs: Any) -> dict[str, Any]
+```
+
+GET a Graph resource and return the parsed JSON.
+
+---
+
+### list
+
+```python
+list(folder: str = '') -> list[dict[str, Any]]
+```
+
+List the children of a OneDrive folder (drive root by default).
+
+Follows `@odata.nextLink` so folders with more than one Graph page are
+returned in full.
+
+---
+
+### request
+
+```python
+request(method: str, path: str, **kwargs: Any)
+```
+
+Make a Microsoft Graph request.
+
+`path` may be an absolute URL or a path relative to the Graph v1.0 base
+(e.g. `"me/drive/root/children"`).
+
+---
+
+### token
+
+```python
+token() -> str
+```
+
+Return a short-lived Microsoft Graph access token for the current user.
 
 ---
 

--- a/docs/python-sdk/api-reference/udf.mdx
+++ b/docs/python-sdk/api-reference/udf.mdx
@@ -176,7 +176,9 @@ Retrieve any scheduled runs of this UDF
 ### invalidate_cache
 
 ```python
-invalidate_cache()
+invalidate_cache(
+    *, z: int | None = None, x: int | None = None, y: int | None = None
+)
 ```
 
 Invalidate the result cache for this UDF.

--- a/docs/python-sdk/top-level-functions.mdx
+++ b/docs/python-sdk/top-level-functions.mdx
@@ -228,7 +228,8 @@ run(
     _return_response: Optional[bool] = False,
     _ignore_unknown_arguments: bool = False,
     _cancel_callback: Callable[[], bool] | None = None,
-    **kw_parameters: Callable[[], bool] | None
+    _stream_logs: bool = False,
+    **kw_parameters: bool
 ) -> Union[
     ResultType,
     Coroutine[ResultType, None, None],


### PR DESCRIPTION
Auto-generated API reference update from fused-py v2.8.0.4.

Triggered by tag [`fused-py-v2.8.0.4`](https://github.com/fusedlabs/application/releases/tag/fused-py-v2.8.0.4) in `fusedlabs/application`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only API reference and CLI docs with no runtime or application code changes.
> 
> **Overview**
> Auto-generated documentation refresh for **fused-py v2.8.0.4**, covering CLI canvas commands and Python SDK API reference pages.
> 
> **`fused.api`** docs add **`daytona_connect`**, **`dropbox_connect`**, **`onedrive_connect`**, and **`openai_connect`**, plus new **`FusedDropboxConnection`** and **`FusedOnedriveConnection`** sections. Storage helper examples switch from **`fd://`** URLs to concrete **`s3://fused-users/fused/aman/...`** paths.
> 
> **CLI** **`fused canvas share`** is described as returning **updated metadata** (not a shareable URL), and **`--new-token`** copy is shortened.
> 
> **`Udf.invalidate_cache`** documents optional tile kwargs **`z`**, **`x`**, **`y`**. **`fused.run`** documents **`_stream_logs`** and updates **`kw_parameters`** typing in the signature block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2abda6f0345db6d0240bdfff8081957fbaa39668. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->