### PR TITLE
docs: add v2.8.0.4 changelog entry

### DIFF
--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -8,6 +8,37 @@ hide_table_of_contents: true
 
 # Changelog
 
+## v2.8.0.4 (2026-06-24)
+
+**Daytona integration**
+
+Connect [Daytona](/workbench/integrations/daytona) to run untrusted code, manage files, and clone repositories inside cloud sandboxes straight from your UDFs, with your API key stored securely as a Fused secret.
+
+See the [Daytona integration](/workbench/integrations/daytona) docs to get started.
+
+**Scheduled UDF runs from the CLI**
+
+Manage recurring UDF runs from the terminal with the new [`fused cronjob`](/cli/cronjob) command — create, list, and remove scheduled jobs without leaving the CLI.
+
+See the [`fused cronjob`](/cli/cronjob) reference to get started.
+
+**Improvements**
+
+- AI: call [OpenAI models inside UDFs](/guide/data-input-outputs/import-connection/using-ai-inside-udf) by adding your OpenAI key under team integrations, alongside the existing Anthropic and built-in models
+- [Widgets](/guide/data-input-outputs/import-connection/widgets): map widget gains tile mode support and auto-fits to your data bounds
+- CLI: snapshot and restore canvases with `fused checkpoint create/list/restore`, and run shared canvases directly with `fused run`
+- [Canvas](/workbench/udf-builder/canvas): open file explorer media directly as image and video widgets
+- [Canvas](/workbench/udf-builder/canvas): redesigned "What's new" modal and a search bar in preset dropdowns
+- [Canvas](/workbench/udf-builder/canvas): visual indicators highlight unsaved canvas and UDF metadata changes
+
+**Bug fixes**
+
+- Fixed: ghost nodes reappearing after a canvas refresh
+- Fixed: multi-select keeping out-of-bounds nodes selected
+- Fixed: text box background color lost when loading a checkpoint
+- Fixed: note and widget styling not preserved across GitHub sync
+- Fixed: map widget auto-fit not fitting to data bounds
+
 ## v2.8.1 (2026-06-03)
 
 **Canvas comments (experimental)**


### PR DESCRIPTION
Auto-generated changelog draft for **fused-py v2.8.0.4**.

Generated by the `/changelog` command from the auto-generated release notes in `fusedlabs/application`.

### Before merging
- [ ] Review the headline feature pick and the wording
- [ ] Add screenshots / GIFs for the named features (see the comment below)
- [ ] Confirm internal doc links resolve
- [ ] Drop any non–user-facing items that slipped through

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the changelog; no application or SDK code is modified.
> 
> **Overview**
> Adds a **v2.8.0.4 (2026-06-24)** section at the top of `docs/python-sdk/changelog.mdx`, ahead of the existing v2.8.1 entry.
> 
> The new release notes cover **Daytona** integration and **`fused cronjob`** for scheduled UDF runs, plus improvements (OpenAI in UDFs, map widget tile mode, CLI checkpoint/`fused run`, canvas UX) and several canvas/widget bug fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42c30943f11c3c476bf34d59318dae1be4a124c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->