### PR TITLE
docs: add v2.8.2 changelog entry

### DIFF
--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -8,6 +8,35 @@ hide_table_of_contents: true
 
 # Changelog
 
+## v2.8.2 (2026-06-24)
+
+**CLI checkpoints**
+
+The `fused` CLI gains `fused checkpoint create`, `list`, and `restore`, so you can snapshot your work from the terminal and roll back to an earlier state at any time.
+
+See the [CLI Reference](/cli/overview) to get started.
+
+**Run shared canvases from the CLI**
+
+`fused run` now works against shared canvases, so you can execute a teammate's shared canvas directly from the terminal without copying it first.
+
+**Improvements**
+
+- [Canvas](/workbench/udf-builder/canvas): visual indicators show when a canvas or UDF has unsaved metadata changes
+- [Canvas](/workbench/udf-builder/canvas): map widget autoFit now fits the view to your data's bounds
+- Workbench job status gains a Debug tab showing dmesg/syslog output for troubleshooting
+- Faster canvas and workbench cold-load, with fewer redundant API calls
+- S3 presigned URLs now proxy through the server so they work behind Zscaler and other corporate networks
+- CLI: clearer help text for the `--env`, `serve-mcp`, and `json-ui` options
+
+**Bug fixes**
+
+- Fixed: ghost nodes resurrecting on canvas refresh and out-of-bounds nodes lingering in multi-select
+- Fixed: text box background color not restored when loading a checkpoint
+- Fixed: note and widget styling lost across GitHub sync, and pulled UDFs failing to re-run
+- Fixed: false GitHub sync self-conflicts, now with clearer conflict errors
+- Fixed: stale alignment helper lines remaining on the canvas after a drag
+
 ## v2.8.1 (2026-06-03)
 
 **Canvas comments (experimental)**


### PR DESCRIPTION
Auto-generated changelog draft for **fused-py v2.8.2**.

Generated by the `/changelog` command from the auto-generated release notes in `fusedlabs/application`.

### Before merging
- [ ] Review the headline feature pick and the wording
- [ ] Add screenshots / GIFs for the named features (see the comment below)
- [ ] Confirm internal doc links resolve
- [ ] Drop any non–user-facing items that slipped through

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit to the public changelog; no application or SDK code changes.
> 
> **Overview**
> Updates **`docs/python-sdk/changelog.mdx`** with a **v2.8.2 (2026-06-24)** release section, replacing the prior draft (**v2.8.0.4**) that highlighted Daytona and **`fused cronjob`**.
> 
> The new top-level callouts are **CLI checkpoints** (`fused checkpoint create` / `list` / `restore`) with a link to the [CLI Reference](/cli/overview), and **`fused run` on shared canvases** so teammates’ shared canvases can be executed from the terminal without copying.
> 
> **Improvements** and **bug fixes** are rewritten for this release: canvas unsaved-metadata indicators and map **autoFit**, Workbench job **Debug** tab, faster cold-load, S3 presigned URL proxying for corporate networks, and consolidated canvas/GitHub sync fixes—while dropping the draft’s Daytona, OpenAI-in-UDF, and widget tile-mode bullets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b39465a984080e295bd040cfa88115eb06bc5dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->