### PR TITLE
docs: add v2.8.3 changelog entry

### DIFF
--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -8,6 +8,18 @@ hide_table_of_contents: true
 
 # Changelog
 
+## v2.8.3 (2026-06-29)
+
+**Improvements**
+
+- UDF `.json` files now support JSON5, so you can use comments and trailing commas in your UDF configuration
+- [Canvas](/workbench/udf-builder/canvas): App nodes now show a clear status message instead of a generic "Running UDF"
+
+**Bug fixes**
+
+- Fixed: your session token no longer affects the UDF cache key, so cached results are reused as expected
+- Fixed: stale state in the UDF collections toolbar
+
 ## v2.8.2 (2026-06-24)
 
 **CLI checkpoints**


### PR DESCRIPTION
Auto-generated changelog draft for **fused-py v2.8.3**.

Generated by the `/changelog` command from the auto-generated release notes in `fusedlabs/application`.

### Before merging
- [ ] Review the headline feature pick and the wording
- [ ] Add screenshots / GIFs for the named features (see the comment below)
- [ ] Confirm internal doc links resolve
- [ ] Drop any non–user-facing items that slipped through

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no runtime or API behavior changes in this repo.
> 
> **Overview**
> Adds a **v2.8.3 (2026-06-29)** section at the top of `docs/python-sdk/changelog.mdx`, documenting the latest Python SDK / Workbench release for readers.
> 
> **Improvements** call out JSON5 support for UDF `.json` config files and clearer App node status text on [Canvas](/workbench/udf-builder/canvas) instead of a generic “Running UDF” message.
> 
> **Bug fixes** note that session tokens are excluded from the UDF cache key (so cache hits behave correctly) and that stale state in the UDF collections toolbar was fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff2c61b8937c4d890c3252e2a11eeb9596f28aa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->