### PR TITLE
docs: update API reference for fused-py v2.8.4

### DIFF
--- a/docs/cli/canvas.mdx
+++ b/docs/cli/canvas.mdx
@@ -24,7 +24,7 @@ fused canvas [SUBCOMMAND] [OPTIONS]
 | `push` | Import a local canvas directory into a canvas. |
 | `rename` | Rename a canvas. |
 | `serve-mcp` | Serve a shared canvas OpenAPI as a local MCP server. |
-| `share` | Share a canvas and return updated metadata. |
+| `share` | Share a canvas and return its shareable URL. |
 | `unshare` | Unshare a canvas and return updated metadata. |
 | `validate` | Validate a canvas directory without running any UDFs. |
 
@@ -65,7 +65,7 @@ fused canvas export CANVAS_REF [OPTIONS]
 | Flag | Description |
 |---|---|
 | `--output FILENAME` | Path to write the downloaded zip bundle. |
-| `--team` | Treat the provided name as a team canvas name. |
+| `--team` | Treat the provided reference as a team canvas name. |
 | `--id` | Treat the provided reference as a canvas ID. |
 
 
@@ -98,7 +98,7 @@ fused canvas pull CANVAS_REF [OPTIONS]
 | Flag | Description |
 |---|---|
 | `--output, -o DIRECTORY` | Directory to extract into (default: sanitized canvas name). |
-| `--team` | Treat the provided name as a team canvas name. |
+| `--team` | Treat the provided reference as a team canvas name. |
 | `--id` | Treat the provided reference as a canvas ID. |
 | `--force, -f` | Overwrite existing files and remove local-only files without prompting. |
 | `--dry-run, -n` | Show actions and diffs without writing files. |
@@ -150,18 +150,18 @@ fused canvas serve-mcp CANVAS_REF [OPTIONS]
 
 | Flag | Description |
 |---|---|
-| `--token` | Treat CANVAS_REF as a shared canvas token (fc_...). |
-| `--team` | Treat CANVAS_REF as a team canvas name. |
-| `--id` | Treat CANVAS_REF as a canvas ID. |
-| `--host TEXT` | (default: `127.0.0.1`) |
-| `--port INTEGER` | (default: `8765`) |
-| `--path TEXT` | (default: `/mcp`) |
+| `--token` | Treat the provided reference as a shared canvas token (fc_...). |
+| `--team` | Treat the provided reference as a team canvas name. |
+| `--id` | Treat the provided reference as a canvas ID. |
+| `--host TEXT` | Host interface to bind the local MCP server to. (default: `127.0.0.1`) |
+| `--port INTEGER` | Port to bind the local MCP server to. (default: `8765`) |
+| `--path TEXT` | URL path to serve the MCP endpoint on. (default: `/mcp`) |
 | `--claude` | Register this MCP server with Claude Code via the `claude` CLI. |
 
 
 ## `fused canvas share`
 
-Share a canvas and return updated metadata.
+Share a canvas and return its shareable URL.
 
 ```
 fused canvas share CANVAS_REF [OPTIONS]
@@ -172,7 +172,7 @@ fused canvas share CANVAS_REF [OPTIONS]
 | Flag | Description |
 |---|---|
 | `--client-id TEXT` | Override realtime client ID for share token generation. |
-| `--new-token` | Generate a new share token instead of reusing an existing one. |
+| `--new-token` | Generate a new share token instead of reusing the existing one. This immediately invalidates the previous token, so any already-distributed link or embed stops working. |
 | `--id` | Treat the provided reference as a canvas ID. |
 
 

--- a/docs/cli/checkpoint.mdx
+++ b/docs/cli/checkpoint.mdx
@@ -1,0 +1,90 @@
+---
+id: checkpoint
+title: fused checkpoint
+sidebar_label: fused checkpoint
+---
+
+# `fused checkpoint`
+
+Manage canvas checkpoints.
+
+```
+fused checkpoint [SUBCOMMAND] [OPTIONS]
+```
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| `create` | Create a checkpoint of a canvas's current state. |
+| `list` | List all checkpoints for a canvas. |
+| `pr` | Open a GitHub PR from an existing checkpoint. |
+| `restore` | Restore a canvas from a checkpoint. |
+
+## `fused checkpoint create`
+
+Create a checkpoint of a canvas's current state.
+
+```
+fused checkpoint create CANVAS_REF [OPTIONS]
+```
+
+**Options**
+
+| Flag | Description |
+|---|---|
+| `--name TEXT` | Custom checkpoint name. If not provided, auto-generates a timestamp-based name. |
+| `--id` | Treat the provided reference as a canvas ID. |
+
+
+## `fused checkpoint list`
+
+List all checkpoints for a canvas.
+
+```
+fused checkpoint list CANVAS_REF [OPTIONS]
+```
+
+**Options**
+
+| Flag | Description |
+|---|---|
+| `--id` | Treat the provided reference as a canvas ID. |
+
+
+## `fused checkpoint pr`
+
+Open a GitHub PR from an existing checkpoint.
+
+```
+fused checkpoint pr CANVAS_REF CHECKPOINT_NAME [OPTIONS]
+```
+
+**Options**
+
+| Flag | Description |
+|---|---|
+| `--message, -m TEXT` | Commit message / PR title. |
+| `--id` | Treat the provided reference as a canvas ID. |
+| `--repo TEXT` | Target GitHub repository (owner/repo). Defaults to the canvas's gitRepo. |
+| `--path TEXT` | Target folder within the repo. Defaults to the canvas's folderName. |
+| `--share [public\|team]` | Share access scope for the canvas. |
+| `--share-token TEXT` | Vanity share token name (requires --share). |
+
+
+## `fused checkpoint restore`
+
+Restore a canvas from a checkpoint.
+
+```
+fused checkpoint restore CANVAS_REF CHECKPOINT_NAME [OPTIONS]
+```
+
+**Options**
+
+| Flag | Description |
+|---|---|
+| `--id` | Treat the provided reference as a canvas ID. |
+| `--no-backup` | Skip creating a safety backup before restore. |
+
+

--- a/docs/cli/claude.mdx
+++ b/docs/cli/claude.mdx
@@ -31,9 +31,9 @@ fused claude add-mcp CANVAS_REF [OPTIONS]
 
 | Flag | Description |
 |---|---|
-| `--token` | Treat CANVAS_REF as a shared canvas token (fc_...). |
-| `--team` | Treat CANVAS_REF as a team canvas name. |
-| `--id` | Treat CANVAS_REF as a canvas ID. |
+| `--token` | Treat the provided reference as a shared canvas token (fc_...). |
+| `--team` | Treat the provided reference as a team canvas name. |
+| `--id` | Treat the provided reference as a canvas ID. |
 | `--create-session-token / --no-create-session-token` | Create a session token for team-scoped canvases when none is passed. (default: `True`) |
 | `--session-max-age TEXT` | Lifetime for --create-session-token (e.g. 30m, 1h, 1d). (default: `1h`) |
 

--- a/docs/cli/files.mdx
+++ b/docs/cli/files.mdx
@@ -93,7 +93,7 @@ fused files search [PATH_AND_QUERY...] [OPTIONS]
 | Flag | Description |
 |---|---|
 | `--count` | Return only the number of matching objects (JSON: \{"count": N\}). |
-| `--prefix TEXT` | Registered index prefix (which index table to use). Default: first segment of PATH, e.g. fused/ from s3://fused-users/fused/... |
+| `--prefix TEXT` | Registered index prefix (which index table to use). Default: first segment of PATH, e.g. team_name/ from s3://fused-users/team_name/... |
 | `--key-prefix TEXT` | Only return object keys starting with this prefix. Default: directory portion of PATH. |
 | `--limit INTEGER` | Max rows to return (ignored with --count). (default: `100`) |
 | `--offset INTEGER` | Pagination offset (ignored with --count). (default: `0`) |

--- a/docs/cli/json-ui.mdx
+++ b/docs/cli/json-ui.mdx
@@ -43,8 +43,8 @@ fused json-ui run-inline-widget CANVAS_SHARE_TOKEN WIDGET_CONFIG [OPTIONS]
 
 | Flag | Description |
 |---|---|
-| `--print-url-only` | — |
-| `--browser [chrome\|firefox]` | (default: `chrome`) |
+| `--print-url-only` | Print the widget URL and exit without launching a browser or screenshotting. |
+| `--browser [chrome\|firefox]` | Headless browser to use for screenshotting. (default: `chrome`) |
 | `--wait INTEGER` | Seconds to sleep after canvas loading settles before capture. (default: `2`) |
 | `--screenshot-filename FILENAME` | Save the screenshot to the given file. It should be a PNG file path. |
 
@@ -61,8 +61,8 @@ fused json-ui run-shared-widget CANVAS_SHARE_TOKEN WIDGET_NAME [OPTIONS]
 
 | Flag | Description |
 |---|---|
-| `--print-url-only` | — |
-| `--browser [chrome\|firefox]` | (default: `chrome`) |
+| `--print-url-only` | Print the widget URL and exit without launching a browser or screenshotting. |
+| `--browser [chrome\|firefox]` | Headless browser to use for screenshotting. (default: `chrome`) |
 | `--wait INTEGER` | Seconds to sleep after canvas loading settles before capture. (default: `2`) |
 | `--screenshot-filename FILENAME` | Save the screenshot to the given file. It should be a PNG file path. |
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -18,7 +18,7 @@ These flags apply to every command:
 
 | Flag | Env var | Description |
 |---|---|---|
-| `--env TEXT` | `FUSED_ENV` | — |
+| `--env TEXT` | `FUSED_ENV` | Override the Fused environment. |
 | `--format [json\|text]` | `FUSED_CLI_FORMAT` | Output format for command results (json or text). |
 
 ## Commands
@@ -26,6 +26,7 @@ These flags apply to every command:
 | Command | Description |
 |---|---|
 | [`fused canvas`](/cli/canvas) | Manage canvases. |
+| [`fused checkpoint`](/cli/checkpoint) | Manage canvas checkpoints. |
 | [`fused claude`](/cli/claude) | Manage Fused for Claude Code (via the `claude` CLI). |
 | [`fused completion`](/cli/completion) | Print or install shell tab completion for the fused CLI. |
 | [`fused cronjob`](/cli/cronjob) | Manage scheduled UDF runs. |

--- a/docs/cli/run.mdx
+++ b/docs/cli/run.mdx
@@ -26,4 +26,6 @@ fused run CANVAS [UDF] [OPTIONS]
 | `--verbose / --no-verbose` | Show UDF stdout/stderr from the runtime (default: on). (default: `True`) |
 | `--profile / --no-profile` | Collect and print lineprofile timings annotated against UDF source. |
 | `--output_file, --output-file FILENAME` | Write the result to a file. |
+| `--team` | Treat the provided reference as a team canvas name. |
+| `--id` | Treat the provided reference as a canvas ID. |
 

--- a/docs/cli/udf-schema.mdx
+++ b/docs/cli/udf-schema.mdx
@@ -17,4 +17,6 @@ fused udf-schema CANVAS [UDF] [OPTIONS]
 | Flag | Description |
 |---|---|
 | `--stdin` | Read UDF source code from standard input (same as passing multiline code to fused.load). |
+| `--team` | Treat the provided reference as a team canvas name. |
+| `--id` | Treat the provided reference as a canvas ID. |
 

--- a/docs/python-sdk/api-reference/api.mdx
+++ b/docs/python-sdk/api-reference/api.mdx
@@ -114,7 +114,7 @@ Delete the files at the path.
 
 **Parameters:**
 
-- **path** (`str`) – Directory or file to delete, like `s3://fused-users/fused/aman/my-old-table/`
+- **path** (`str`) – Directory or file to delete, like `s3://fused-users/team_name/user_name/my-old-table/`
 - **max_deletion_depth** (`int | Literal['unlimited']`) – If set (defaults to 3), the maximum depth the operation will recurse to.
   This option is to help avoid accidentally deleting more data that intended.
   Pass `"unlimited"` for unlimited.
@@ -122,7 +122,7 @@ Delete the files at the path.
 **Examples:**
 
 ```python
-fused.api.delete("s3://fused-users/fused/aman/deprecated_table/")
+fused.api.delete("s3://fused-users/team_name/user_name/deprecated_table/")
 ```
 
 ---
@@ -137,7 +137,7 @@ Download the contents at the path to disk.
 
 **Parameters:**
 
-- **path** (`str`) – URL to a file, like `s3://fused-users/fused/aman/file.parquet`
+- **path** (`str`) – URL to a file, like `s3://fused-users/team_name/user_name/file.parquet`
 - **local_path** (`str | Path`) – Path to a local file.
 
 ---
@@ -177,7 +177,7 @@ Download the contents at the path to memory.
 
 **Parameters:**
 
-- **path** (`str`) – URL to a file, like `s3://fused-users/fused/aman/file.parquet`
+- **path** (`str`) – URL to a file, like `s3://fused-users/team_name/user_name/file.parquet`
 
 **Returns:**
 
@@ -186,7 +186,7 @@ Download the contents at the path to memory.
 **Examples:**
 
 ```python
-fused.api.get("s3://fused-users/fused/aman/file.parquet")
+fused.api.get("s3://fused-users/team_name/user_name/file.parquet")
 ```
 
 ---
@@ -473,7 +473,7 @@ List the files at the path.
 
 **Parameters:**
 
-- **path** (`str`) – Parent directory URL, like `s3://fused-users/fused/aman/`
+- **path** (`str`) – Parent directory URL, like `s3://fused-users/team_name/user_name/`
 - **details** (`bool`) – If True, return additional metadata about each record.
 
 **Returns:**
@@ -483,7 +483,7 @@ List the files at the path.
 **Examples:**
 
 ```python
-fused.api.list("s3://fused-users/fused/aman/")
+fused.api.list("s3://fused-users/team_name/user_name/")
 ```
 
 ---
@@ -720,7 +720,7 @@ This function may not check that the file represented by the path exists.
 
 **Parameters:**
 
-- **path** (`str`) – URL to a file, like `s3://fused-users/fused/aman/file.parquet`
+- **path** (`str`) – URL to a file, like `s3://fused-users/team_name/user_name/file.parquet`
 
 **Returns:**
 
@@ -729,7 +729,7 @@ This function may not check that the file represented by the path exists.
 **Examples:**
 
 ```python
-fused.api.sign_url("s3://fused-users/fused/aman/table_directory/file.parquet")
+fused.api.sign_url("s3://fused-users/team_name/user_name/table_directory/file.parquet")
 ```
 
 ---
@@ -744,7 +744,7 @@ Create signed URLs to access all blobs under the path.
 
 **Parameters:**
 
-- **path** (`str`) – URL to a prefix, like `s3://fused-users/fused/aman/some_directory/`
+- **path** (`str`) – URL to a prefix, like `s3://fused-users/team_name/user_name/some_directory/`
 
 **Returns:**
 
@@ -753,7 +753,7 @@ Create signed URLs to access all blobs under the path.
 **Examples:**
 
 ```python
-fused.api.sign_url_prefix("s3://fused-users/fused/aman/table_directory/")
+fused.api.sign_url_prefix("s3://fused-users/team_name/user_name/table_directory/")
 ```
 
 ---
@@ -849,7 +849,7 @@ Upload local file to S3.
   (which will get uploaded as Parquet file), or the contents to upload.
   Any string will be treated as a Path, if you wish to upload the contents of
   the string, first encode it: `s.encode("utf-8")`
-- **remote_path** (`str`) – URL to upload to, like `s3://fused-users/fused/aman/new-file.txt`
+- **remote_path** (`str`) – URL to upload to, like `s3://fused-users/team_name/user_name/new-file.txt`
 - **timeout** (`float | None`) – Optional timeout in seconds for the upload (will default to `OPTIONS.request_timeout` if not specified).
 
 **Examples:**
@@ -857,7 +857,7 @@ Upload local file to S3.
 To upload a local json file to your Fused-managed S3 bucket:
 
 ```py
-fused.api.upload("my_file.json", "s3://fused-users/fused/aman/my_file.json")
+fused.api.upload("my_file.json", "s3://fused-users/team_name/user_name/my_file.json")
 ```
 
 ---


### PR DESCRIPTION
Auto-generated API reference update from fused-py v2.8.4.

Triggered by tag [`fused-py-v2.8.4`](https://github.com/fusedlabs/application/releases/tag/fused-py-v2.8.4) in `fusedlabs/application`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application code; risk is limited to possible doc inaccuracies relative to the released CLI.
> 
> **Overview**
> Auto-generated documentation refresh for **fused-py v2.8.4**, focused on CLI coverage and clearer option text rather than runtime changes in this repo.
> 
> **New `fused checkpoint` docs** document create, list, restore, and opening a GitHub PR from a checkpoint (including `--no-backup`, share options on `pr`), and the CLI overview now links to that page.
> 
> **Canvas / run / schema CLI updates** document `--team` and `--id` on `fused run` and `fused udf-schema`, refine canvas-related wording (e.g. **share** returns a shareable URL, stronger **`--new-token`** warning), and flesh out previously empty descriptions for `serve-mcp`, `json-ui`, and global **`--env`**.
> 
> **Python API reference** updates S3 path examples in `fused.api` file helpers to the `team_name/user_name/` layout instead of the older `fused/aman/` style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b827b01aa25978775f6d654099d0458d3f2b746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->