### PR TITLE
docs: add v2.8.4 changelog entry

### DIFF
--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -10,14 +10,6 @@ hide_table_of_contents: true
 
 ## v2.8.4 (2026-07-21)
 
-**Improvements**
-
-- Higher free-tier serving limits — up to 20 mounts and a 100 req/s serving rate limit
-- Repeat serving requests are faster thanks to result caching on the serve path
-- Larger inline uploads — the upload size cap is now configurable (default 200 MiB)
-- Mounts gain recreate and repoint operations for easier lifecycle management
-- Org invites now send a branded email so teammates get a proper invitation
-
 **Bug fixes**
 
 - Fixed: `fused.cache` now surfaces the real error to concurrent waiters instead of a generic failure

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -14,7 +14,6 @@ hide_table_of_contents: true
 
 - Fixed: `fused.cache` now surfaces the real error to concurrent waiters instead of a generic failure
 - Fixed: requesting a missing collection now returns a clear HTTP error instead of a server error
-- Fixed: client disconnects are handled cleanly instead of being reported as server errors
 
 ## v2.8.3 (2026-06-29)
 

--- a/docs/python-sdk/changelog.mdx
+++ b/docs/python-sdk/changelog.mdx
@@ -8,6 +8,22 @@ hide_table_of_contents: true
 
 # Changelog
 
+## v2.8.4 (2026-07-21)
+
+**Improvements**
+
+- Higher free-tier serving limits — up to 20 mounts and a 100 req/s serving rate limit
+- Repeat serving requests are faster thanks to result caching on the serve path
+- Larger inline uploads — the upload size cap is now configurable (default 200 MiB)
+- Mounts gain recreate and repoint operations for easier lifecycle management
+- Org invites now send a branded email so teammates get a proper invitation
+
+**Bug fixes**
+
+- Fixed: `fused.cache` now surfaces the real error to concurrent waiters instead of a generic failure
+- Fixed: requesting a missing collection now returns a clear HTTP error instead of a server error
+- Fixed: client disconnects are handled cleanly instead of being reported as server errors
+
 ## v2.8.3 (2026-06-29)
 
 **Improvements**


### PR DESCRIPTION
Auto-generated changelog draft for **fused-py v2.8.4**.

Generated by the `/changelog` command from the auto-generated release notes in `fusedlabs/application`.

### Before merging
- [ ] Review the headline feature pick and the wording
- [ ] Add screenshots / GIFs for the named features (see the comment below)
- [ ] Confirm internal doc links resolve
- [ ] Drop any non–user-facing items that slipped through

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `changelog.mdx`; no runtime or API behavior is modified in this PR.
> 
> **Overview**
> Documents **fused-py v2.8.4** (2026-07-21) at the top of the Python SDK changelog.
> 
> The new section lists two **bug fixes**: concurrent `fused.cache` waiters now see the underlying error instead of a generic failure, and requests for a missing collection return a clear HTTP client error rather than a server error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd057e4af30ce76392fc9955c1a273274e871ab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->